### PR TITLE
feat: best-rate routing to the highest-APY depositable vault (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Meridian is a **testnet technical preview**, not a finished product. Be clear-ey
 - Non-custodial signing flow: the API builds an unsigned Soroban XDR, your wallet (Freighter) signs and submits it — keys never leave the browser
 - **Direct deposit / withdraw against a real Blend pool** (#4): funds supply straight into Blend from your wallet and the resulting bToken position is yours — no Meridian-controlled custody
 - Live position reads from the Blend pool (current supplied value)
+- Best-rate routing (#6): the API recommends the highest-APY vault it can actually deposit into, skipping display-only protocols and pools flagged risky
 - `MeridianVault` Soroban contract (ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails) with unit tests — reserved for the v2 single-transaction rebalancing router (#8)
 
 **In progress — the core promise is not finished**
 - Direct deposit/withdraw against real DeFindex vaults (#5) — *transaction builders are implemented locally (no hosted API); gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired*
-- Best-rate routing API that automatically picks the winning pool (#6)
 - Live DeFindex position reads, and per-position yield earned (cost-basis tracking for a direct Blend supply)
 - Mainnet configuration and a security audit before any real-funds use
 

--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -12,6 +12,7 @@ vi.mock("@meridian/stellar-sdk-helpers", () => ({
   buildAddTrustlineTx: vi.fn(async () => ({ xdr: "TRUST_XDR" })),
   submitTx: vi.fn(async () => ({ hash: "HASH" })),
   fetchAllVaults: vi.fn(async () => [{ id: "blend-usdc-fixed", protocol: "blend" }]),
+  selectBestVault: vi.fn(() => ({ id: "blend-usdc-fixed" })),
   fetchBlendPositions: vi.fn(async () => [
     { vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 },
   ]),
@@ -147,7 +148,11 @@ describe("GET /api/v1/vaults", () => {
     await vaultsHandler({ method: "GET" }, res);
     expect(res.statusCode).toBe(200);
     expect(res.headers["Cache-Control"]).toContain("s-maxage=60");
-    expect(res.body).toMatchObject({ vaults: [{ id: "blend-usdc-fixed" }], cached: false });
+    expect(res.body).toMatchObject({
+      vaults: [{ id: "blend-usdc-fixed" }],
+      recommendedVaultId: "blend-usdc-fixed",
+      cached: false,
+    });
   });
 });
 

--- a/api/v1/vaults/index.ts
+++ b/api/v1/vaults/index.ts
@@ -1,4 +1,5 @@
-import { fetchAllVaults } from "@meridian/stellar-sdk-helpers";
+import { fetchAllVaults, selectBestVault } from "@meridian/stellar-sdk-helpers";
+import { CONTRACT_ADDRESSES } from "@meridian/shared";
 
 // Cache the aggregated vault list at the Vercel CDN. APY/TVL move slowly, so a
 // short fresh window keeps DeFiLlama call volume low, and the stale-while-
@@ -6,12 +7,22 @@ import { fetchAllVaults } from "@meridian/stellar-sdk-helpers";
 // transient DeFiLlama outage instead of failing the whole dashboard.
 const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
 
+const defindexConfigured = Boolean(
+  process.env.DEFINDEX_VAULT_ID ?? CONTRACT_ADDRESSES.testnet.defindex.vault
+);
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(_req: any, res: any) {
   try {
     const vaults = await fetchAllVaults();
+    const best = selectBestVault(vaults, { defindexConfigured });
     res.setHeader("Cache-Control", CACHE_CONTROL);
-    res.json({ vaults, updatedAt: new Date().toISOString(), cached: false });
+    res.json({
+      vaults,
+      recommendedVaultId: best?.id ?? null,
+      updatedAt: new Date().toISOString(),
+      cached: false,
+    });
   } catch (err) {
     console.error("[vaults] fetch error:", err);
     res.status(500).json({ error: "Failed to fetch vaults" });

--- a/apps/api/src/routes/vaults.ts
+++ b/apps/api/src/routes/vaults.ts
@@ -1,10 +1,22 @@
 import type { FastifyPluginAsync } from "fastify";
+import { selectBestVault } from "@meridian/stellar-sdk-helpers";
+import { CONTRACT_ADDRESSES } from "@meridian/shared";
 import { fetchAllVaults } from "../services/vaults.js";
+
+const defindexConfigured = Boolean(
+  process.env.DEFINDEX_VAULT_ID ?? CONTRACT_ADDRESSES.testnet.defindex.vault
+);
 
 export const vaultsRoute: FastifyPluginAsync = async (app) => {
   app.get("/", async (_req, reply) => {
     const vaults = await fetchAllVaults();
-    return reply.send({ vaults, updatedAt: new Date().toISOString(), cached: false });
+    const best = selectBestVault(vaults, { defindexConfigured });
+    return reply.send({
+      vaults,
+      recommendedVaultId: best?.id ?? null,
+      updatedAt: new Date().toISOString(),
+      cached: false,
+    });
   });
 
   app.get("/:vaultId", async (req, reply) => {

--- a/apps/web/src/components/dashboard/VaultPanel.tsx
+++ b/apps/web/src/components/dashboard/VaultPanel.tsx
@@ -29,7 +29,8 @@ function formatTvl(value: number): string {
 type Tab = "deposit" | "withdraw";
 
 export function VaultPanel() {
-  const { data: vaults, isLoading: vaultsLoading } = useVaults();
+  const { data, isLoading: vaultsLoading } = useVaults();
+  const vaults = data?.vaults;
   const { connected, publicKey } = useWalletStore();
   const { handleConnect, status: connectStatus } = useWalletConnect();
   const { data: positions = [] } = usePositions(publicKey);
@@ -44,7 +45,9 @@ export function VaultPanel() {
     e.preventDefault();
   }
 
-  const bestVault = vaults?.reduce((best, v) => (v.apy > best.apy ? v : best), vaults[0]);
+  // Route to the server's recommendation: the highest-APY vault Meridian can
+  // actually deposit into (excludes display-only protocols and risky pools).
+  const bestVault = vaults?.find((v) => v.id === data?.recommendedVaultId);
   // Single-vault architecture: the user holds at most one position. Revisit if multi-vault is added.
   const position = positions[0];
   const hasPosition = position && position.deposited > 0;

--- a/apps/web/src/hooks/useVaults.ts
+++ b/apps/web/src/hooks/useVaults.ts
@@ -1,15 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 import { api, type ApiVault } from "../lib/api";
 
+export interface VaultsResult {
+  vaults: ApiVault[];
+  // Server-chosen best routable vault (highest APY among depositable, non-risky
+  // pools), or null when nothing is routable.
+  recommendedVaultId: string | null;
+}
+
 export function useVaults() {
-  return useQuery<ApiVault[], Error>({
+  return useQuery<VaultsResult, Error>({
     queryKey: ["vaults"],
     queryFn: async () => {
       const [data] = await Promise.all([
         api.getVaults(),
         new Promise((r) => setTimeout(r, 2_000)),
       ]);
-      return data.vaults;
+      return { vaults: data.vaults, recommendedVaultId: data.recommendedVaultId };
     },
     staleTime: 5 * 60_000,
     retry: 1,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -39,9 +39,12 @@ export interface ApiPosition {
 
 export const api = {
   getVaults: () =>
-    apiFetch<{ vaults: ApiVault[]; updatedAt: string; cached: boolean }>(
-      "/api/v1/vaults"
-    ),
+    apiFetch<{
+      vaults: ApiVault[];
+      recommendedVaultId: string | null;
+      updatedAt: string;
+      cached: boolean;
+    }>("/api/v1/vaults"),
   getPositions: (publicKey: string) =>
     apiFetch<{ positions: ApiPosition[] }>(
       `/api/v1/positions/${publicKey}`

--- a/packages/stellar-sdk-helpers/src/index.ts
+++ b/packages/stellar-sdk-helpers/src/index.ts
@@ -3,6 +3,7 @@ export * from "./defilamma";
 export * from "./defindex";
 export * from "./horizon";
 export * from "./positions";
+export * from "./routing";
 export * from "./tx";
 export * from "./types";
 export * from "./vaults";

--- a/packages/stellar-sdk-helpers/src/routing.test.ts
+++ b/packages/stellar-sdk-helpers/src/routing.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { selectBestVault } from "./routing";
+import type { ApiVault } from "./vaults";
+
+function vault(p: Partial<ApiVault>): ApiVault {
+  return {
+    id: p.id ?? "v",
+    protocol: p.protocol ?? "blend",
+    asset: "USDC",
+    name: "n",
+    label: "l",
+    apy: p.apy ?? 5,
+    tvl: 1_000_000,
+    userBalance: 0,
+    riskLevel: p.riskLevel ?? "safe",
+  };
+}
+
+describe("selectBestVault", () => {
+  const opts = { defindexConfigured: true };
+
+  it("picks the highest-APY routable vault", () => {
+    const best = selectBestVault(
+      [
+        vault({ id: "a", protocol: "blend", apy: 4 }),
+        vault({ id: "b", protocol: "defindex", apy: 7 }),
+        vault({ id: "c", protocol: "blend", apy: 6 }),
+      ],
+      opts
+    );
+    expect(best?.id).toBe("b");
+  });
+
+  it("excludes non-depositable protocols even when they have the best APY", () => {
+    const best = selectBestVault(
+      [
+        vault({ id: "ondo", protocol: "ondo", apy: 12 }),
+        vault({ id: "blend", protocol: "blend", apy: 5 }),
+      ],
+      opts
+    );
+    expect(best?.id).toBe("blend");
+  });
+
+  it("excludes DeFindex when no vault is configured", () => {
+    const best = selectBestVault(
+      [
+        vault({ id: "dfx", protocol: "defindex", apy: 9 }),
+        vault({ id: "blend", protocol: "blend", apy: 5 }),
+      ],
+      { defindexConfigured: false }
+    );
+    expect(best?.id).toBe("blend");
+  });
+
+  it("prefers a non-risky pool over a higher-APY risky one", () => {
+    const best = selectBestVault(
+      [
+        vault({ id: "risky", protocol: "blend", apy: 15, riskLevel: "risky" }),
+        vault({ id: "safe", protocol: "blend", apy: 6, riskLevel: "safe" }),
+      ],
+      opts
+    );
+    expect(best?.id).toBe("safe");
+  });
+
+  it("falls back to the best risky pool when nothing safer is routable", () => {
+    const best = selectBestVault(
+      [
+        vault({ id: "r1", protocol: "blend", apy: 11, riskLevel: "risky" }),
+        vault({ id: "r2", protocol: "blend", apy: 14, riskLevel: "risky" }),
+      ],
+      opts
+    );
+    expect(best?.id).toBe("r2");
+  });
+
+  it("returns null when nothing is routable", () => {
+    expect(selectBestVault([vault({ protocol: "ondo" })], opts)).toBeNull();
+    expect(selectBestVault([], opts)).toBeNull();
+  });
+});

--- a/packages/stellar-sdk-helpers/src/routing.ts
+++ b/packages/stellar-sdk-helpers/src/routing.ts
@@ -1,0 +1,31 @@
+import type { ApiVault } from "./vaults";
+
+export interface RouteOptions {
+  // DeFindex vaults are only routable once a real vault contract is configured.
+  defindexConfigured: boolean;
+}
+
+// A vault is routable only if Meridian can build a deposit for its protocol.
+// Blend is always supported; DeFindex once a vault is configured; everything
+// else (e.g. Ondo, or an unknown protocol) is display-only.
+function isRoutable(vault: ApiVault, opts: RouteOptions): boolean {
+  if (vault.protocol === "blend") return true;
+  if (vault.protocol === "defindex") return opts.defindexConfigured;
+  return false;
+}
+
+/**
+ * Pick the vault to route a new deposit into: the highest-APY vault Meridian can
+ * actually build a deposit for, preferring pools not flagged "risky". Falls back
+ * to the best routable pool when every option is risky, and returns null when
+ * nothing is routable. Pure — no I/O.
+ */
+export function selectBestVault(vaults: ApiVault[], opts: RouteOptions): ApiVault | null {
+  const routable = vaults.filter((v) => isRoutable(v, opts));
+  if (routable.length === 0) return null;
+
+  const safe = routable.filter((v) => v.riskLevel !== "risky");
+  const candidates = safe.length > 0 ? safe : routable;
+
+  return candidates.reduce((best, v) => (v.apy > best.apy ? v : best));
+}


### PR DESCRIPTION
## Summary

Implements best-rate routing (#6) and fixes a real bug: the dashboard previously picked the deposit target with a naive client-side max-APY `reduce`, which could land on a **non-depositable** protocol (Ondo, or unconfigured DeFindex) — failing at deposit time — or on a **risky** pool.

### What changed
- **`selectBestVault`** — a pure ranker that picks the highest-APY vault Meridian can actually build a deposit for (Blend always; DeFindex when configured; display-only protocols excluded), prefers pools not flagged `risky`, and returns `null` when nothing is routable.
- Both vaults endpoints (Vercel + Fastify) now return `recommendedVaultId`.
- The dashboard routes deposits to `recommendedVaultId` instead of the naive pick.
- Thorough unit tests for the ranking rules (APY order, protocol exclusion, DeFindex gating, risk preference, fallback, empty).

### Verification
`lint` ✓ · `typecheck` (6/6) ✓ · `typecheck:api` ✓ · `test` ✓

Closes #6