### PR TITLE
feat: read live DeFindex vault positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Meridian is a **testnet technical preview**, not a finished product. Be clear-ey
 - Live APY / TVL feed across Stellar stablecoin pools (via DeFiLlama) with a risk heuristic
 - Non-custodial signing flow: the API builds an unsigned Soroban XDR, your wallet (Freighter) signs and submits it — keys never leave the browser
 - **Direct deposit / withdraw against a real Blend pool** (#4): funds supply straight into Blend from your wallet and the resulting bToken position is yours — no Meridian-controlled custody
-- Live position reads from the Blend pool (current supplied value)
+- Live position reads from the Blend pool and (when a DeFindex vault is configured) DeFindex vault — current supplied value
 - `MeridianVault` Soroban contract (ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails) with unit tests — reserved for the v2 single-transaction rebalancing router (#8)
 
 **In progress — the core promise is not finished**
 - Direct deposit/withdraw against real DeFindex vaults (#5) — *transaction builders are implemented locally (no hosted API); gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired*
 - Best-rate routing API that automatically picks the winning pool (#6)
-- Live DeFindex position reads, and per-position yield earned (cost-basis tracking for a direct Blend supply)
+- Per-position yield earned (cost-basis tracking for direct Blend/DeFindex positions)
 - Mainnet configuration and a security audit before any real-funds use
 
 Until a DeFindex vault is configured, DeFindex routes return `501` rather than silently routing elsewhere. Track progress in the [Roadmap](#roadmap) and [open issues](../../issues).

--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -15,6 +15,7 @@ vi.mock("@meridian/stellar-sdk-helpers", () => ({
   fetchBlendPositions: vi.fn(async () => [
     { vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 },
   ]),
+  fetchDefindexPosition: vi.fn(async () => []),
 }));
 
 import depositHandler from "../v1/tx/deposit";

--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,8 +1,9 @@
-import { fetchBlendPositions } from "@meridian/stellar-sdk-helpers";
+import { fetchBlendPositions, fetchDefindexPosition } from "@meridian/stellar-sdk-helpers";
 import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
+const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
@@ -17,6 +18,17 @@ export default async function handler(req: any, res: any) {
       { assetId: addresses.usdc, vaultId: "blend-usdc-fixed" },
       { assetId: addresses.eurc, vaultId: "blend-eurc-fixed" },
     ]);
+
+    if (defindexVaultId) {
+      // Isolated so a DeFindex read failure can't drop the Blend positions.
+      try {
+        const dfx = await fetchDefindexPosition(network, defindexVaultId, "defindex-usdc", publicKey);
+        positions.push(...dfx);
+      } catch (err) {
+        console.error("[positions] defindex read failed:", err);
+      }
+    }
+
     res.json({ positions });
   } catch (err) {
     console.error("[positions] error:", err);

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -1,9 +1,10 @@
 import type { FastifyPluginAsync } from "fastify";
 import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
-import { fetchBlendPositions } from "@meridian/stellar-sdk-helpers";
+import { fetchBlendPositions, fetchDefindexPosition } from "@meridian/stellar-sdk-helpers";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
+const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault;
 
 export const positionsRoute: FastifyPluginAsync = async (app) => {
   app.get("/:publicKey", async (req, reply) => {
@@ -18,6 +19,17 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
         { assetId: addresses.usdc, vaultId: "blend-usdc-fixed" },
         { assetId: addresses.eurc, vaultId: "blend-eurc-fixed" },
       ]);
+
+      if (defindexVaultId) {
+        // Isolated so a DeFindex read failure can't drop the Blend positions.
+        try {
+          const dfx = await fetchDefindexPosition(network, defindexVaultId, "defindex-usdc", publicKey);
+          positions.push(...dfx);
+        } catch (err) {
+          app.log.error(err, "[positions] defindex read failed");
+        }
+      }
+
       reply.send({ positions });
     } catch (err) {
       app.log.error(err, "[positions] read failed");

--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -7,9 +7,16 @@ import {
   rpc,
   xdr,
 } from "@stellar/stellar-sdk";
+import { simulateView } from "./tx";
 import type { StellarNetwork } from "./types";
+import type { PositionInfo } from "./positions";
 
 const BASE_FEE = "100";
+const STROOPS_PER_UNIT = 1e7;
+
+function toBigInt(value: unknown): bigint {
+  return BigInt((value as bigint | number | null) ?? 0);
+}
 
 export interface DefindexVaultConfig {
   // DeFindex vault contract (C...) the request targets.
@@ -91,4 +98,48 @@ export async function buildDefindexWithdrawTx(
     xdr.ScVal.scvVec([i128(0n)]),
     Address.fromString(withdrawer).toScVal(),
   ]);
+}
+
+/**
+ * Read a user's live position in a DeFindex vault via read-only simulation.
+ * `balance` gives the dfToken share count; `get_asset_amounts_per_shares` values
+ * those shares in the underlying asset. Returns `[]` when the user holds nothing.
+ *
+ * `shares` carries the dfToken count (not the USD value) because a DeFindex
+ * withdrawal burns shares — so the UI's "withdraw max" maps straight to it.
+ * `earned` is 0: a direct vault position has no on-chain cost basis (same as the
+ * Blend path).
+ */
+export async function fetchDefindexPosition(
+  network: StellarNetwork,
+  vaultId: string,
+  reportVaultId: string,
+  publicKey: string
+): Promise<PositionInfo[]> {
+  const server = new rpc.Server(network.rpcUrl);
+  const caller = Address.fromString(publicKey).toScVal();
+
+  const shares = toBigInt(
+    await simulateView(server, vaultId, network.passphrase, "balance", caller)
+  );
+  if (shares <= 0n) return [];
+
+  const amounts = (await simulateView(
+    server,
+    vaultId,
+    network.passphrase,
+    "get_asset_amounts_per_shares",
+    i128(shares)
+  )) as Array<bigint | number> | null;
+  const underlying = Array.isArray(amounts) && amounts.length > 0 ? toBigInt(amounts[0]) : 0n;
+
+  return [
+    {
+      vaultId: reportVaultId,
+      shares: Number(shares) / STROOPS_PER_UNIT,
+      deposited: Number(underlying) / STROOPS_PER_UNIT,
+      earned: 0,
+      entryTime: 0,
+    },
+  ];
 }


### PR DESCRIPTION
## Summary

Follow-up to #110. Reads a user's live DeFindex vault position so it shows on the dashboard once a vault is configured — completing the position layer for both protocols.

### What changed
- **`fetchDefindexPosition`** — reads the user's dfToken `balance` and values it via the vault's `get_asset_amounts_per_shares(vault_shares: i128) -> Vec<i128>` getter through read-only simulation (local, no hosted API).
- Both positions endpoints (Vercel + Fastify) append a DeFindex position when `DEFINDEX_VAULT_ID` is set, inside an **isolated try/catch** so a DeFindex read failure can't drop the Blend positions.
- `shares` carries the dfToken count (a DeFindex withdrawal burns shares, so the UI "withdraw max" maps to it); `earned` stays `0` pending cost-basis tracking, consistent with the Blend path.

### Verification
`lint` ✓ · `typecheck` (6/6) ✓ · `typecheck:api` ✓ · `test` ✓

Refs #5