### PR TITLE
fix: remove Ondo protocol -- no contract integration exists

### DIFF
--- a/apps/web/src/components/dashboard/VaultPanel.tsx
+++ b/apps/web/src/components/dashboard/VaultPanel.tsx
@@ -8,7 +8,6 @@ import { useWalletConnect } from "../../hooks/useWalletConnect";
 const PROTOCOL_LABEL: Record<string, string> = {
   blend: "Blend Capital",
   defindex: "DeFindex",
-  ondo: "Ondo",
 };
 
 function formatUsd(value: number): string {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -19,7 +19,7 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 // JSON-safe vault shape (bigints serialised as numbers by the API)
 export interface ApiVault {
   id: string;
-  protocol: "blend" | "defindex" | "ondo";
+  protocol: "blend" | "defindex";
   asset: string;
   name: string;
   label: string;

--- a/packages/stellar-sdk-helpers/src/known-pools.ts
+++ b/packages/stellar-sdk-helpers/src/known-pools.ts
@@ -1,14 +1,13 @@
 export interface KnownPoolMeta {
   id: string;
   name: string;
-  protocol: "blend" | "defindex" | "ondo";
+  protocol: "blend" | "defindex";
   label: string;
 }
 
 export const KNOWN_POOLS: Record<string, KnownPoolMeta> = {
-  "ecf788e3-d2ef-4fdd-9ece-8a2d96226ddf": { id: "blend-usdc-fixed",    name: "Blend Capital", protocol: "blend", label: "Fixed Rate"     },
-  "3a61420f-6f6e-45f9-accc-8d23f5a32d33": { id: "blend-eurc-fixed",    name: "Blend Capital", protocol: "blend", label: "Fixed Rate"     },
-  "48c597dc-9367-4b4a-aa10-49b9755c4c2e": { id: "blend-usdc-variable", name: "Blend Capital", protocol: "blend", label: "Variable Rate"  },
-  "9a2f1f81-0a6e-441d-8219-c13b3520bd57": { id: "blend-eurc-variable", name: "Blend Capital", protocol: "blend", label: "Variable Rate"  },
-  "a66e2d12-188b-407d-aaec-d95640e08ef7": { id: "ondo-usdy",           name: "Ondo Finance",  protocol: "ondo",  label: "Treasury Yield" },
+  "ecf788e3-d2ef-4fdd-9ece-8a2d96226ddf": { id: "blend-usdc-fixed",    name: "Blend Capital", protocol: "blend", label: "Fixed Rate"    },
+  "3a61420f-6f6e-45f9-accc-8d23f5a32d33": { id: "blend-eurc-fixed",    name: "Blend Capital", protocol: "blend", label: "Fixed Rate"    },
+  "48c597dc-9367-4b4a-aa10-49b9755c4c2e": { id: "blend-usdc-variable", name: "Blend Capital", protocol: "blend", label: "Variable Rate" },
+  "9a2f1f81-0a6e-441d-8219-c13b3520bd57": { id: "blend-eurc-variable", name: "Blend Capital", protocol: "blend", label: "Variable Rate" },
 } satisfies Record<string, KnownPoolMeta>;

--- a/packages/stellar-sdk-helpers/src/routing.ts
+++ b/packages/stellar-sdk-helpers/src/routing.ts
@@ -6,8 +6,7 @@ export interface RouteOptions {
 }
 
 // A vault is routable only if Meridian can build a deposit for its protocol.
-// Blend is always supported; DeFindex once a vault is configured; everything
-// else (e.g. Ondo, or an unknown protocol) is display-only.
+// Blend is always supported; DeFindex once a vault contract is configured.
 function isRoutable(vault: ApiVault, opts: RouteOptions): boolean {
   if (vault.protocol === "blend") return true;
   if (vault.protocol === "defindex") return opts.defindexConfigured;

--- a/packages/stellar-sdk-helpers/src/types.ts
+++ b/packages/stellar-sdk-helpers/src/types.ts
@@ -1,12 +1,3 @@
-export interface VaultInfo {
-  id: string;
-  protocol: "blend" | "defindex";
-  asset: string;
-  apy: number;
-  tvl: number;
-  userBalance: number;
-}
-
 export interface YieldPosition {
   vaultId: string;
   deposited: number;

--- a/packages/stellar-sdk-helpers/src/vaults.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.ts
@@ -3,7 +3,7 @@ import { KNOWN_POOLS } from "./known-pools";
 
 export interface ApiVault {
   id: string;
-  protocol: "blend" | "defindex" | "ondo";
+  protocol: "blend" | "defindex";
   asset: string;
   name: string;
   label: string;


### PR DESCRIPTION
## Summary
- Removes the Ondo USDY pool from `KNOWN_POOLS` in `known-pools.ts`
- Narrows `KnownPoolMeta.protocol`, `ApiVault.protocol`, and the frontend `ApiVault` type from `blend | defindex | ondo` to `blend | defindex`
- Removes `ondo` from `PROTOCOL_LABEL` in `VaultPanel.tsx`
- Removes the unused `VaultInfo` interface from `types.ts`
- Cleans up the now-stale comment in `routing.ts` that mentioned Ondo as display-only

Ondo was wired through the data layer but `isRoutable()` returned false for it and `buildDepositTx` would throw if it were ever selected. Users would see a vault they could never deposit into.

## Test plan
- [x] All 45 SDK tests pass
- [x] Web typecheck passes

Closes #137