### PR TITLE
chore: update README and remove unused Redis dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Meridian
 
-**Stablecoin yield aggregator on Stellar — built for emerging market savers.**
+**Stablecoin yield aggregator on Stellar, built for emerging market savers.**
 
 Meridian is a savings dashboard that routes USDC deposits to the highest-yielding vaults across [Blend](https://blend.capital) and [DeFindex](https://defindex.io) on the Stellar network. It targets users in West Africa and other emerging markets where dollar-denominated savings yield meaningful real returns compared to local currency alternatives.
 
@@ -10,7 +10,7 @@ Submitted to the **Drips Stellar Wave Program**.
 
 ## Why Meridian?
 
-Inflation in many West African economies regularly exceeds 20 % annually. Access to USD savings accounts is limited by KYC friction and minimum balances. Stellar's low fees (< $0.01/tx), fast finality (5s), and USDC availability make it an ideal rails layer. Meridian removes the final UX barrier — users connect a wallet, see live APY across protocols, and deposit in three clicks.
+Inflation in many West African economies regularly exceeds 20 % annually. Access to USD savings accounts is limited by KYC friction and minimum balances. Stellar's low fees (< $0.01/tx), fast finality (5s), and USDC availability make it an ideal rails layer. Meridian removes the final UX barrier: users connect a wallet, see live APY across protocols, and deposit in three clicks.
 
 ---
 
@@ -20,7 +20,7 @@ Inflation in many West African economies regularly exceeds 20 % annually. Access
 meridian/
 ├── apps/
 │   ├── web/          # Vite + React 18 dashboard (TypeScript, Tailwind, Zustand)
-│   └── api/          # Fastify REST API — builds Soroban txs, aggregates APY
+│   └── api/          # Fastify REST API (local dev): builds Soroban txs, aggregates APY
 ├── packages/
 │   ├── stellar-sdk-helpers/  # Blend & DeFindex client wrappers
 │   ├── shared/               # Zod schemas, constants, pure utils
@@ -35,12 +35,14 @@ This is a **pnpm + Turborepo** monorepo. All packages are TypeScript-first with 
 ```
 User browser
   └─► Vite + React frontend
-        └─► Fastify API (builds unsigned XDR)
+        └─► Vercel Serverless Functions (builds unsigned XDR)
               ├─► Blend Protocol (pool data + deposit tx)
               └─► DeFindex Protocol (vault data + deposit tx)
                         │
                    Stellar RPC (Soroban)
 ```
+
+In production, API routes are Vercel serverless functions (`api/v1/...`). The Fastify server in `apps/api` is used for local development only.
 
 The API never holds private keys. It builds an unsigned Soroban transaction, returns the XDR, and the frontend forwards it to the user's wallet (Freighter) for signing and submission.
 
@@ -51,7 +53,8 @@ The API never holds private keys. It builds an unsigned Soroban transaction, ret
 | Layer | Technology |
 |---|---|
 | Frontend | Vite 5, React 18, Tailwind CSS, Zustand, TanStack Query |
-| Backend | Fastify, Redis (APY cache), Zod validation |
+| Backend (prod) | Vercel Serverless Functions, Zod validation |
+| Backend (local) | Fastify |
 | Blockchain | Stellar Soroban, `@stellar/stellar-sdk` v12 |
 | Protocols | Blend Capital, DeFindex |
 | Contracts | Rust / Soroban SDK |
@@ -68,7 +71,6 @@ The API never holds private keys. It builds an unsigned Soroban transaction, ret
 - pnpm ≥ 9 (`npm i -g pnpm`)
 - Rust + `wasm32-unknown-unknown` target (for contracts)
 - Stellar CLI (`cargo install stellar-cli`)
-- Redis (for API APY caching)
 
 ### Install
 
@@ -82,7 +84,7 @@ pnpm install
 
 ```bash
 cp .env.example .env
-# Edit .env — set STELLAR_NETWORK=testnet for local dev
+# Edit .env: set STELLAR_NETWORK=testnet for local dev
 ```
 
 ### Run locally
@@ -124,14 +126,14 @@ DeFindex is a yield-strategy vault protocol on Stellar that composes multiple yi
 
 ## Contributing
 
-We welcome contributions — see [open issues](../../issues) for a range of tasks across TypeScript, Rust/Soroban, and UI.
+We welcome contributions. See [open issues](../../issues) for a range of tasks across TypeScript, Rust/Soroban, and UI.
 
 1. Fork the repo and create a feature branch: `git checkout -b feat/your-feature`
 2. Follow the existing code style (no comments unless WHY is non-obvious)
 3. Run `pnpm lint && pnpm typecheck && pnpm test` before opening a PR
 4. Reference the relevant GitHub issue in your PR description
 
-Issues are tagged `good first issue`, `medium`, and `hard`, and carry the `Stellar Wave` label — pick your level.
+Issues are tagged `good first issue`, `medium`, and `hard`, and carry the `Stellar Wave` label. Pick your level.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Inflation in many West African economies regularly exceeds 20 % annually. Access
 
 ## Architecture
 
-```
+```text
 meridian/
 ├── apps/
 │   ├── web/          # Vite + React 18 dashboard (TypeScript, Tailwind, Zustand)
@@ -32,7 +32,7 @@ This is a **pnpm + Turborepo** monorepo. All packages are TypeScript-first with 
 
 ### Data flow
 
-```
+```text
 User browser
   └─► Vite + React frontend
         └─► Vercel Serverless Functions (builds unsigned XDR)
@@ -51,7 +51,7 @@ The API never holds private keys. It builds an unsigned Soroban transaction, ret
 ## Tech Stack
 
 | Layer | Technology |
-|---|---|
+| --- | --- |
 | Frontend | Vite 5, React 18, Tailwind CSS, Zustand, TanStack Query |
 | Backend (prod) | Vercel Serverless Functions, Zod validation |
 | Backend (local) | Fastify |
@@ -94,9 +94,9 @@ cp .env.example .env
 pnpm dev
 ```
 
-- Web: http://localhost:3000
-- API: http://localhost:3001
-- Health: http://localhost:3001/health
+- Web: <http://localhost:3000>
+- API: <http://localhost:3001>
+- Health: <http://localhost:3001/health>
 
 ### Run tests
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,7 +18,6 @@
     "fastify": "^4.28.0",
     "@fastify/cors": "^9.0.0",
     "@fastify/rate-limit": "^9.0.0",
-    "redis": "^4.6.0",
     "zod": "^3.23.0",
     "dotenv": "^16.4.0"
   },

--- a/apps/api/src/routes/vaults.ts
+++ b/apps/api/src/routes/vaults.ts
@@ -1,46 +1,10 @@
 import type { FastifyPluginAsync } from "fastify";
-import { createClient } from "redis";
 import { fetchAllVaults } from "../services/vaults.js";
-
-const CACHE_KEY = "meridian:vaults";
-const CACHE_TTL = 3_600; // 1 hour — DeFiLlama data is daily
-
-let redisClient: ReturnType<typeof createClient> | null = null;
-let redisInitialised = false;
-
-async function getCache(): Promise<ReturnType<typeof createClient> | null> {
-  if (redisInitialised) return redisClient?.isReady ? redisClient : null;
-  redisInitialised = true;
-
-  try {
-    const client = createClient({ url: process.env.REDIS_URL ?? "redis://localhost:6379" });
-    client.on("error", () => { redisClient = null; });
-    await client.connect();
-    redisClient = client;
-    return redisClient;
-  } catch (err) {
-    console.warn("[redis] unavailable, running without cache:", (err as Error).message);
-    return null;
-  }
-}
 
 export const vaultsRoute: FastifyPluginAsync = async (app) => {
   app.get("/", async (_req, reply) => {
-    const cache = await getCache();
-
-    if (cache) {
-      const raw = await cache.get(CACHE_KEY).catch(() => null);
-      if (raw) return reply.send({ ...JSON.parse(raw), cached: true });
-    }
-
     const vaults = await fetchAllVaults();
-    const payload = { vaults, updatedAt: new Date().toISOString(), cached: false };
-
-    if (cache) {
-      await cache.setEx(CACHE_KEY, CACHE_TTL, JSON.stringify(payload)).catch(() => {});
-    }
-
-    return reply.send(payload);
+    return reply.send({ vaults, updatedAt: new Date().toISOString(), cached: false });
   });
 
   app.get("/:vaultId", async (req, reply) => {

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "lib": ["ES2020"],
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
+    "rootDir": "../..",
     "outDir": "dist",
     "paths": {
       "@meridian/shared": ["../../packages/shared/src"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       fastify:
         specifier: ^4.28.0
         version: 4.29.1
-      redis:
-        specifier: ^4.6.0
-        version: 4.7.1
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -641,35 +638,6 @@ packages:
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
-  '@redis/bloom@1.2.0':
-    resolution: {integrity: sha512-HG2DFjYKbpNmVXsa0keLHp/3leGJz1mjh09f2RLGGLQZzSHpkmZWuwJbAvo3QcRY8p80m5+ZdXZdYOSBLlp7Cg==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/client@1.6.1':
-    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
-    engines: {node: '>=14'}
-
-  '@redis/graph@1.1.1':
-    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/json@1.0.7':
-    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/search@1.2.0':
-    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
-  '@redis/time-series@1.1.0':
-    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
-    peerDependencies:
-      '@redis/client': ^1.0.0
-
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -1189,10 +1157,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  cluster-key-slot@1.1.2:
-    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
-    engines: {node: '>=0.10.0'}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1539,10 +1503,6 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  generic-pool@3.9.0:
-    resolution: {integrity: sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==}
-    engines: {node: '>= 4'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2093,9 +2053,6 @@ packages:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  redis@4.7.1:
-    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
-
   require-addon@1.2.0:
     resolution: {integrity: sha512-VNPDZlYgIYQwWp9jMTzljx+k0ZtatKlcvOhktZ/anNPI3dQ9NXk7cq2U4iJ1wd9IrytRnYhyEocFWbkdPb+MYA==}
     engines: {bare: '>=1.10.0'}
@@ -2453,9 +2410,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yallist@4.0.0:
-    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -2848,32 +2802,6 @@ snapshots:
       fastq: 1.20.1
 
   '@pinojs/redact@0.4.0': {}
-
-  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
-  '@redis/client@1.6.1':
-    dependencies:
-      cluster-key-slot: 1.1.2
-      generic-pool: 3.9.0
-      yallist: 4.0.0
-
-  '@redis/graph@1.1.1(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
-  '@redis/json@1.0.7(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
-  '@redis/search@1.2.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
-
-  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
-    dependencies:
-      '@redis/client': 1.6.1
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3395,8 +3323,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  cluster-key-slot@1.1.2: {}
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3802,8 +3728,6 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
-
-  generic-pool@3.9.0: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -4305,15 +4229,6 @@ snapshots:
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
 
-  redis@4.7.1:
-    dependencies:
-      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
-      '@redis/client': 1.6.1
-      '@redis/graph': 1.1.1(@redis/client@1.6.1)
-      '@redis/json': 1.0.7(@redis/client@1.6.1)
-      '@redis/search': 1.2.0(@redis/client@1.6.1)
-      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
-
   require-addon@1.2.0:
     dependencies:
       bare-addon-resolve: 1.10.0
@@ -4708,8 +4623,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   yallist@3.1.1: {}
-
-  yallist@4.0.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

- Updates README data flow diagram to reflect Vercel serverless functions as the production path (Fastify is local dev only)
- Removes Redis from the tech stack table and prerequisites (never wired up in production; Fastify routes degrade gracefully without it)
- Drops the `redis` package from `apps/api/package.json` and strips the caching code from the vaults route
- Fixes `baseUrl` deprecation warning and sets explicit `rootDir` in `apps/api/tsconfig.json`
- Fixes all markdownlint warnings in README (MD040, MD060, MD034)