### PR TITLE
fix: correct disconnect button markup and clipboard error handling

### DIFF
--- a/apps/web/src/components/onboarding/WalletConnect.tsx
+++ b/apps/web/src/components/onboarding/WalletConnect.tsx
@@ -29,7 +29,7 @@ export function WalletConnect() {
 
   if (connected && publicKey) {
     return (
-      <div className="flex items-center gap-2 text-sm border border-gray-700 rounded-lg px-3 py-1.5 text-gray-300 hover:border-gray-600 hover:text-white transition-colors duration-150">
+      <div className="flex items-center gap-2 text-sm border border-gray-700 rounded-lg px-3 py-2 text-gray-300 hover:border-gray-600 hover:text-white transition-colors duration-150">
         <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" />
         <span>{shortenAddress(publicKey)}</span>
         <button
@@ -58,7 +58,7 @@ export function WalletConnect() {
         href="https://freighter.app"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-sm border border-amber-800 rounded-lg px-4 py-1.5 font-medium text-amber-400 hover:border-amber-600 hover:text-amber-300 transition-colors duration-150"
+        className="text-sm border border-amber-800 rounded-lg px-4 py-2 font-medium text-amber-400 hover:border-amber-600 hover:text-amber-300 transition-colors duration-150"
       >
         Install Freighter
       </a>
@@ -69,7 +69,7 @@ export function WalletConnect() {
     <button
       onClick={handleConnect}
       disabled={status === "connecting"}
-      className="text-sm border border-gray-700 rounded-lg px-4 py-1.5 font-medium text-gray-300 hover:border-gray-600 hover:text-white transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
+      className="text-sm border border-gray-700 rounded-lg px-4 py-2 font-medium text-gray-300 hover:border-gray-600 hover:text-white transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
     >
       {status === "connecting" ? "Connecting..." : "Connect Wallet"}
     </button>

--- a/apps/web/src/components/onboarding/WalletConnect.tsx
+++ b/apps/web/src/components/onboarding/WalletConnect.tsx
@@ -40,12 +40,12 @@ export function WalletConnect() {
         </button>
 
         <span className="text-gray-600">·</span>
-        <span
-         onClick={handleDisconnect}
-         className="flex items-center gap-2 text-sm border border-gray-700 rounded-lg px-3 py-1.5 text-gray-300 hover:border-gray-600 hover:text-white transition-colors duration-150"
-         >
-        Disconnect
-        </span>
+        <button
+          onClick={handleDisconnect}
+          className="text-gray-400 hover:text-white transition-colors duration-150"
+        >
+          Disconnect
+        </button>
       </div>
     );
   }

--- a/apps/web/src/components/onboarding/WalletConnect.tsx
+++ b/apps/web/src/components/onboarding/WalletConnect.tsx
@@ -13,11 +13,13 @@ export function WalletConnect() {
 
   const handleCopy = async () => {
     if (!publicKey) return;
-    await navigator.clipboard.writeText(publicKey);
-    setCopied(true);
-    setTimeout(() => {
-      setCopied(false);
-    }, 2000);
+    try {
+      await navigator.clipboard.writeText(publicKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      push("error", "Failed to copy address");
+    }
   };
   
   function handleDisconnect() {


### PR DESCRIPTION
## Summary

- Replace `<span onClick>` with a semantic `<button>` for the Disconnect action and remove duplicated outer-container classes (`border`, `rounded-lg`, `px-3 py-2`) that produced a nested pill-within-pill appearance
- Handle clipboard API errors in `handleCopy`. A denied or unavailable clipboard now pushes an error toast instead of failing silently
- Normalise vertical padding to `py-2` across all three wallet connect states (connected pill, Install Freighter, Connect Wallet button)

## Test plan

- [x] Connected pill renders: status dot, shortened address, copy icon, separator dot, "Disconnect" with no nested border
- [x] Click Disconnect — wallet disconnects and info toast fires
- [x] Click copy icon — address copied, icon switches to Check for 2s
- [x] Simulate clipboard failure — error toast appears
- [x] All three states (connected, no-extension, disconnected) have consistent height
