### PR TITLE
fix: resolve DeFindex contract from request vaultId not env var

### DIFF
--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -5,11 +5,10 @@ import {
   resolveProtocol,
   toStroops,
 } from "@meridian/stellar-sdk-helpers";
-import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
+import { CONTRACT_ADDRESSES, STELLAR_NETWORKS, defindexContractForVault } from "@meridian/shared";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
-const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
@@ -36,13 +35,12 @@ export default async function handler(req: any, res: any) {
       return res.json(result);
     }
 
-    if (!defindexVaultId) {
-      return res
-        .status(501)
-        .json({ error: "DeFindex vault not configured. Set DEFINDEX_VAULT_ID. See issue #5." });
+    const contractId = defindexContractForVault(vaultId, addresses);
+    if (!contractId) {
+      return res.status(400).json({ error: `DeFindex vault '${vaultId}' is not configured` });
     }
     const result = await buildDefindexDepositTx(
-      { vaultId: defindexVaultId, network },
+      { vaultId: contractId, network },
       walletAddress,
       toStroops(amount)
     );

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -5,11 +5,10 @@ import {
   resolveProtocol,
   toStroops,
 } from "@meridian/stellar-sdk-helpers";
-import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
+import { CONTRACT_ADDRESSES, STELLAR_NETWORKS, defindexContractForVault } from "@meridian/shared";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
-const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
@@ -37,14 +36,13 @@ export default async function handler(req: any, res: any) {
       return res.json(result);
     }
 
-    if (!defindexVaultId) {
-      return res
-        .status(501)
-        .json({ error: "DeFindex vault not configured. Set DEFINDEX_VAULT_ID. See issue #5." });
+    const contractId = defindexContractForVault(vaultId, addresses);
+    if (!contractId) {
+      return res.status(400).json({ error: `DeFindex vault '${vaultId}' is not configured` });
     }
     // For a DeFindex vault, `amount` is the number of dfToken shares to burn.
     const result = await buildDefindexWithdrawTx(
-      { vaultId: defindexVaultId, network },
+      { vaultId: contractId, network },
       walletAddress,
       toStroops(amount)
     );

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -1,5 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import { DepositRequestSchema, WithdrawRequestSchema, CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
+import { DepositRequestSchema, WithdrawRequestSchema, CONTRACT_ADDRESSES, STELLAR_NETWORKS, defindexContractForVault } from "@meridian/shared";
 import {
   buildBlendDepositTx,
   buildBlendWithdrawTx,
@@ -14,7 +14,6 @@ import {
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
-const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault;
 
 export const txRoute: FastifyPluginAsync = async (app) => {
   app.post("/deposit", async (req, reply) => {
@@ -36,11 +35,12 @@ export const txRoute: FastifyPluginAsync = async (app) => {
         );
         return reply.send(result);
       }
-      if (!defindexVaultId) {
-        return reply.code(501).send({ error: "DeFindex vault not configured. Set DEFINDEX_VAULT_ID. See issue #5." });
+      const contractId = defindexContractForVault(vaultId, addresses);
+      if (!contractId) {
+        return reply.code(400).send({ error: `DeFindex vault '${vaultId}' is not configured` });
       }
       const result = await buildDefindexDepositTx(
-        { vaultId: defindexVaultId, network },
+        { vaultId: contractId, network },
         walletAddress,
         toStroops(amount)
       );
@@ -70,12 +70,13 @@ export const txRoute: FastifyPluginAsync = async (app) => {
         );
         return reply.send(result);
       }
-      if (!defindexVaultId) {
-        return reply.code(501).send({ error: "DeFindex vault not configured. Set DEFINDEX_VAULT_ID. See issue #5." });
+      const contractId = defindexContractForVault(vaultId, addresses);
+      if (!contractId) {
+        return reply.code(400).send({ error: `DeFindex vault '${vaultId}' is not configured` });
       }
       // For a DeFindex vault, `amount` is the number of dfToken shares to burn.
       const result = await buildDefindexWithdrawTx(
-        { vaultId: defindexVaultId, network },
+        { vaultId: contractId, network },
         walletAddress,
         toStroops(amount)
       );

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,3 +1,23 @@
 export function shortenAddress(address: string, chars = 4): string {
   return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }
+
+import { CONTRACT_ADDRESSES } from "./constants";
+
+type TestnetAddresses = (typeof CONTRACT_ADDRESSES)["testnet"];
+
+/**
+ * Resolves the on-chain contract address for a logical DeFindex vault ID.
+ * Returns an empty string when the vault is not yet configured.
+ * The DEFINDEX_VAULT_ID env var overrides the defindex-usdc entry for
+ * backward compatibility with the single-vault setup.
+ */
+export function defindexContractForVault(
+  logicalVaultId: string,
+  addresses: TestnetAddresses
+): string {
+  const registry: Record<string, string> = {
+    "defindex-usdc": process.env.DEFINDEX_VAULT_ID || addresses.defindex.vault,
+  };
+  return registry[logicalVaultId] ?? "";
+}


### PR DESCRIPTION
## Summary
- Adds a defindexContractForVault(logicalVaultId, addresses) helper in @meridian/shared that maps logical vault IDs to their contract addresses
- Deposit and withdraw handlers in both API layers now use the request's aultId to resolve the DeFindex contract, instead of always falling back to the env-configured vault
- Supports the DEFINDEX_VAULT_ID env override for backward compatibility

## Test plan
- [x] Run all tests and confirm they pass
- [x] Send a deposit request with a specific DeFindex vault ID and verify the correct contract is targeted

Closes #113