### PR TITLE
docs: replace maintainer email with GitHub Discussions link

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -30,9 +30,7 @@ This Code of Conduct applies to all Meridian project spaces including GitHub Iss
 
 ## Enforcement
 
-Instances of unacceptable behaviour may be reported to the project maintainer:
-
-**Collins Ezedike** — [collinsezedike@gmail.com](mailto:collinsezedike@gmail.com)
+Instances of unacceptable behaviour may be reported to the project maintainer via [GitHub Discussions](https://github.com/collinsezedike/meridian/discussions)
 
 All reports will be reviewed promptly and handled with discretion. The maintainer is obligated to keep reporter information confidential.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,7 +52,7 @@ Use **GitHub's private vulnerability reporting**:
 2. Fill in the advisory form with as much detail as possible (see below)
 3. Submit — this creates a private draft advisory visible only to you and the maintainer
 
-Alternatively, email **[collinsezedike@gmail.com](mailto:collinsezedike@gmail.com)** with the subject line `[SECURITY] Meridian — <brief description>`.
+Alternatively, open a thread in [GitHub Discussions](https://github.com/collinsezedike/meridian/discussions) with the subject line `[SECURITY] Meridian — <brief description>`.
 
 ### What to Include in Your Report
 
@@ -74,9 +74,9 @@ Alternatively, email **[collinsezedike@gmail.com](mailto:collinsezedike@gmail.co
 | Fix or mitigation for Critical/High    | Within **14 days** where technically feasible |
 | Public disclosure                      | Coordinated with reporter after fix deploys   |
 
-¹ Meridian is solo-maintained. For Critical reports, email directly in addition to the advisory to improve response time.
+¹ Meridian is solo-maintained. For Critical reports, open a GitHub Discussions thread in addition to the advisory to improve response time.
 
-We will keep you informed at each stage. If you do not receive an acknowledgement within 48 hours, follow up via email.
+We will keep you informed at each stage. If you do not receive an acknowledgement within 48 hours, follow up via GitHub Discussions.
 
 ---
 


### PR DESCRIPTION
Removes the maintainer's personal email from public-facing documents and redirects all contact to GitHub Discussions until a dedicated project email domain is set up.

Affects `SECURITY.md` and `CODE_OF_CONDUCT.md`.