### PR TITLE
feat: serve landing and app under one Vercel deployment via path routing

### DIFF
--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -114,6 +114,27 @@
 
     .nav-gh:hover { color: var(--text); border-color: var(--border-strong); }
 
+    .nav-actions {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .nav-launch {
+      display: inline-flex;
+      align-items: center;
+      padding: 9px 18px;
+      border-radius: 9px;
+      background: var(--green);
+      font-size: 13.5px;
+      font-weight: 600;
+      color: #fff;
+      text-decoration: none;
+      transition: background 0.2s, box-shadow 0.2s;
+    }
+
+    .nav-launch:hover { background: #059669; box-shadow: 0 0 20px rgba(16,185,129,0.3); }
+
     /* ── Hero ── */
     .hero { padding: 120px 0 120px; overflow: hidden; }
 
@@ -703,10 +724,13 @@
   <div class="wrap">
     <div class="nav-row">
       <span class="wordmark">Meridian</span>
-      <a class="nav-gh" href="https://github.com/collinsezedike/meridian" target="_blank" rel="noopener">
-        <svg width="15" height="15" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
-        View on GitHub
-      </a>
+      <div class="nav-actions">
+        <a class="nav-gh" href="https://github.com/collinsezedike/meridian" target="_blank" rel="noopener">
+          <svg width="15" height="15" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
+          GitHub
+        </a>
+        <a class="nav-launch" href="/app">Launch App</a>
+      </div>
     </div>
   </div>
 </nav>

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -123,17 +123,19 @@
     .nav-launch {
       display: inline-flex;
       align-items: center;
-      padding: 9px 18px;
-      border-radius: 9px;
-      background: var(--green);
-      font-size: 13.5px;
+      gap: 5px;
+      padding: 8px 16px;
+      border-radius: 8px;
+      border: 1px solid rgba(16,185,129,0.45);
+      background: transparent;
+      font-size: 13px;
       font-weight: 600;
-      color: #fff;
+      color: var(--green);
       text-decoration: none;
-      transition: background 0.2s, box-shadow 0.2s;
+      transition: border-color 0.2s, background 0.2s;
     }
 
-    .nav-launch:hover { background: #059669; box-shadow: 0 0 20px rgba(16,185,129,0.3); }
+    .nav-launch:hover { border-color: var(--green); background: rgba(16,185,129,0.06); }
 
     /* ── Hero ── */
     .hero { padding: 120px 0 120px; overflow: hidden; }
@@ -729,7 +731,7 @@
           <svg width="15" height="15" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
           GitHub
         </a>
-        <a class="nav-launch" href="/app">Launch App</a>
+        <a class="nav-launch" href="/app">Launch App ↗</a>
       </div>
     </div>
   </div>

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,7 +12,7 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "baseUrl": ".",
+    "noEmit": true,
     "paths": {
       "@meridian/shared": ["../../packages/shared/src"],
       "@meridian/stellar-sdk-helpers": ["../../packages/stellar-sdk-helpers/src"]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,7 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  base: "/app/",
   server: {
     port: 3000,
     proxy: {

--- a/scripts/build-vercel.sh
+++ b/scripts/build-vercel.sh
@@ -20,3 +20,7 @@ cp -r "$ROOT/apps/web/dist/." "$OUT/app/"
 
 echo "✓ dist/ structure:"
 find "$OUT" -maxdepth 2 | sort
+
+echo ""
+echo "  Landing : $OUT/index.html ($(wc -c < "$OUT/index.html") bytes)"
+echo "  App     : $OUT/app/index.html ($(wc -c < "$OUT/app/index.html") bytes)"

--- a/scripts/build-vercel.sh
+++ b/scripts/build-vercel.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="$ROOT/dist"
+
+echo "▶ Cleaning output directory…"
+rm -rf "$OUT"
+mkdir -p "$OUT"
+
+echo "▶ Building React app (base: /app/)…"
+pnpm --filter @meridian/web build
+
+echo "▶ Assembling combined output…"
+# Landing page → dist/index.html
+cp "$ROOT/apps/landing/index.html" "$OUT/index.html"
+
+# React SPA build → dist/app/
+cp -r "$ROOT/apps/web/dist/." "$OUT/app/"
+
+echo "✓ dist/ structure:"
+find "$OUT" -maxdepth 2 | sort

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "buildCommand": "bash scripts/build-vercel.sh",
+  "outputDirectory": "dist",
+  "rewrites": [
+    { "source": "/app/:path*", "destination": "/app/index.html" }
+  ]
+}


### PR DESCRIPTION
## Summary

- `usemeridian.vercel.app/` → landing page (unchanged static HTML)
- `usemeridian.vercel.app/app` → React dashboard (and all deep `/app/*` routes)
- Closes #46

## Changes

**`vercel.json`** (new, root)
Single build command + output dir. One rewrite rule sends every `/app/:path*` request to `/app/index.html` so React Router handles client-side navigation.

**`scripts/build-vercel.sh`** (new)
Builds the React app, then assembles:
```
dist/index.html        ← apps/landing/index.html (copied as-is)
dist/app/              ← apps/web/dist/ (Vite build)
dist/app/assets/       ← hashed JS + CSS bundles
```

**`apps/web/vite.config.ts`**
Added `base: '/app/'` so all asset URLs in the React bundle are prefixed correctly — without this, the SPA would 404 its own JS/CSS.

**`apps/landing/index.html`**
Added **"Launch App"** green button to the nav (alongside the GitHub link) pointing to `/app`. No changes to the hero or existing waitlist form.

## How to verify locally

```bash
bash scripts/build-vercel.sh
npx serve dist          # visit / for landing, /app for the React app
```

## Test plan

- [x] `pnpm typecheck` — 6/6 packages pass
- [x] `bash scripts/build-vercel.sh` completes cleanly
- [x] `dist/app/index.html` references `/app/assets/…` (not `/assets/…`)
- [x] Vercel preview deploy — landing renders at `/`, app renders at `/app`, hard-refresh on `/app/dashboard` works