### PR TITLE
fix: prevent bigint precision loss in fetchDefindexPosition

### DIFF
--- a/packages/stellar-sdk-helpers/src/defindex.test.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildDefindexDepositTx, buildDefindexWithdrawTx } from "./defindex";
+import { buildDefindexDepositTx, buildDefindexWithdrawTx, stroopsToUnits } from "./defindex";
 import type { StellarNetwork } from "./types";
 
 const network: StellarNetwork = {
@@ -22,5 +22,23 @@ describe("buildDefindexDepositTx", () => {
 describe("buildDefindexWithdrawTx", () => {
   it("rejects non-positive shares", async () => {
     await expect(buildDefindexWithdrawTx(config, ADDR, 0n)).rejects.toThrow(/positive/);
+  });
+});
+
+describe("stroopsToUnits", () => {
+  it("converts small values exactly", () => {
+    expect(stroopsToUnits(10_000_000n)).toBe(1);
+    expect(stroopsToUnits(5_000_000n)).toBe(0.5);
+  });
+
+  it("preserves precision for values above Number.MAX_SAFE_INTEGER stroops", () => {
+    // 1 billion units = 10_000_000_000_000_000 stroops (1e16), above MAX_SAFE_INTEGER
+    const stroops = 10_000_000_000_000_000n;
+    expect(stroopsToUnits(stroops)).toBe(1_000_000_000);
+  });
+
+  it("handles fractional units correctly", () => {
+    // 1.0000001 units = 10_000_001 stroops
+    expect(stroopsToUnits(10_000_001n)).toBeCloseTo(1.0000001, 7);
   });
 });

--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -12,10 +12,17 @@ import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
 
 const BASE_FEE = "100";
-const STROOPS_PER_UNIT = 1e7;
+const STROOPS = 10_000_000n;
 
 function toBigInt(value: unknown): bigint {
   return BigInt((value as bigint | number | null) ?? 0);
+}
+
+// Converts a stroop-denominated bigint to a floating-point unit value without
+// precision loss: the whole-unit part stays in bigint space until it fits
+// safely in a Number, then the sub-unit remainder is added as a fraction.
+export function stroopsToUnits(stroops: bigint): number {
+  return Number(stroops / STROOPS) + Number(stroops % STROOPS) / 1e7;
 }
 
 export interface DefindexVaultConfig {
@@ -136,8 +143,8 @@ export async function fetchDefindexPosition(
   return [
     {
       vaultId: reportVaultId,
-      shares: Number(shares) / STROOPS_PER_UNIT,
-      deposited: Number(underlying) / STROOPS_PER_UNIT,
+      shares: stroopsToUnits(shares),
+      deposited: stroopsToUnits(underlying),
       earned: 0,
       entryTime: 0,
     },


### PR DESCRIPTION
## Summary
- Replaces Number(bigint) / 1e7 with integer-first division (igint / 10_000_000n) before converting to Number, preventing IEEE 754 precision loss for positions above 2^53 stroops
- Extracts a stroopsToUnits(stroops: bigint): number helper and adds unit tests for it

## Test plan
- [x] Run pnpm --filter @meridian/stellar-sdk-helpers run test and confirm all tests pass including the new precision tests

Closes #116