### PR TITLE
test: add unit tests for @meridian/stellar-sdk-helpers utilities

### DIFF
--- a/packages/stellar-sdk-helpers/package.json
+++ b/packages/stellar-sdk-helpers/package.json
@@ -6,11 +6,15 @@
   "types": "./src/index.ts",
   "scripts": {
     "build": "tsc",
+    "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",
     "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.8"
   },
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/packages/stellar-sdk-helpers/src/horizon.test.ts
+++ b/packages/stellar-sdk-helpers/src/horizon.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { Horizon } from "@stellar/stellar-sdk";
+import { buildHorizonServer } from "./horizon";
+import type { StellarNetwork, VaultInfo } from "./types";
+
+function network(name: StellarNetwork["network"]): StellarNetwork {
+  return { network: name, rpcUrl: "", passphrase: "" };
+}
+
+describe("buildHorizonServer", () => {
+  it("returns a Horizon.Server instance for every supported network", () => {
+    expect(buildHorizonServer(network("testnet"))).toBeInstanceOf(Horizon.Server);
+    expect(buildHorizonServer(network("mainnet"))).toBeInstanceOf(Horizon.Server);
+    expect(buildHorizonServer(network("futurenet"))).toBeInstanceOf(Horizon.Server);
+  });
+
+  it("maps each network to its canonical Horizon endpoint", () => {
+    // serverURL.toString() normalises with a trailing slash.
+    expect(buildHorizonServer(network("testnet")).serverURL.toString()).toBe(
+      "https://horizon-testnet.stellar.org/"
+    );
+    expect(buildHorizonServer(network("mainnet")).serverURL.toString()).toBe(
+      "https://horizon.stellar.org/"
+    );
+    expect(buildHorizonServer(network("futurenet")).serverURL.toString()).toBe(
+      "https://horizon-futurenet.stellar.org/"
+    );
+  });
+});
+
+describe("VaultInfo shape", () => {
+  it("accepts a well-formed vault object", () => {
+    const vault = {
+      id: "blend-usdc",
+      protocol: "blend",
+      asset: "USDC",
+      apy: 5.25,
+      tvl: 1_000_000,
+      userBalance: 0,
+    } satisfies VaultInfo;
+
+    expect(vault.protocol).toBe("blend");
+    expect(typeof vault.apy).toBe("number");
+  });
+});

--- a/packages/stellar-sdk-helpers/tsconfig.json
+++ b/packages/stellar-sdk-helpers/tsconfig.json
@@ -9,5 +9,6 @@
       "@meridian/shared": ["../shared/src"]
     }
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,10 @@ importers:
       zod:
         specifier: ^3.23.0
         version: 3.25.76
+    devDependencies:
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@types/node@20.19.39)(vite@8.0.16(@types/node@20.19.39)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.1))
 
 packages:
 


### PR DESCRIPTION
## Summary

Adds vitest coverage to `@meridian/stellar-sdk-helpers` (companion to #7 for `@meridian/shared`). Fixes #53.

## Changes
- Add `vitest` devDependency and a `test` script (`vitest run --passWithNoTests`) to the package
- New `src/horizon.test.ts`:
  - `buildHorizonServer` returns a `Horizon.Server` for `testnet`/`mainnet`/`futurenet` (3 assertions)
  - maps each network to its canonical Horizon endpoint URL (3 assertions)
  - a `satisfies VaultInfo` type-level assertion validating the vault shape
- Exclude `*.test.ts` from the library build (`tsconfig.json`) so tests don't emit into `dist`

## Verification (run locally)
- `pnpm --filter @meridian/stellar-sdk-helpers test` → **3 passed**
- `pnpm --filter @meridian/stellar-sdk-helpers typecheck` → clean
- `pnpm --filter @meridian/stellar-sdk-helpers build` → clean, no test artifacts in `dist`
- `pnpm install --frozen-lockfile` → up to date (lockfile committed)

## Notes
The original task list mentions testing "all pure helper functions"; `horizon.ts` currently exposes one pure function (`buildHorizonServer`) — `getAccountBalances` performs a network call and is not unit-testable without mocking. Coverage meets the "at least 6 assertions" acceptance criterion.

Closes #53