### PR TITLE
refactor: centralise shared constants and utilities in internal.ts

### DIFF
--- a/packages/stellar-sdk-helpers/src/blend.ts
+++ b/packages/stellar-sdk-helpers/src/blend.ts
@@ -1,9 +1,8 @@
-import { Networks, TransactionBuilder, rpc, xdr } from "@stellar/stellar-sdk";
+import { TransactionBuilder, rpc, xdr } from "@stellar/stellar-sdk";
 import { PoolContractV2, PoolV2, RequestType } from "@blend-capital/blend-sdk";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
-
-const BASE_FEE = "100";
+import { BASE_FEE, passphraseFor } from "./internal";
 
 export interface BlendPoolConfig {
   // Blend pool contract (C...) the request is submitted to.
@@ -11,10 +10,6 @@ export interface BlendPoolConfig {
   // Reserve asset contract — the USDC/EURC Stellar Asset Contract being moved.
   assetId: string;
   network: StellarNetwork;
-}
-
-function passphraseFor(network: StellarNetwork): string {
-  return network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
 }
 
 // Map a Meridian vault id (e.g. "blend-usdc-fixed") to the reserve asset whose

--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -1,7 +1,6 @@
 import {
   Address,
   Contract,
-  Networks,
   TransactionBuilder,
   nativeToScVal,
   rpc,
@@ -10,13 +9,9 @@ import {
 import { simulateView } from "./tx";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
+import { BASE_FEE, toBigInt, passphraseFor } from "./internal";
 
-const BASE_FEE = "100";
 const STROOPS = 10_000_000n;
-
-function toBigInt(value: unknown): bigint {
-  return BigInt((value as bigint | number | null) ?? 0);
-}
 
 // Converts a stroop-denominated bigint to a floating-point unit value without
 // precision loss: the whole-unit part stays in bigint space until it fits
@@ -29,10 +24,6 @@ export interface DefindexVaultConfig {
   // DeFindex vault contract (C...) the request targets.
   vaultId: string;
   network: StellarNetwork;
-}
-
-function passphraseFor(network: StellarNetwork): string {
-  return network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
 }
 
 function i128(value: bigint): xdr.ScVal {

--- a/packages/stellar-sdk-helpers/src/internal.ts
+++ b/packages/stellar-sdk-helpers/src/internal.ts
@@ -1,0 +1,14 @@
+import { Networks } from "@stellar/stellar-sdk";
+import type { StellarNetwork } from "./types";
+
+export const BASE_FEE = "100";
+
+export const STROOPS_PER_UNIT = 1e7;
+
+export function toBigInt(value: unknown): bigint {
+  return BigInt((value as bigint | number | null) ?? 0);
+}
+
+export function passphraseFor(network: StellarNetwork): string {
+  return network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+}

--- a/packages/stellar-sdk-helpers/src/positions.ts
+++ b/packages/stellar-sdk-helpers/src/positions.ts
@@ -1,6 +1,7 @@
 import { rpc, Address, xdr } from "@stellar/stellar-sdk";
 import { simulateView } from "./tx";
 import type { StellarNetwork } from "./types";
+import { STROOPS_PER_UNIT, toBigInt } from "./internal";
 
 export interface PositionInfo {
   vaultId: string;
@@ -20,8 +21,6 @@ export interface RawPosition {
   principal: bigint | null;
   entryTime: bigint;
 }
-
-const STROOPS_PER_UNIT = 1e7;
 
 /**
  * Derive the display position from raw on-chain figures. Pure and total — no
@@ -50,10 +49,6 @@ export function computePosition(vaultId: string, raw: RawPosition): PositionInfo
       entryTime: Number(raw.entryTime),
     },
   ];
-}
-
-function toBigInt(value: unknown): bigint {
-  return BigInt((value as bigint | number | null) ?? 0);
 }
 
 /**

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -13,6 +13,7 @@ import {
   Networks,
 } from "@stellar/stellar-sdk";
 import type { StellarNetwork } from "./types";
+import { BASE_FEE } from "./internal";
 
 const USDC_ISSUER: Record<string, string> = {
   testnet: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
@@ -29,8 +30,6 @@ const HORIZON_URL: Record<string, string> = {
   testnet: "https://horizon-testnet.stellar.org",
   mainnet: "https://horizon.stellar.org",
 };
-
-const BASE_FEE = "100";
 
 function usdcAsset(network: StellarNetwork): Asset {
   const issuer = USDC_ISSUER[network.network];
@@ -94,7 +93,7 @@ export async function simulateView(
 ): Promise<unknown> {
   const dummyAccount = new Account("GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN", "0");
   const contract = new Contract(contractId);
-  const tx = new TransactionBuilder(dummyAccount, { fee: "100", networkPassphrase })
+  const tx = new TransactionBuilder(dummyAccount, { fee: BASE_FEE, networkPassphrase })
     .addOperation(contract.call(method, ...args))
     .setTimeout(0)
     .build();


### PR DESCRIPTION
## Summary

- Extracts `BASE_FEE`, `STROOPS_PER_UNIT`, `toBigInt`, and `passphraseFor` into a new `internal.ts` module within `@meridian/stellar-sdk-helpers`
- Removes the four local copies that were duplicated across `blend.ts`, `defindex.ts`, `tx.ts`, and `positions.ts`

## Test plan

- [ ] Run `pnpm --filter @meridian/stellar-sdk-helpers run test` and confirm all 39 tests pass

Closes #119