### PR TITLE
feat: implement unsigned Soroban XDR builder for deposit, withdraw, and submit

### DIFF
--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "lib": ["ES2020", "DOM"]
+    "lib": ["ES2020", "DOM"],
+    "types": ["node"]
   },
   "include": ["**/*.ts"]
 }

--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async function handler(req: any, res: any) {
+export default async function handler(_req: any, res: any) {
   // TODO(#issue-6): fetch real on-chain positions for this public key
   res.json({ positions: [] });
 }

--- a/api/v1/tx/_shared.ts
+++ b/api/v1/tx/_shared.ts
@@ -1,0 +1,93 @@
+import {
+  Contract,
+  TransactionBuilder,
+  Address,
+  nativeToScVal,
+  rpc,
+  xdr,
+  Networks,
+} from "@stellar/stellar-sdk";
+
+const VAULT_CONTRACT_ID = process.env.VAULT_CONTRACT_ID ?? "";
+const RPC_URL = "https://soroban-testnet.stellar.org";
+const NETWORK_PASSPHRASE = Networks.TESTNET;
+const BASE_FEE = "100";
+
+function toStroops(value: string): bigint {
+  const [whole = "0", frac = ""] = value.split(".");
+  const fracPadded = frac.padEnd(7, "0").slice(0, 7);
+  return BigInt(whole) * 10_000_000n + BigInt(fracPadded);
+}
+
+function resolveProtocol(vaultId: string): "Blend" | "DeFindex" {
+  if (vaultId.startsWith("blend-")) return "Blend";
+  if (vaultId.startsWith("defindex-")) return "DeFindex";
+  throw new Error(`No protocol mapping for vault: ${vaultId}`);
+}
+
+export async function buildDepositXdr(
+  walletAddress: string,
+  vaultId: string,
+  amount: string
+): Promise<{ xdr: string; fee: string }> {
+  if (!VAULT_CONTRACT_ID) throw new Error("Vault contract not yet deployed");
+
+  const protocol = resolveProtocol(vaultId);
+  const server = new rpc.Server(RPC_URL);
+  const account = await server.getAccount(walletAddress);
+  const contract = new Contract(VAULT_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK_PASSPHRASE })
+    .addOperation(
+      contract.call(
+        "deposit",
+        Address.fromString(walletAddress).toScVal(),
+        nativeToScVal(toStroops(amount), { type: "i128" }),
+        xdr.ScVal.scvSymbol(protocol),
+      )
+    )
+    .setTimeout(300)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
+
+  const prepared = rpc.assembleTransaction(tx, sim).build();
+  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+}
+
+export async function buildWithdrawXdr(
+  walletAddress: string,
+  shares: string
+): Promise<{ xdr: string; fee: string }> {
+  if (!VAULT_CONTRACT_ID) throw new Error("Vault contract not yet deployed");
+
+  const server = new rpc.Server(RPC_URL);
+  const account = await server.getAccount(walletAddress);
+  const contract = new Contract(VAULT_CONTRACT_ID);
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: NETWORK_PASSPHRASE })
+    .addOperation(
+      contract.call(
+        "withdraw",
+        Address.fromString(walletAddress).toScVal(),
+        nativeToScVal(toStroops(shares), { type: "i128" }),
+      )
+    )
+    .setTimeout(300)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
+
+  const prepared = rpc.assembleTransaction(tx, sim).build();
+  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+}
+
+export async function submitSignedXdr(signedXdr: string): Promise<{ hash: string }> {
+  const server = new rpc.Server(RPC_URL);
+  const tx = TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
+  const result = await server.sendTransaction(tx);
+  if (result.status === "ERROR") throw new Error(`Transaction rejected (${result.status})`);
+  return { hash: result.hash };
+}

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -1,3 +1,5 @@
+import { buildDepositXdr } from "./_shared";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
@@ -10,6 +12,11 @@ export default async function handler(req: any, res: any) {
     return res.status(400).json({ error: `Missing required fields: ${missing}` });
   }
 
-  // TODO(#issue-7): build unsigned Soroban deposit tx, return XDR for wallet signing
-  res.status(501).json({ error: "Deposit signing not yet implemented" });
+  try {
+    const result = await buildDepositXdr(walletAddress, vaultId, amount);
+    res.json(result);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to build deposit transaction";
+    res.status(500).json({ error: msg });
+  }
 }

--- a/api/v1/tx/submit.ts
+++ b/api/v1/tx/submit.ts
@@ -1,3 +1,5 @@
+import { submitSignedXdr } from "./_shared";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
@@ -5,6 +7,11 @@ export default async function handler(req: any, res: any) {
   const { xdr } = req.body ?? {};
   if (!xdr) return res.status(400).json({ error: "Missing required field: xdr" });
 
-  // TODO(#issue-7): submit signed XDR to Stellar network
-  res.status(501).json({ error: "Transaction submission not yet implemented" });
+  try {
+    const result = await submitSignedXdr(xdr);
+    res.json(result);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to submit transaction";
+    res.status(500).json({ error: msg });
+  }
 }

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -1,3 +1,5 @@
+import { buildWithdrawXdr } from "./_shared";
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
@@ -10,6 +12,11 @@ export default async function handler(req: any, res: any) {
     return res.status(400).json({ error: `Missing required fields: ${missing}` });
   }
 
-  // TODO(#issue-7): build unsigned Soroban withdraw tx, return XDR for wallet signing
-  res.status(501).json({ error: "Withdrawal signing not yet implemented" });
+  try {
+    const result = await buildWithdrawXdr(walletAddress, shares);
+    res.json(result);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Failed to build withdraw transaction";
+    res.status(500).json({ error: msg });
+  }
 }

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -1,5 +1,9 @@
 import type { FastifyPluginAsync } from "fastify";
-import { DepositRequestSchema, WithdrawRequestSchema } from "@meridian/shared";
+import { DepositRequestSchema, WithdrawRequestSchema, CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
+import { buildDepositTx, buildWithdrawTx, submitTx } from "@meridian/stellar-sdk-helpers";
+
+const network = STELLAR_NETWORKS.testnet;
+const vaultContractId = process.env.VAULT_CONTRACT_ID ?? CONTRACT_ADDRESSES.testnet.vault;
 
 export const txRoute: FastifyPluginAsync = async (app) => {
   app.post("/deposit", async (req, reply) => {
@@ -9,8 +13,16 @@ export const txRoute: FastifyPluginAsync = async (app) => {
       const msg = Object.entries(fields).map(([k, v]) => `${k}: ${v?.join(", ")}`).join("; ");
       return reply.code(400).send({ error: msg || "Invalid request" });
     }
-    // TODO(#issue-7): build unsigned Soroban tx, return XDR for wallet signing
-    reply.code(501).send({ error: "Deposit signing not yet implemented" });
+    if (!vaultContractId) return reply.code(503).send({ error: "Vault contract not yet deployed" });
+
+    try {
+      const { walletAddress, vaultId, amount } = parsed.data;
+      const result = await buildDepositTx(vaultContractId, walletAddress, vaultId, amount, network);
+      reply.send(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to build deposit transaction";
+      reply.code(500).send({ error: msg });
+    }
   });
 
   app.post("/withdraw", async (req, reply) => {
@@ -20,7 +32,28 @@ export const txRoute: FastifyPluginAsync = async (app) => {
       const msg = Object.entries(fields).map(([k, v]) => `${k}: ${v?.join(", ")}`).join("; ");
       return reply.code(400).send({ error: msg || "Invalid request" });
     }
-    // TODO(#issue-7): build unsigned Soroban tx, return XDR for wallet signing
-    reply.code(501).send({ error: "Withdrawal signing not yet implemented" });
+    if (!vaultContractId) return reply.code(503).send({ error: "Vault contract not yet deployed" });
+
+    try {
+      const { walletAddress, shares } = parsed.data;
+      const result = await buildWithdrawTx(vaultContractId, walletAddress, shares, network);
+      reply.send(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to build withdraw transaction";
+      reply.code(500).send({ error: msg });
+    }
+  });
+
+  app.post("/submit", async (req, reply) => {
+    const { xdr } = (req.body ?? {}) as { xdr?: string };
+    if (!xdr) return reply.code(400).send({ error: "Missing required field: xdr" });
+
+    try {
+      const result = await submitTx(xdr, network);
+      reply.send(result);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Failed to submit transaction";
+      reply.code(500).send({ error: msg });
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck"
   },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^12.0.0"
+  },
   "devDependencies": {
+    "@types/node": "^20.0.0",
     "turbo": "^2.9.14",
     "typescript": "^5.4.0",
     "prettier": "^3.2.0",

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -15,6 +15,7 @@ export const CONTRACT_ADDRESSES = {
     },
     usdc: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
     eurc: "CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV",
+    vault: "", // set after testnet deployment
   },
 } as const;
 

--- a/packages/stellar-sdk-helpers/src/index.ts
+++ b/packages/stellar-sdk-helpers/src/index.ts
@@ -2,5 +2,6 @@ export * from "./blend";
 export * from "./defilamma";
 export * from "./defindex";
 export * from "./horizon";
+export * from "./tx";
 export * from "./types";
 export * from "./vaults";

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -1,0 +1,99 @@
+import {
+  Contract,
+  TransactionBuilder,
+  Address,
+  nativeToScVal,
+  rpc,
+  xdr,
+  Networks,
+} from "@stellar/stellar-sdk";
+import type { StellarNetwork } from "./types";
+
+const BASE_FEE = "100";
+
+function toStroops(value: string): bigint {
+  const [whole = "0", frac = ""] = value.split(".");
+  const fracPadded = frac.padEnd(7, "0").slice(0, 7);
+  return BigInt(whole) * 10_000_000n + BigInt(fracPadded);
+}
+
+function resolveProtocol(vaultId: string): "Blend" | "DeFindex" {
+  if (vaultId.startsWith("blend-")) return "Blend";
+  if (vaultId.startsWith("defindex-")) return "DeFindex";
+  throw new Error(`No protocol mapping for vault: ${vaultId}`);
+}
+
+export async function buildDepositTx(
+  contractId: string,
+  walletAddress: string,
+  vaultId: string,
+  amount: string,
+  network: StellarNetwork
+): Promise<{ xdr: string; fee: string }> {
+  const protocol = resolveProtocol(vaultId);
+  const passphrase = network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+  const server = new rpc.Server(network.rpcUrl);
+  const account = await server.getAccount(walletAddress);
+  const contract = new Contract(contractId);
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
+    .addOperation(
+      contract.call(
+        "deposit",
+        Address.fromString(walletAddress).toScVal(),
+        nativeToScVal(toStroops(amount), { type: "i128" }),
+        xdr.ScVal.scvSymbol(protocol),
+      )
+    )
+    .setTimeout(300)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
+
+  const prepared = rpc.assembleTransaction(tx, sim).build();
+  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+}
+
+export async function buildWithdrawTx(
+  contractId: string,
+  walletAddress: string,
+  shares: string,
+  network: StellarNetwork
+): Promise<{ xdr: string; fee: string }> {
+  const passphrase = network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+
+  const server = new rpc.Server(network.rpcUrl);
+  const account = await server.getAccount(walletAddress);
+  const contract = new Contract(contractId);
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
+    .addOperation(
+      contract.call(
+        "withdraw",
+        Address.fromString(walletAddress).toScVal(),
+        nativeToScVal(toStroops(shares), { type: "i128" }),
+      )
+    )
+    .setTimeout(300)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
+
+  const prepared = rpc.assembleTransaction(tx, sim).build();
+  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+}
+
+export async function submitTx(
+  signedXdr: string,
+  network: StellarNetwork
+): Promise<{ hash: string }> {
+  const passphrase = network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+  const server = new rpc.Server(network.rpcUrl);
+  const tx = TransactionBuilder.fromXDR(signedXdr, passphrase);
+  const result = await server.sendTransaction(tx);
+  if (result.status === "ERROR") throw new Error(`Transaction rejected (${result.status})`);
+  return { hash: result.hash };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,14 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      '@stellar/stellar-sdk':
+        specifier: ^12.0.0
+        version: 12.3.0
     devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
       eslint:
         specifier: ^8.57.0
         version: 8.57.1


### PR DESCRIPTION
Closes #14

## Summary

- Adds `api/v1/tx/_shared.ts` with `buildDepositXdr`, `buildWithdrawXdr`, and `submitSignedXdr` — self-contained Soroban transaction builders for the Vercel serverless functions
- Adds `packages/stellar-sdk-helpers/src/tx.ts` with the equivalent `buildDepositTx`, `buildWithdrawTx`, and `submitTx` functions for the local Fastify dev server
- Wires both deposit and withdraw handlers to build a real `invokeHostFunction` transaction, simulate it against the Soroban testnet RPC to populate the resource footprint, and return the unsigned XDR + simulated fee
- Implements the submit endpoint, which forwards the Freighter-signed XDR to the Stellar network and returns the transaction hash
- Adds `/submit` route to the Fastify server (was missing entirely)
- Adds `@stellar/stellar-sdk` and `@types/node` to root `package.json` so the serverless functions can resolve them
- Adds `vault` placeholder to `CONTRACT_ADDRESSES.testnet` in `@meridian/shared`
- Fixes `TODO(#issue-7)` references in tx routes to correctly point to #14

## Protocol routing

`vaultId` from the client maps to the contract's `Protocol` enum: `blend-*` → `Blend`, `defindex-*` → `DeFindex`. The enum variant is passed as the `route_to` argument so the user signs exactly which protocol their funds are routed to.

## Test plan

- [ ] Set `VAULT_CONTRACT_ID` env var to a deployed testnet vault address
- [ ] POST `{ walletAddress, vaultId, amount }` to `/api/v1/tx/deposit` and verify a valid base64 XDR is returned
- [ ] Decode returned XDR and confirm it invokes `deposit` on the vault contract with the correct arguments
- [ ] Sign the XDR with Freighter on testnet and submit via `/api/v1/tx/submit`, verify transaction hash is returned
- [ ] Repeat for withdraw
- [ ] Verify that missing `VAULT_CONTRACT_ID` returns 500 "Vault contract not yet deployed"
- [ ] Verify that an unsupported `vaultId` (e.g. `ondo-usdy`) returns 500 with a clear protocol mapping error