### PR TITLE
fix: return 503 instead of empty 200 when Blend RPC fails

### DIFF
--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -174,10 +174,11 @@ describe("GET /api/v1/positions/:publicKey", () => {
     expect(fetchBlendPositions).toHaveBeenCalledOnce();
   });
 
-  it("degrades to an empty list if the read throws", async () => {
+  it("returns 503 when the Blend read throws", async () => {
     vi.mocked(fetchBlendPositions).mockRejectedValueOnce(new Error("rpc down"));
     const res = makeRes();
     await positionsHandler({ method: "GET", query: { publicKey: PUBKEY } }, res);
-    expect(res.body).toEqual({ positions: [] });
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: "Failed to read positions" });
   });
 });

--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -32,6 +32,6 @@ export default async function handler(req: any, res: any) {
     res.json({ positions });
   } catch (err) {
     console.error("[positions] error:", err);
-    res.json({ positions: [] });
+    res.status(503).json({ error: "Failed to read positions" });
   }
 }

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -33,7 +33,7 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
       reply.send({ positions });
     } catch (err) {
       app.log.error(err, "[positions] read failed");
-      reply.send({ positions: [] });
+      reply.code(503).send({ error: "Failed to read positions" });
     }
   });
 };


### PR DESCRIPTION
## Summary
- Changes the outer catch in both the Vercel and Fastify positions handlers to return HTTP 503 instead of 200 with an empty array when the Blend RPC call fails
- Updates the handler test to assert the correct status code and error body

## Test plan
- [x] Run tests and confirm all pass
- [x] Simulate an RPC failure and confirm the response is 503 with an error message

Closes #114