### PR TITLE
fix: remove hardcoded 2-second delay from useVaults query

### DIFF
--- a/apps/web/src/hooks/useVaults.ts
+++ b/apps/web/src/hooks/useVaults.ts
@@ -12,10 +12,7 @@ export function useVaults() {
   return useQuery<VaultsResult, Error>({
     queryKey: ["vaults"],
     queryFn: async () => {
-      const [data] = await Promise.all([
-        api.getVaults(),
-        new Promise((r) => setTimeout(r, 2_000)),
-      ]);
+      const data = await api.getVaults();
       return { vaults: data.vaults, recommendedVaultId: data.recommendedVaultId };
     },
     staleTime: 5 * 60_000,


### PR DESCRIPTION
## Summary
- Removes the artificial `setTimeout(r, 2_000)` delay from the `useVaults` query function
- `api.getVaults()` is now awaited directly; loading state is driven by actual network latency

## Test plan
- [x] Open the dashboard and confirm vaults load as soon as the API responds (no extra 2-second pause)
- [x] Confirm the loading skeleton still appears while the request is in flight

Closes #118