### PR TITLE
feat: expose mUSDC share balance from positions API and use it for wi…

### DIFF
--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -67,9 +67,10 @@ export default async function handler(req: any, res: any) {
       positions: [
         {
           vaultId: VAULT_CONTRACT_ID,
+          shares: Number(sharesBig) / 1e7,
           deposited,
-          earned: 0,
-          entryTime: 0,
+          earned: 0, // contract does not track yield per user yet
+          entryTime: 0, // contract does not record deposit timestamp yet
         },
       ],
     });

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -66,9 +66,10 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
         positions: [
           {
             vaultId: vaultContractId,
+            shares: Number(sharesBig) / 1e7,
             deposited,
-            earned: 0,
-            entryTime: 0,
+            earned: 0, // contract does not track yield per user yet
+            entryTime: 0, // contract does not record deposit timestamp yet
           },
         ],
       });

--- a/apps/web/src/components/dashboard/VaultPanel.tsx
+++ b/apps/web/src/components/dashboard/VaultPanel.tsx
@@ -239,12 +239,12 @@ export function VaultPanel() {
               <>
                 <div>
                   <div className="flex items-center justify-between mb-2">
-                    <span className="text-xs font-medium text-gray-500">Shares</span>
+                    <span className="text-xs font-medium text-gray-500">Amount</span>
                     <button
-                      onClick={() => setAmount(String(position.deposited))}
+                      onClick={() => setAmount(position.shares.toFixed(7))}
                       className="text-xs text-emerald-500 hover:text-emerald-400 transition-colors duration-150"
                     >
-                      Max: {position.deposited.toFixed(2)}
+                      Max: {position.shares.toFixed(2)}
                     </button>
                   </div>
                   <div className="flex items-center gap-3 rounded-xl border border-gray-700 bg-gray-900/70 px-4 py-3.5 focus-within:border-gray-500 transition-colors duration-150">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -31,6 +31,7 @@ export interface ApiVault {
 
 export interface ApiPosition {
   vaultId: string;
+  shares: number;
   deposited: number;
   earned: number;
   entryTime: number;
@@ -56,7 +57,7 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
-  buildWithdraw: (body: unknown) =>
+  buildWithdraw: (body: { walletAddress: string; vaultId: string; shares: string }) =>
     apiFetch<{ xdr: string }>("/api/v1/tx/withdraw", {
       method: "POST",
       body: JSON.stringify(body),

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -10,7 +10,7 @@ export const DepositRequestSchema = z.object({
 export const WithdrawRequestSchema = z.object({
   walletAddress: z.string().length(56),
   vaultId: z.string(),
-  shares: z.string().regex(/^\d+$/),
+  shares: z.string().regex(/^\d+(\.\d{1,7})?$/),
 });
 
 export type DepositRequest = z.infer<typeof DepositRequestSchema>;

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -1,4 +1,5 @@
 import {
+  Account,
   Contract,
   TransactionBuilder,
   Address,
@@ -6,6 +7,7 @@ import {
   Horizon,
   Operation,
   nativeToScVal,
+  scValToNative,
   rpc,
   xdr,
   Networks,
@@ -81,6 +83,25 @@ function resolveProtocol(vaultId: string): "Blend" | "DeFindex" {
   if (vaultId.startsWith("blend-")) return "Blend";
   if (vaultId.startsWith("defindex-")) return "DeFindex";
   throw new Error(`No protocol mapping for vault: ${vaultId}`);
+}
+
+export async function simulateView(
+  server: rpc.Server,
+  contractId: string,
+  networkPassphrase: string,
+  method: string,
+  ...args: xdr.ScVal[]
+): Promise<unknown> {
+  const dummyAccount = new Account("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", "0");
+  const contract = new Contract(contractId);
+  const tx = new TransactionBuilder(dummyAccount, { fee: "100", networkPassphrase })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(0)
+    .build();
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(sim.error);
+  if (!rpc.Api.isSimulationSuccess(sim) || !sim.result) return null;
+  return scValToNative(sim.result.retval);
 }
 
 export async function buildAddTrustlineTx(


### PR DESCRIPTION
## Summary

- Expose `shares` (the user's raw mUSDC balance as a decimal) from both the Fastify and Vercel positions handlers alongside the existing `deposited` field
- Add `shares: number` to the `ApiPosition` type in the web client
- Wire the withdraw tab Max button and input badge to `position.shares` so the user enters and submits an mUSDC share amount, not a USDC equivalent
- Update `WithdrawRequestSchema` to accept decimal share amounts (was integer-only)
- Add `simulateView` to `@meridian/stellar-sdk-helpers` as a shared utility for read-only contract calls

## Context

Withdrawal burns mUSDC shares and returns USDC. The input must be in shares, not USDC. Previously `position.deposited` (a USDC float) was used for the Max button, which works at 1:1 but is semantically wrong and breaks once the vault accrues yield.

## Test plan

- [ ] Deposit USDC and confirm a position appears
- [ ] Switch to Withdraw tab. Max button shows the correct mUSDC share balance
- [ ] Click Max. Input populates with the full share amount to 7 decimal places
- [ ] Submit withdrawal. Transaction is signed and submitted. Position clears on success
- [ ] Partial withdrawal. Enter an amount less than Max. Confirm only that share amount is withdrawn
