### PR TITLE
feat: build DeFindex vault deposit/withdraw txs locally (no hosted API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ Meridian is a **testnet technical preview**, not a finished product. Be clear-ey
 - `MeridianVault` Soroban contract (ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails) with unit tests — reserved for the v2 single-transaction rebalancing router (#8)
 
 **In progress — the core promise is not finished**
-- Direct deposit/withdraw against real DeFindex vaults (#5)
+- Direct deposit/withdraw against real DeFindex vaults (#5) — *transaction builders are implemented locally (no hosted API); gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired*
 - Best-rate routing API that automatically picks the winning pool (#6)
-- Per-position yield earned (cost-basis tracking for a direct Blend supply)
+- Live DeFindex position reads, and per-position yield earned (cost-basis tracking for a direct Blend supply)
 - Mainnet configuration and a security audit before any real-funds use
 
-DeFindex routes currently return `501` rather than silently routing elsewhere. Track progress in the [Roadmap](#roadmap) and [open issues](../../issues).
+Until a DeFindex vault is configured, DeFindex routes return `501` rather than silently routing elsewhere. Track progress in the [Roadmap](#roadmap) and [open issues](../../issues).
 
 ---
 

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -1,5 +1,6 @@
 import {
   buildBlendDepositTx,
+  buildDefindexDepositTx,
   blendAssetForVault,
   resolveProtocol,
   toStroops,
@@ -8,6 +9,7 @@ import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
+const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
@@ -34,11 +36,17 @@ export default async function handler(req: any, res: any) {
       return res.json(result);
     }
 
-    // DeFindex routing is not wired yet — see issue #5. Fail honestly rather
-    // than silently routing somewhere else.
-    return res
-      .status(501)
-      .json({ error: "DeFindex deposits are not implemented yet. See issue #5." });
+    if (!defindexVaultId) {
+      return res
+        .status(501)
+        .json({ error: "DeFindex vault not configured. Set DEFINDEX_VAULT_ID. See issue #5." });
+    }
+    const result = await buildDefindexDepositTx(
+      { vaultId: defindexVaultId, network },
+      walletAddress,
+      toStroops(amount)
+    );
+    return res.json(result);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to build deposit transaction";
     res.status(500).json({ error: msg });

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -1,5 +1,6 @@
 import {
   buildBlendWithdrawTx,
+  buildDefindexWithdrawTx,
   blendAssetForVault,
   resolveProtocol,
   toStroops,
@@ -8,6 +9,7 @@ import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
+const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
@@ -35,9 +37,18 @@ export default async function handler(req: any, res: any) {
       return res.json(result);
     }
 
-    return res
-      .status(501)
-      .json({ error: "DeFindex withdrawals are not implemented yet. See issue #5." });
+    if (!defindexVaultId) {
+      return res
+        .status(501)
+        .json({ error: "DeFindex vault not configured. Set DEFINDEX_VAULT_ID. See issue #5." });
+    }
+    // For a DeFindex vault, `amount` is the number of dfToken shares to burn.
+    const result = await buildDefindexWithdrawTx(
+      { vaultId: defindexVaultId, network },
+      walletAddress,
+      toStroops(amount)
+    );
+    return res.json(result);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to build withdraw transaction";
     res.status(500).json({ error: msg });

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -3,6 +3,8 @@ import { DepositRequestSchema, WithdrawRequestSchema, CONTRACT_ADDRESSES, STELLA
 import {
   buildBlendDepositTx,
   buildBlendWithdrawTx,
+  buildDefindexDepositTx,
+  buildDefindexWithdrawTx,
   blendAssetForVault,
   resolveProtocol,
   toStroops,
@@ -12,6 +14,7 @@ import {
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
+const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault;
 
 export const txRoute: FastifyPluginAsync = async (app) => {
   app.post("/deposit", async (req, reply) => {
@@ -24,12 +27,20 @@ export const txRoute: FastifyPluginAsync = async (app) => {
 
     try {
       const { walletAddress, vaultId, amount } = parsed.data;
-      if (resolveProtocol(vaultId) !== "Blend") {
-        return reply.code(501).send({ error: "DeFindex deposits are not implemented yet. See issue #5." });
+      if (resolveProtocol(vaultId) === "Blend") {
+        const asset = blendAssetForVault(vaultId);
+        const result = await buildBlendDepositTx(
+          { poolId: addresses.blend.pool, assetId: addresses[asset], network },
+          walletAddress,
+          toStroops(amount)
+        );
+        return reply.send(result);
       }
-      const asset = blendAssetForVault(vaultId);
-      const result = await buildBlendDepositTx(
-        { poolId: addresses.blend.pool, assetId: addresses[asset], network },
+      if (!defindexVaultId) {
+        return reply.code(501).send({ error: "DeFindex vault not configured. Set DEFINDEX_VAULT_ID. See issue #5." });
+      }
+      const result = await buildDefindexDepositTx(
+        { vaultId: defindexVaultId, network },
         walletAddress,
         toStroops(amount)
       );
@@ -50,12 +61,21 @@ export const txRoute: FastifyPluginAsync = async (app) => {
 
     try {
       const { walletAddress, vaultId, amount } = parsed.data;
-      if (resolveProtocol(vaultId) !== "Blend") {
-        return reply.code(501).send({ error: "DeFindex withdrawals are not implemented yet. See issue #5." });
+      if (resolveProtocol(vaultId) === "Blend") {
+        const asset = blendAssetForVault(vaultId);
+        const result = await buildBlendWithdrawTx(
+          { poolId: addresses.blend.pool, assetId: addresses[asset], network },
+          walletAddress,
+          toStroops(amount)
+        );
+        return reply.send(result);
       }
-      const asset = blendAssetForVault(vaultId);
-      const result = await buildBlendWithdrawTx(
-        { poolId: addresses.blend.pool, assetId: addresses[asset], network },
+      if (!defindexVaultId) {
+        return reply.code(501).send({ error: "DeFindex vault not configured. Set DEFINDEX_VAULT_ID. See issue #5." });
+      }
+      // For a DeFindex vault, `amount` is the number of dfToken shares to burn.
+      const result = await buildDefindexWithdrawTx(
+        { vaultId: defindexVaultId, network },
         walletAddress,
         toStroops(amount)
       );

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -12,6 +12,10 @@ export const CONTRACT_ADDRESSES = {
     },
     defindex: {
       factory: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK75",
+      // Single-asset (USDC) DeFindex vault. Empty until a real testnet vault is
+      // wired — until then DeFindex routes report "not configured" rather than
+      // pointing at a placeholder. Override at runtime with DEFINDEX_VAULT_ID.
+      vault: "",
     },
     usdc: "CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA",
     eurc: "CDTKPWPLOURQA2SGTKTUQOWRCBZEORB4BWBOMJ3D3ZTQQSGE5F6JBQLV",

--- a/packages/stellar-sdk-helpers/src/defindex.test.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { buildDefindexDepositTx, buildDefindexWithdrawTx } from "./defindex";
+import type { StellarNetwork } from "./types";
+
+const network: StellarNetwork = {
+  network: "testnet",
+  rpcUrl: "https://soroban-testnet.stellar.org",
+  passphrase: "Test SDF Network ; September 2015",
+};
+const config = { vaultId: "CVAULT", network };
+const ADDR = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+// The positive-amount guards run before any network access, so they are
+// unit-testable without an RPC server.
+describe("buildDefindexDepositTx", () => {
+  it("rejects a non-positive amount", async () => {
+    await expect(buildDefindexDepositTx(config, ADDR, 0n)).rejects.toThrow(/positive/);
+    await expect(buildDefindexDepositTx(config, ADDR, -1n)).rejects.toThrow(/positive/);
+  });
+});
+
+describe("buildDefindexWithdrawTx", () => {
+  it("rejects non-positive shares", async () => {
+    await expect(buildDefindexWithdrawTx(config, ADDR, 0n)).rejects.toThrow(/positive/);
+  });
+});

--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -1,14 +1,94 @@
+import {
+  Address,
+  Contract,
+  Networks,
+  TransactionBuilder,
+  nativeToScVal,
+  rpc,
+  xdr,
+} from "@stellar/stellar-sdk";
 import type { StellarNetwork } from "./types";
 
+const BASE_FEE = "100";
+
 export interface DefindexVaultConfig {
-  contractId: string;
+  // DeFindex vault contract (C...) the request targets.
+  vaultId: string;
   network: StellarNetwork;
 }
 
+function passphraseFor(network: StellarNetwork): string {
+  return network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+}
+
+function i128(value: bigint): xdr.ScVal {
+  return nativeToScVal(value, { type: "i128" });
+}
+
+async function prepareVaultTx(
+  config: DefindexVaultConfig,
+  caller: string,
+  method: string,
+  args: xdr.ScVal[]
+): Promise<{ xdr: string; fee: string }> {
+  const passphrase = passphraseFor(config.network);
+  const server = new rpc.Server(config.network.rpcUrl);
+  const account = await server.getAccount(caller);
+  const contract = new Contract(config.vaultId);
+
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(300)
+    .build();
+
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
+
+  const prepared = rpc.assembleTransaction(tx, sim).build();
+  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+}
+
+/**
+ * Build an unsigned transaction that deposits `amount` (in stroops) of the
+ * vault's single underlying asset into a DeFindex vault on behalf of `depositor`,
+ * auto-investing into the vault's strategies. The user signs and submits the
+ * returned XDR and holds the resulting dfToken shares directly — non-custodial.
+ *
+ * Contract ABI: deposit(amounts_desired: Vec<i128>, amounts_min: Vec<i128>,
+ * from: Address, invest: bool). Single-asset vault, so each Vec has one element
+ * and amounts_min equals amounts_desired (no slippage for a 1:1 deposit).
+ */
 export async function buildDefindexDepositTx(
-  _config: DefindexVaultConfig,
-  _depositor: string,
-  _amount: bigint
-) {
-  throw new Error("Not implemented. See issue #5.");
+  config: DefindexVaultConfig,
+  depositor: string,
+  amount: bigint
+): Promise<{ xdr: string; fee: string }> {
+  if (amount <= 0n) throw new Error("amount must be positive");
+  return prepareVaultTx(config, depositor, "deposit", [
+    xdr.ScVal.scvVec([i128(amount)]),
+    xdr.ScVal.scvVec([i128(amount)]),
+    Address.fromString(depositor).toScVal(),
+    xdr.ScVal.scvBool(true),
+  ]);
+}
+
+/**
+ * Build an unsigned transaction that burns `shares` (dfTokens, in stroops) to
+ * withdraw the proportional underlying back to `withdrawer`.
+ *
+ * Contract ABI: withdraw(withdraw_shares: i128, min_amounts_out: Vec<i128>,
+ * from: Address). min_amounts_out is [0] — slippage protection is deferred to a
+ * later pass that quotes the expected out amount.
+ */
+export async function buildDefindexWithdrawTx(
+  config: DefindexVaultConfig,
+  withdrawer: string,
+  shares: bigint
+): Promise<{ xdr: string; fee: string }> {
+  if (shares <= 0n) throw new Error("shares must be positive");
+  return prepareVaultTx(config, withdrawer, "withdraw", [
+    i128(shares),
+    xdr.ScVal.scvVec([i128(0n)]),
+    Address.fromString(withdrawer).toScVal(),
+  ]);
 }


### PR DESCRIPTION
## Summary

Implements DeFindex (#5) using the **local XDR** approach (per maintainer decision): the vault contract calls are encoded directly with `@stellar/stellar-sdk` and simulated/assembled — the same non-custodial model as Blend, **no API key or hosted-service dependency** (the official `@defindex/sdk` is a hosted-API client, deliberately not used).

### What changed
- Replaces the throwing `defindex.ts` stub with `buildDefindexDepositTx` / `buildDefindexWithdrawTx`.
- ABI (from DeFindex docs): `deposit(amounts_desired: Vec<i128>, amounts_min: Vec<i128>, from: Address, invest: bool)` and `withdraw(withdraw_shares: i128, min_amounts_out: Vec<i128>, from: Address)`. Single-asset vault, so each `Vec` has one element; DeFindex withdraw burns dfToken shares.
- Dispatch in both the Vercel functions and the Fastify dev server now routes DeFindex vaults here.
- **Gated behind `DEFINDEX_VAULT_ID`** (new empty config slot): until a real testnet vault is wired, DeFindex routes return a clear `501` instead of pointing at a placeholder address. No fabricated addresses.

### Needs maintainer input to go live
A real DeFindex testnet vault contract address. Set `DEFINDEX_VAULT_ID` (env) or `CONTRACT_ADDRESSES.testnet.defindex.vault` and the route activates — code is ready.

### Not in this PR
DeFindex live position reads (the dashboard still reads Blend positions only) and slippage quoting on withdraw (`min_amounts_out` is `[0]`). Follow-ups.

### Verification
`lint` ✓ · `typecheck` (6/6) ✓ · `typecheck:api` ✓ · `test` ✓

Refs #5