### PR TITLE
chore: add .editorconfig for consistent indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig — https://editorconfig.org
+# Keeps indentation and line endings consistent across editors.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{ts,tsx,js,jsx,json}]
+indent_style = space
+indent_size = 2
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

Adds a root `.editorconfig` so contributors on different editors (VS Code, Vim, WebStorm) produce consistent indentation and line endings.

## Settings
- `indent_style = space`, `indent_size = 2` for `.ts`, `.tsx`, `.js`, `.jsx`, `.json` — matches existing code style
- `indent_size = 4` for `.rs` (Rust convention)
- `end_of_line = lf`, `insert_final_newline = true`, `charset = utf-8`, `trim_trailing_whitespace = true` globally
- Trailing-whitespace trimming disabled for `.md` (Markdown uses it for hard line breaks)

Closes #48