### PR TITLE
refactor: extract Blend/DeFindex routing into shared orchestration functions

### DIFF
--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -4,11 +4,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // contract (method guards, field validation, status codes, payload shape), not
 // the Soroban transaction building, which is unit-tested in the helpers package.
 vi.mock("@meridian/stellar-sdk-helpers", () => ({
-  buildBlendDepositTx: vi.fn(async () => ({ xdr: "DEPOSIT_XDR", fee: "100" })),
-  buildBlendWithdrawTx: vi.fn(async () => ({ xdr: "WITHDRAW_XDR", fee: "100" })),
-  blendAssetForVault: vi.fn(() => "usdc"),
-  resolveProtocol: vi.fn(() => "Blend"),
-  toStroops: vi.fn(() => 100_000_000n),
+  buildDepositTx: vi.fn(async () => ({ xdr: "DEPOSIT_XDR", fee: "100" })),
+  buildWithdrawTx: vi.fn(async () => ({ xdr: "WITHDRAW_XDR", fee: "100" })),
   buildAddTrustlineTx: vi.fn(async () => ({ xdr: "TRUST_XDR" })),
   submitTx: vi.fn(async () => ({ hash: "HASH" })),
   fetchAllVaults: vi.fn(async () => [{ id: "blend-usdc-fixed", protocol: "blend" }]),
@@ -25,7 +22,7 @@ import trustlineHandler from "../v1/tx/add-trustline";
 import submitHandler from "../v1/tx/submit";
 import vaultsHandler from "../v1/vaults/index";
 import positionsHandler from "../v1/positions/[publicKey]";
-import { buildBlendDepositTx, fetchBlendPositions } from "@meridian/stellar-sdk-helpers";
+import { buildDepositTx, fetchBlendPositions } from "@meridian/stellar-sdk-helpers";
 
 // A 56-char Stellar public key shape (only the length is validated).
 const PUBKEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
@@ -82,11 +79,11 @@ describe("POST /api/v1/tx/deposit", () => {
     );
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({ xdr: "DEPOSIT_XDR", fee: "100" });
-    expect(buildBlendDepositTx).toHaveBeenCalledOnce();
+    expect(buildDepositTx).toHaveBeenCalledOnce();
   });
 
   it("surfaces builder errors as 500", async () => {
-    vi.mocked(buildBlendDepositTx).mockRejectedValueOnce(new Error("USDC trustline missing"));
+    vi.mocked(buildDepositTx).mockRejectedValueOnce(new Error("USDC trustline missing"));
     const res = makeRes();
     await depositHandler(
       { method: "POST", body: { walletAddress: PUBKEY, vaultId: "blend-usdc-fixed", amount: "10" } },

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -1,11 +1,5 @@
-import {
-  buildBlendDepositTx,
-  buildDefindexDepositTx,
-  blendAssetForVault,
-  resolveProtocol,
-  toStroops,
-} from "@meridian/stellar-sdk-helpers";
-import { CONTRACT_ADDRESSES, STELLAR_NETWORKS, defindexContractForVault } from "@meridian/shared";
+import { buildDepositTx } from "@meridian/stellar-sdk-helpers";
+import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
@@ -23,27 +17,12 @@ export default async function handler(req: any, res: any) {
   }
 
   try {
-    const protocol = resolveProtocol(vaultId);
-
-    if (protocol === "Blend") {
-      const asset = blendAssetForVault(vaultId);
-      const result = await buildBlendDepositTx(
-        { poolId: addresses.blend.pool, assetId: addresses[asset], network },
-        walletAddress,
-        toStroops(amount)
-      );
-      return res.json(result);
-    }
-
-    const contractId = defindexContractForVault(vaultId, addresses);
-    if (!contractId) {
-      return res.status(400).json({ error: `DeFindex vault '${vaultId}' is not configured` });
-    }
-    const result = await buildDefindexDepositTx(
-      { vaultId: contractId, network },
-      walletAddress,
-      toStroops(amount)
-    );
+    const result = await buildDepositTx(vaultId, walletAddress, amount, {
+      blendPool: addresses.blend.pool,
+      usdc: addresses.usdc,
+      eurc: addresses.eurc,
+      defindexVault: process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault,
+    }, network);
     return res.json(result);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to build deposit transaction";

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -1,11 +1,5 @@
-import {
-  buildBlendWithdrawTx,
-  buildDefindexWithdrawTx,
-  blendAssetForVault,
-  resolveProtocol,
-  toStroops,
-} from "@meridian/stellar-sdk-helpers";
-import { CONTRACT_ADDRESSES, STELLAR_NETWORKS, defindexContractForVault } from "@meridian/shared";
+import { buildWithdrawTx } from "@meridian/stellar-sdk-helpers";
+import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
@@ -24,28 +18,12 @@ export default async function handler(req: any, res: any) {
   }
 
   try {
-    const protocol = resolveProtocol(vaultId);
-
-    if (protocol === "Blend") {
-      const asset = blendAssetForVault(vaultId);
-      const result = await buildBlendWithdrawTx(
-        { poolId: addresses.blend.pool, assetId: addresses[asset], network },
-        walletAddress,
-        toStroops(amount)
-      );
-      return res.json(result);
-    }
-
-    const contractId = defindexContractForVault(vaultId, addresses);
-    if (!contractId) {
-      return res.status(400).json({ error: `DeFindex vault '${vaultId}' is not configured` });
-    }
-    // For a DeFindex vault, `amount` is the number of dfToken shares to burn.
-    const result = await buildDefindexWithdrawTx(
-      { vaultId: contractId, network },
-      walletAddress,
-      toStroops(amount)
-    );
+    const result = await buildWithdrawTx(vaultId, walletAddress, amount, {
+      blendPool: addresses.blend.pool,
+      usdc: addresses.usdc,
+      eurc: addresses.eurc,
+      defindexVault: process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault,
+    }, network);
     return res.json(result);
   } catch (err) {
     const msg = err instanceof Error ? err.message : "Failed to build withdraw transaction";

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -1,13 +1,8 @@
 import type { FastifyPluginAsync } from "fastify";
-import { DepositRequestSchema, WithdrawRequestSchema, CONTRACT_ADDRESSES, STELLAR_NETWORKS, defindexContractForVault } from "@meridian/shared";
+import { DepositRequestSchema, WithdrawRequestSchema, CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
 import {
-  buildBlendDepositTx,
-  buildBlendWithdrawTx,
-  buildDefindexDepositTx,
-  buildDefindexWithdrawTx,
-  blendAssetForVault,
-  resolveProtocol,
-  toStroops,
+  buildDepositTx,
+  buildWithdrawTx,
   buildAddTrustlineTx,
   submitTx,
 } from "@meridian/stellar-sdk-helpers";
@@ -26,24 +21,12 @@ export const txRoute: FastifyPluginAsync = async (app) => {
 
     try {
       const { walletAddress, vaultId, amount } = parsed.data;
-      if (resolveProtocol(vaultId) === "Blend") {
-        const asset = blendAssetForVault(vaultId);
-        const result = await buildBlendDepositTx(
-          { poolId: addresses.blend.pool, assetId: addresses[asset], network },
-          walletAddress,
-          toStroops(amount)
-        );
-        return reply.send(result);
-      }
-      const contractId = defindexContractForVault(vaultId, addresses);
-      if (!contractId) {
-        return reply.code(400).send({ error: `DeFindex vault '${vaultId}' is not configured` });
-      }
-      const result = await buildDefindexDepositTx(
-        { vaultId: contractId, network },
-        walletAddress,
-        toStroops(amount)
-      );
+      const result = await buildDepositTx(vaultId, walletAddress, amount, {
+        blendPool: addresses.blend.pool,
+        usdc: addresses.usdc,
+        eurc: addresses.eurc,
+        defindexVault: process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault,
+      }, network);
       reply.send(result);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to build deposit transaction";
@@ -61,25 +44,13 @@ export const txRoute: FastifyPluginAsync = async (app) => {
 
     try {
       const { walletAddress, vaultId, amount } = parsed.data;
-      if (resolveProtocol(vaultId) === "Blend") {
-        const asset = blendAssetForVault(vaultId);
-        const result = await buildBlendWithdrawTx(
-          { poolId: addresses.blend.pool, assetId: addresses[asset], network },
-          walletAddress,
-          toStroops(amount)
-        );
-        return reply.send(result);
-      }
-      const contractId = defindexContractForVault(vaultId, addresses);
-      if (!contractId) {
-        return reply.code(400).send({ error: `DeFindex vault '${vaultId}' is not configured` });
-      }
       // For a DeFindex vault, `amount` is the number of dfToken shares to burn.
-      const result = await buildDefindexWithdrawTx(
-        { vaultId: contractId, network },
-        walletAddress,
-        toStroops(amount)
-      );
+      const result = await buildWithdrawTx(vaultId, walletAddress, amount, {
+        blendPool: addresses.blend.pool,
+        usdc: addresses.usdc,
+        eurc: addresses.eurc,
+        defindexVault: process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vault,
+      }, network);
       reply.send(result);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Failed to build withdraw transaction";

--- a/packages/stellar-sdk-helpers/src/index.ts
+++ b/packages/stellar-sdk-helpers/src/index.ts
@@ -2,6 +2,7 @@ export * from "./blend";
 export * from "./defilamma";
 export * from "./defindex";
 export * from "./horizon";
+export * from "./orchestration";
 export * from "./positions";
 export * from "./routing";
 export * from "./tx";

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -1,0 +1,61 @@
+import { buildBlendDepositTx, buildBlendWithdrawTx, blendAssetForVault } from "./blend";
+import { buildDefindexDepositTx, buildDefindexWithdrawTx } from "./defindex";
+import { toStroops, resolveProtocol } from "./tx";
+import type { StellarNetwork } from "./types";
+
+export interface ProtocolAddresses {
+  blendPool: string;
+  usdc: string;
+  eurc: string;
+  defindexVault: string;
+}
+
+export async function buildDepositTx(
+  vaultId: string,
+  walletAddress: string,
+  amount: string,
+  addresses: ProtocolAddresses,
+  network: StellarNetwork
+): Promise<{ xdr: string; fee: string }> {
+  if (resolveProtocol(vaultId) === "Blend") {
+    const asset = blendAssetForVault(vaultId);
+    return buildBlendDepositTx(
+      { poolId: addresses.blendPool, assetId: addresses[asset], network },
+      walletAddress,
+      toStroops(amount)
+    );
+  }
+  if (!addresses.defindexVault) {
+    throw new Error("DeFindex vault not configured. Set DEFINDEX_VAULT_ID.");
+  }
+  return buildDefindexDepositTx(
+    { vaultId: addresses.defindexVault, network },
+    walletAddress,
+    toStroops(amount)
+  );
+}
+
+export async function buildWithdrawTx(
+  vaultId: string,
+  walletAddress: string,
+  amount: string,
+  addresses: ProtocolAddresses,
+  network: StellarNetwork
+): Promise<{ xdr: string; fee: string }> {
+  if (resolveProtocol(vaultId) === "Blend") {
+    const asset = blendAssetForVault(vaultId);
+    return buildBlendWithdrawTx(
+      { poolId: addresses.blendPool, assetId: addresses[asset], network },
+      walletAddress,
+      toStroops(amount)
+    );
+  }
+  if (!addresses.defindexVault) {
+    throw new Error("DeFindex vault not configured. Set DEFINDEX_VAULT_ID.");
+  }
+  return buildDefindexWithdrawTx(
+    { vaultId: addresses.defindexVault, network },
+    walletAddress,
+    toStroops(amount)
+  );
+}

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -2,11 +2,9 @@ import {
   Account,
   Contract,
   TransactionBuilder,
-  Address,
   Asset,
   Horizon,
   Operation,
-  nativeToScVal,
   scValToNative,
   rpc,
   xdr,
@@ -58,18 +56,6 @@ function hasAssetTrustline(
       (b as Horizon.HorizonApi.BalanceLine<"credit_alphanum4">).asset_code === code &&
       (b as Horizon.HorizonApi.BalanceLine<"credit_alphanum4">).asset_issuer === issuer
   );
-}
-
-async function assertTrustlines(walletAddress: string, network: StellarNetwork): Promise<void> {
-  const horizon = horizonServer(network);
-  const account = await horizon.loadAccount(walletAddress);
-
-  if (!hasAssetTrustline(account.balances, "USDC", USDC_ISSUER[network.network] ?? "")) {
-    throw new Error("USDC trustline missing. Add vault assets to your wallet before depositing.");
-  }
-  if (MUSDC_ISSUER[network.network] && !hasAssetTrustline(account.balances, "MUSDC", MUSDC_ISSUER[network.network])) {
-    throw new Error("mUSDC trustline missing. Add vault assets to your wallet before depositing.");
-  }
 }
 
 export function toStroops(value: string): bigint {
@@ -146,41 +132,6 @@ export async function buildAddTrustlineTx(
   const tx = builder.setTimeout(300).build();
 
   return { xdr: tx.toEnvelope().toXDR("base64") };
-}
-
-export async function buildDepositTx(
-  contractId: string,
-  walletAddress: string,
-  vaultId: string,
-  amount: string,
-  network: StellarNetwork
-): Promise<{ xdr: string; fee: string }> {
-  await assertTrustlines(walletAddress, network);
-
-  const protocol = resolveProtocol(vaultId);
-  const contract = new Contract(contractId);
-  const op = contract.call(
-    "deposit",
-    Address.fromString(walletAddress).toScVal(),
-    nativeToScVal(toStroops(amount), { type: "i128" }),
-    xdr.ScVal.scvVec([xdr.ScVal.scvSymbol(protocol)]),
-  );
-  return prepareSorobanTx(network, walletAddress, op);
-}
-
-export async function buildWithdrawTx(
-  contractId: string,
-  walletAddress: string,
-  shares: string,
-  network: StellarNetwork
-): Promise<{ xdr: string; fee: string }> {
-  const contract = new Contract(contractId);
-  const op = contract.call(
-    "withdraw",
-    Address.fromString(walletAddress).toScVal(),
-    nativeToScVal(toStroops(shares), { type: "i128" }),
-  );
-  return prepareSorobanTx(network, walletAddress, op);
 }
 
 // Default polling cadence for confirmation. Soroban testnet/mainnet close


### PR DESCRIPTION
## Summary
- Adds `buildDepositTx` and `buildWithdrawTx` orchestration functions to `@meridian/stellar-sdk-helpers` (via a new `orchestration.ts` module) that own the Blend vs. DeFindex protocol branching
- Removes the four copies of the same routing logic from the Vercel handlers and the Fastify routes
- Removes the dead legacy `buildDepositTx`/`buildWithdrawTx` from `tx.ts` that were never imported anywhere
- Updates the handler test mock to stub the new orchestration functions

## Test plan
- [x] Run `pnpm --filter @meridian/stellar-sdk-helpers run test` and confirm all 45 tests pass
- [x] Run `pnpm --filter @meridian/api-functions run test` and confirm all 14 tests pass

Closes #122