### PR TITLE
feat: read live Blend pool positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,19 +12,20 @@ Submitted to the **Drips Stellar Wave Program**.
 
 Meridian is a **testnet technical preview**, not a finished product. Be clear-eyed about what exists today before depositing real funds (you can't yet — mainnet is not wired).
 
-**Working today**
+**Working today (testnet)**
 - Live APY / TVL feed across Stellar stablecoin pools (via DeFiLlama) with a risk heuristic
 - Non-custodial signing flow: the API builds an unsigned Soroban XDR, your wallet (Freighter) signs and submits it — keys never leave the browser
-- Testnet `MeridianVault` Soroban contract (deposit / withdraw, ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails) with unit tests
-- Position reads (shares, principal, entry time, earned)
+- **Direct deposit / withdraw against a real Blend pool** (#4): funds supply straight into Blend from your wallet and the resulting bToken position is yours — no Meridian-controlled custody
+- Live position reads from the Blend pool (current supplied value)
+- `MeridianVault` Soroban contract (ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails) with unit tests — reserved for the v2 single-transaction rebalancing router (#8)
 
 **In progress — the core promise is not finished**
-- Direct deposit/withdraw against real Blend pools (#4) — *being wired now*
 - Direct deposit/withdraw against real DeFindex vaults (#5)
-- Best-rate routing API that picks the winning pool (#6)
+- Best-rate routing API that automatically picks the winning pool (#6)
+- Per-position yield earned (cost-basis tracking for a direct Blend supply)
 - Mainnet configuration and a security audit before any real-funds use
 
-Until #4–#6 land, displayed APYs are **informational**: the testnet vault holds USDC but does not yet forward it to an external yield source. Track progress in the [Roadmap](#roadmap) and [open issues](../../issues).
+DeFindex routes currently return `501` rather than silently routing elsewhere. Track progress in the [Roadmap](#roadmap) and [open issues](../../issues).
 
 ---
 

--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -12,8 +12,8 @@ vi.mock("@meridian/stellar-sdk-helpers", () => ({
   buildAddTrustlineTx: vi.fn(async () => ({ xdr: "TRUST_XDR" })),
   submitTx: vi.fn(async () => ({ hash: "HASH" })),
   fetchAllVaults: vi.fn(async () => [{ id: "blend-usdc-fixed", protocol: "blend" }]),
-  fetchPosition: vi.fn(async () => [
-    { vaultId: "v", shares: 1, deposited: 1, earned: 0, entryTime: 0 },
+  fetchBlendPositions: vi.fn(async () => [
+    { vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 },
   ]),
 }));
 
@@ -23,7 +23,7 @@ import trustlineHandler from "../v1/tx/add-trustline";
 import submitHandler from "../v1/tx/submit";
 import vaultsHandler from "../v1/vaults/index";
 import positionsHandler from "../v1/positions/[publicKey]";
-import { buildBlendDepositTx, fetchPosition } from "@meridian/stellar-sdk-helpers";
+import { buildBlendDepositTx, fetchBlendPositions } from "@meridian/stellar-sdk-helpers";
 
 // A 56-char Stellar public key shape (only the length is validated).
 const PUBKEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
@@ -156,20 +156,20 @@ describe("GET /api/v1/positions/:publicKey", () => {
     const res = makeRes();
     await positionsHandler({ method: "GET", query: { publicKey: "too-short" } }, res);
     expect(res.statusCode).toBe(400);
-    expect(fetchPosition).not.toHaveBeenCalled();
+    expect(fetchBlendPositions).not.toHaveBeenCalled();
   });
 
   it("returns the resolved positions for a valid key", async () => {
     const res = makeRes();
     await positionsHandler({ method: "GET", query: { publicKey: PUBKEY } }, res);
     expect(res.body).toEqual({
-      positions: [{ vaultId: "v", shares: 1, deposited: 1, earned: 0, entryTime: 0 }],
+      positions: [{ vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 }],
     });
-    expect(fetchPosition).toHaveBeenCalledOnce();
+    expect(fetchBlendPositions).toHaveBeenCalledOnce();
   });
 
   it("degrades to an empty list if the read throws", async () => {
-    vi.mocked(fetchPosition).mockRejectedValueOnce(new Error("rpc down"));
+    vi.mocked(fetchBlendPositions).mockRejectedValueOnce(new Error("rpc down"));
     const res = makeRes();
     await positionsHandler({ method: "GET", query: { publicKey: PUBKEY } }, res);
     expect(res.body).toEqual({ positions: [] });

--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,8 +1,8 @@
-import { fetchPosition } from "@meridian/stellar-sdk-helpers";
+import { fetchBlendPositions } from "@meridian/stellar-sdk-helpers";
 import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
 
 const network = STELLAR_NETWORKS.testnet;
-const vaultContractId = process.env.VAULT_CONTRACT_ID ?? CONTRACT_ADDRESSES.testnet.vault;
+const addresses = CONTRACT_ADDRESSES.testnet;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
@@ -13,7 +13,10 @@ export default async function handler(req: any, res: any) {
   }
 
   try {
-    const positions = await fetchPosition(network, vaultContractId, publicKey);
+    const positions = await fetchBlendPositions(network, addresses.blend.pool, publicKey, [
+      { assetId: addresses.usdc, vaultId: "blend-usdc-fixed" },
+      { assetId: addresses.eurc, vaultId: "blend-eurc-fixed" },
+    ]);
     res.json({ positions });
   } catch (err) {
     console.error("[positions] error:", err);

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -1,9 +1,9 @@
 import type { FastifyPluginAsync } from "fastify";
 import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
-import { fetchPosition } from "@meridian/stellar-sdk-helpers";
+import { fetchBlendPositions } from "@meridian/stellar-sdk-helpers";
 
 const network = STELLAR_NETWORKS.testnet;
-const vaultContractId = process.env.VAULT_CONTRACT_ID ?? CONTRACT_ADDRESSES.testnet.vault;
+const addresses = CONTRACT_ADDRESSES.testnet;
 
 export const positionsRoute: FastifyPluginAsync = async (app) => {
   app.get("/:publicKey", async (req, reply) => {
@@ -14,7 +14,10 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
     }
 
     try {
-      const positions = await fetchPosition(network, vaultContractId, publicKey);
+      const positions = await fetchBlendPositions(network, addresses.blend.pool, publicKey, [
+        { assetId: addresses.usdc, vaultId: "blend-usdc-fixed" },
+        { assetId: addresses.eurc, vaultId: "blend-eurc-fixed" },
+      ]);
       reply.send({ positions });
     } catch (err) {
       app.log.error(err, "[positions] read failed");

--- a/packages/stellar-sdk-helpers/src/blend.ts
+++ b/packages/stellar-sdk-helpers/src/blend.ts
@@ -1,6 +1,7 @@
 import { Networks, TransactionBuilder, rpc, xdr } from "@stellar/stellar-sdk";
-import { PoolContractV2, RequestType } from "@blend-capital/blend-sdk";
+import { PoolContractV2, PoolV2, RequestType } from "@blend-capital/blend-sdk";
 import type { StellarNetwork } from "./types";
+import type { PositionInfo } from "./positions";
 
 const BASE_FEE = "100";
 
@@ -88,4 +89,41 @@ export function buildBlendWithdrawTx(
   amount: bigint
 ): Promise<{ xdr: string; fee: string }> {
   return buildPoolRequestTx(config, withdrawer, RequestType.WithdrawCollateral, amount);
+}
+
+export interface BlendReserveRef {
+  // Reserve asset contract (the USDC/EURC Stellar Asset Contract).
+  assetId: string;
+  // Meridian vault id the resulting position is reported under.
+  vaultId: string;
+}
+
+/**
+ * Read a user's live supply position in a Blend pool, one entry per reserve the
+ * user holds. The pool ledger state is loaded once and each reserve is valued
+ * via the SDK (collateral + plain supply, in underlying asset units).
+ *
+ * `deposited` is the current value of the position; `shares` mirrors it so the
+ * UI's "withdraw max" reflects the full withdrawable amount. `earned` is 0 for
+ * now — a direct Blend supply carries no on-chain cost basis, so yield can't be
+ * derived without event indexing (tracked separately).
+ */
+export async function fetchBlendPositions(
+  network: StellarNetwork,
+  poolId: string,
+  publicKey: string,
+  reserves: BlendReserveRef[]
+): Promise<PositionInfo[]> {
+  const pool = await PoolV2.load({ rpc: network.rpcUrl, passphrase: network.passphrase }, poolId);
+  const user = await pool.loadUser(publicKey);
+
+  const positions: PositionInfo[] = [];
+  for (const { assetId, vaultId } of reserves) {
+    const reserve = pool.reserves.get(assetId);
+    if (!reserve) continue;
+    const value = user.getCollateralFloat(reserve) + user.getSupplyFloat(reserve);
+    if (value <= 0) continue;
+    positions.push({ vaultId, shares: value, deposited: value, earned: 0, entryTime: 0 });
+  }
+  return positions;
 }


### PR DESCRIPTION
## Summary

Follow-up to #108. Closes the deposit → balance → withdraw loop: positions now read from the **real Blend pool** instead of the idle `MeridianVault`, so a deposit actually shows up on the dashboard.

### What changed
- **`fetchBlendPositions`** — loads the Blend pool ledger state via `@blend-capital/blend-sdk` (`PoolV2.load` + `loadUser`) and reports each reserve's current supplied value (`getCollateralFloat` + `getSupplyFloat`) for the connected wallet.
- Vercel positions endpoint and the Fastify dev route now use it (USDC + EURC reserves of the configured pool).
- `fetchPosition` (the `MeridianVault` reader) stays exported/tested — reserved for the v2 single-tx rebalancing router (#8).
- README status updated: Blend deposit/withdraw + live position reads are now under "working today".

### Known limitation (documented)
`earned` is reported as `0`: a direct Blend supply carries no on-chain cost basis, so per-position yield needs event indexing. Tracked as a follow-up.

### Verification
`lint` ✓ · `typecheck` (6/6) ✓ · `typecheck:api` ✓ · `test` ✓

Closes #4