### PR TITLE
fix: break APY ties in selectBestVault by vault id

### DIFF
--- a/packages/stellar-sdk-helpers/src/routing.test.ts
+++ b/packages/stellar-sdk-helpers/src/routing.test.ts
@@ -79,4 +79,11 @@ describe("selectBestVault", () => {
     expect(selectBestVault([vault({ protocol: "ondo" })], opts)).toBeNull();
     expect(selectBestVault([], opts)).toBeNull();
   });
+
+  it("breaks APY ties deterministically by vault id regardless of input order", () => {
+    const a = vault({ id: "blend-eurc-fixed", apy: 5 });
+    const b = vault({ id: "blend-usdc-fixed", apy: 5 });
+    expect(selectBestVault([a, b], opts)?.id).toBe("blend-eurc-fixed");
+    expect(selectBestVault([b, a], opts)?.id).toBe("blend-eurc-fixed");
+  });
 });

--- a/packages/stellar-sdk-helpers/src/routing.ts
+++ b/packages/stellar-sdk-helpers/src/routing.ts
@@ -27,5 +27,8 @@ export function selectBestVault(vaults: ApiVault[], opts: RouteOptions): ApiVaul
   const safe = routable.filter((v) => v.riskLevel !== "risky");
   const candidates = safe.length > 0 ? safe : routable;
 
-  return candidates.reduce((best, v) => (v.apy > best.apy ? v : best));
+  // Tie-break by id (alphabetical) so the result is stable across requests.
+  return candidates.reduce((best, v) =>
+    v.apy > best.apy || (v.apy === best.apy && v.id < best.id) ? v : best
+  );
 }


### PR DESCRIPTION
## Summary
- Adds a deterministic tie-breaker to `selectBestVault`: when two vaults share the top APY, the one with the lexicographically smaller vault ID wins
- Prevents the recommended vault from flipping between page loads when APYs are equal

## Test plan
- [x] Run `pnpm --filter @meridian/stellar-sdk-helpers run test` and confirm all tests pass including the new tie-breaker test

Closes #121