### PR TITLE
refactor: extract simulate-assemble-XDR pattern into prepareSorobanTx

### DIFF
--- a/packages/stellar-sdk-helpers/src/blend.ts
+++ b/packages/stellar-sdk-helpers/src/blend.ts
@@ -1,8 +1,8 @@
-import { TransactionBuilder, rpc, xdr } from "@stellar/stellar-sdk";
+import { xdr } from "@stellar/stellar-sdk";
 import { PoolContractV2, PoolV2, RequestType } from "@blend-capital/blend-sdk";
+import { prepareSorobanTx } from "./tx";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
-import { BASE_FEE, passphraseFor } from "./internal";
 
 export interface BlendPoolConfig {
   // Blend pool contract (C...) the request is submitted to.
@@ -29,10 +29,6 @@ async function buildPoolRequestTx(
 ): Promise<{ xdr: string; fee: string }> {
   if (amount <= 0n) throw new Error("amount must be positive");
 
-  const passphrase = passphraseFor(config.network);
-  const server = new rpc.Server(config.network.rpcUrl);
-  const account = await server.getAccount(caller);
-
   // PoolContractV2.submit returns a base64 Soroban operation; we wrap it in a
   // transaction, simulate to obtain the resource footprint + fee, then assemble.
   const pool = new PoolContractV2(config.poolId);
@@ -43,17 +39,7 @@ async function buildPoolRequestTx(
     requests: [{ request_type: requestType, address: config.assetId, amount }],
   });
   const op = xdr.Operation.fromXDR(opXdr, "base64");
-
-  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
-    .addOperation(op)
-    .setTimeout(300)
-    .build();
-
-  const sim = await server.simulateTransaction(tx);
-  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
-
-  const prepared = rpc.assembleTransaction(tx, sim).build();
-  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+  return prepareSorobanTx(config.network, caller, op);
 }
 
 /**

--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -1,15 +1,14 @@
 import {
   Address,
   Contract,
-  TransactionBuilder,
   nativeToScVal,
   rpc,
   xdr,
 } from "@stellar/stellar-sdk";
-import { simulateView } from "./tx";
+import { simulateView, prepareSorobanTx } from "./tx";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
-import { BASE_FEE, toBigInt, passphraseFor } from "./internal";
+import { toBigInt } from "./internal";
 
 const STROOPS = 10_000_000n;
 
@@ -28,29 +27,6 @@ export interface DefindexVaultConfig {
 
 function i128(value: bigint): xdr.ScVal {
   return nativeToScVal(value, { type: "i128" });
-}
-
-async function prepareVaultTx(
-  config: DefindexVaultConfig,
-  caller: string,
-  method: string,
-  args: xdr.ScVal[]
-): Promise<{ xdr: string; fee: string }> {
-  const passphrase = passphraseFor(config.network);
-  const server = new rpc.Server(config.network.rpcUrl);
-  const account = await server.getAccount(caller);
-  const contract = new Contract(config.vaultId);
-
-  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
-    .addOperation(contract.call(method, ...args))
-    .setTimeout(300)
-    .build();
-
-  const sim = await server.simulateTransaction(tx);
-  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
-
-  const prepared = rpc.assembleTransaction(tx, sim).build();
-  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
 }
 
 /**
@@ -74,12 +50,13 @@ export async function buildDefindexDepositTx(
 ): Promise<{ xdr: string; fee: string }> {
   if (amount <= 0n) throw new Error("amount must be positive");
   const minAmount = amount - (amount * slippageBps) / 10_000n;
-  return prepareVaultTx(config, depositor, "deposit", [
+  const contract = new Contract(config.vaultId);
+  return prepareSorobanTx(config.network, depositor, contract.call("deposit",
     xdr.ScVal.scvVec([i128(amount)]),
     xdr.ScVal.scvVec([i128(minAmount)]),
     Address.fromString(depositor).toScVal(),
     xdr.ScVal.scvBool(true),
-  ]);
+  ));
 }
 
 /**
@@ -96,11 +73,12 @@ export async function buildDefindexWithdrawTx(
   shares: bigint
 ): Promise<{ xdr: string; fee: string }> {
   if (shares <= 0n) throw new Error("shares must be positive");
-  return prepareVaultTx(config, withdrawer, "withdraw", [
+  const contract = new Contract(config.vaultId);
+  return prepareSorobanTx(config.network, withdrawer, contract.call("withdraw",
     i128(shares),
     xdr.ScVal.scvVec([i128(0n)]),
     Address.fromString(withdrawer).toScVal(),
-  ]);
+  ));
 }
 
 /**

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -103,6 +103,24 @@ export async function simulateView(
   return scValToNative(sim.result.retval);
 }
 
+export async function prepareSorobanTx(
+  network: StellarNetwork,
+  caller: string,
+  op: xdr.Operation
+): Promise<{ xdr: string; fee: string }> {
+  const passphrase = network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+  const server = new rpc.Server(network.rpcUrl);
+  const account = await server.getAccount(caller);
+  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
+    .addOperation(op)
+    .setTimeout(300)
+    .build();
+  const sim = await server.simulateTransaction(tx);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
+  const prepared = rpc.assembleTransaction(tx, sim).build();
+  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+}
+
 export async function buildAddTrustlineTx(
   walletAddress: string,
   network: StellarNetwork
@@ -140,28 +158,14 @@ export async function buildDepositTx(
   await assertTrustlines(walletAddress, network);
 
   const protocol = resolveProtocol(vaultId);
-  const passphrase = network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
-  const server = new rpc.Server(network.rpcUrl);
-  const account = await server.getAccount(walletAddress);
   const contract = new Contract(contractId);
-
-  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
-    .addOperation(
-      contract.call(
-        "deposit",
-        Address.fromString(walletAddress).toScVal(),
-        nativeToScVal(toStroops(amount), { type: "i128" }),
-        xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(protocol)]),
-      )
-    )
-    .setTimeout(300)
-    .build();
-
-  const sim = await server.simulateTransaction(tx);
-  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
-
-  const prepared = rpc.assembleTransaction(tx, sim).build();
-  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+  const op = contract.call(
+    "deposit",
+    Address.fromString(walletAddress).toScVal(),
+    nativeToScVal(toStroops(amount), { type: "i128" }),
+    xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(protocol)]),
+  );
+  return prepareSorobanTx(network, walletAddress, op);
 }
 
 export async function buildWithdrawTx(
@@ -170,27 +174,13 @@ export async function buildWithdrawTx(
   shares: string,
   network: StellarNetwork
 ): Promise<{ xdr: string; fee: string }> {
-  const passphrase = network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
-  const server = new rpc.Server(network.rpcUrl);
-  const account = await server.getAccount(walletAddress);
   const contract = new Contract(contractId);
-
-  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
-    .addOperation(
-      contract.call(
-        "withdraw",
-        Address.fromString(walletAddress).toScVal(),
-        nativeToScVal(toStroops(shares), { type: "i128" }),
-      )
-    )
-    .setTimeout(300)
-    .build();
-
-  const sim = await server.simulateTransaction(tx);
-  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
-
-  const prepared = rpc.assembleTransaction(tx, sim).build();
-  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+  const op = contract.call(
+    "withdraw",
+    Address.fromString(walletAddress).toScVal(),
+    nativeToScVal(toStroops(shares), { type: "i128" }),
+  );
+  return prepareSorobanTx(network, walletAddress, op);
 }
 
 // Default polling cadence for confirmation. Soroban testnet/mainnet close


### PR DESCRIPTION
## Summary

- Extracts the repeated get-account / build-tx / simulate / assemble / return-XDR sequence into a single `prepareSorobanTx(network, caller, op)` helper exported from `tx.ts`
- Replaces the duplicated pattern in `buildPoolRequestTx` (blend.ts) and `prepareVaultTx` (defindex.ts) with calls to the shared helper, removing `prepareVaultTx` entirely

## Test plan

- [x] Run `pnpm --filter @meridian/stellar-sdk-helpers run test` and confirm all 39 tests pass

Closes #120