### PR TITLE
fix: add CORS headers and rate limiting to Vercel handlers

### DIFF
--- a/api/_lib/middleware.ts
+++ b/api/_lib/middleware.ts
@@ -1,0 +1,58 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Req = any;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Res = any;
+
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? "https://usemeridian.vercel.app";
+
+/**
+ * Set CORS headers and handle preflight. Returns true when the request was a
+ * preflight OPTIONS and has been fully handled — the caller should return
+ * immediately in that case.
+ */
+export function applyCors(req: Req, res: Res): boolean {
+  res.setHeader?.("Access-Control-Allow-Origin", ALLOWED_ORIGIN);
+  res.setHeader?.("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+  res.setHeader?.("Access-Control-Allow-Headers", "Content-Type");
+  if (req.method === "OPTIONS") {
+    res.status(204).end();
+    return true;
+  }
+  return false;
+}
+
+// In-memory rate limit: per-IP, 20 req / 60 s. Resets on cold start and is
+// not shared across invocation instances. For a distributed limit use Upstash
+// Redis or Vercel KV and swap this implementation.
+const counts = new Map<string, { n: number; resetAt: number }>();
+const LIMIT = 20;
+const WINDOW_MS = 60_000;
+
+function clientIp(req: Req): string {
+  const fwd = req.headers?.["x-forwarded-for"];
+  return (typeof fwd === "string" ? fwd.split(",")[0].trim() : null) ??
+    req.socket?.remoteAddress ??
+    "unknown";
+}
+
+/**
+ * Check the per-IP rate limit. Returns true when the request is allowed.
+ * Writes a 429 response and returns false when the limit is exceeded — the
+ * caller should return immediately.
+ */
+export function checkRateLimit(req: Req, res: Res): boolean {
+  const ip = clientIp(req);
+  const now = Date.now();
+  const entry = counts.get(ip);
+
+  if (!entry || now > entry.resetAt) {
+    counts.set(ip, { n: 1, resetAt: now + WINDOW_MS });
+    return true;
+  }
+  if (entry.n >= LIMIT) {
+    res.status(429).json({ error: "Too many requests. Try again in a minute." });
+    return false;
+  }
+  entry.n++;
+  return true;
+}

--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,5 +1,6 @@
 import { fetchBlendPositions, fetchDefindexPosition } from "@meridian/stellar-sdk-helpers";
 import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
+import { applyCors } from "../../_lib/middleware";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
@@ -7,6 +8,7 @@ const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? addresses.defindex.vaul
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
+  if (applyCors(req, res)) return;
   const { publicKey } = req.query as { publicKey: string };
 
   if (!publicKey || publicKey.length !== 56) {

--- a/api/v1/tx/add-trustline.ts
+++ b/api/v1/tx/add-trustline.ts
@@ -1,10 +1,13 @@
 import { buildAddTrustlineTx } from "@meridian/stellar-sdk-helpers";
 import { STELLAR_NETWORKS } from "@meridian/shared";
+import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 const network = STELLAR_NETWORKS.testnet;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
+  if (applyCors(req, res)) return;
+  if (!checkRateLimit(req, res)) return;
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
   const { walletAddress } = req.body ?? {};

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -1,11 +1,14 @@
 import { buildDepositTx } from "@meridian/stellar-sdk-helpers";
 import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
+import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
+  if (applyCors(req, res)) return;
+  if (!checkRateLimit(req, res)) return;
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
   const { walletAddress, vaultId, amount } = req.body ?? {};

--- a/api/v1/tx/submit.ts
+++ b/api/v1/tx/submit.ts
@@ -1,10 +1,13 @@
 import { submitTx } from "@meridian/stellar-sdk-helpers";
 import { STELLAR_NETWORKS } from "@meridian/shared";
+import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 const network = STELLAR_NETWORKS.testnet;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
+  if (applyCors(req, res)) return;
+  if (!checkRateLimit(req, res)) return;
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
   const { xdr } = req.body ?? {};

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -1,11 +1,14 @@
 import { buildWithdrawTx } from "@meridian/stellar-sdk-helpers";
 import { CONTRACT_ADDRESSES, STELLAR_NETWORKS } from "@meridian/shared";
+import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 const network = STELLAR_NETWORKS.testnet;
 const addresses = CONTRACT_ADDRESSES.testnet;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
+  if (applyCors(req, res)) return;
+  if (!checkRateLimit(req, res)) return;
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
   // `amount` is the underlying asset amount (USDC/EURC) to withdraw from the pool.

--- a/api/v1/vaults/[vaultId].ts
+++ b/api/v1/vaults/[vaultId].ts
@@ -1,7 +1,9 @@
 import { fetchAllVaults } from "@meridian/stellar-sdk-helpers";
+import { applyCors } from "../../_lib/middleware";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default async function handler(req: any, res: any) {
+  if (applyCors(req, res)) return;
   const { vaultId } = req.query as { vaultId: string };
 
   try {

--- a/api/v1/vaults/index.ts
+++ b/api/v1/vaults/index.ts
@@ -1,5 +1,6 @@
 import { fetchAllVaults, selectBestVault } from "@meridian/stellar-sdk-helpers";
 import { CONTRACT_ADDRESSES } from "@meridian/shared";
+import { applyCors } from "../../_lib/middleware";
 
 // Cache the aggregated vault list at the Vercel CDN. APY/TVL move slowly, so a
 // short fresh window keeps DeFiLlama call volume low, and the stale-while-
@@ -12,7 +13,8 @@ const defindexConfigured = Boolean(
 );
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default async function handler(_req: any, res: any) {
+export default async function handler(req: any, res: any) {
+  if (applyCors(req, res)) return;
   try {
     const vaults = await fetchAllVaults();
     const best = selectBestVault(vaults, { defindexConfigured });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -14,7 +14,7 @@ import { txRoute } from "./routes/tx";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: process.env.ALLOWED_ORIGIN ?? "*" });
+await app.register(cors, { origin: process.env.ALLOWED_ORIGIN ?? "https://usemeridian.vercel.app" });
 await app.register(rateLimit, { max: 100, timeWindow: "1 minute" });
 
 app.register(vaultsRoute, { prefix: "/api/v1/vaults" });


### PR DESCRIPTION
## Summary
- Adds `api/_lib/middleware.ts` with two shared utilities: `applyCors` (sets `Access-Control-Allow-Origin` from `ALLOWED_ORIGIN` env var, handles OPTIONS preflight) and `checkRateLimit` (20 req/60 s per IP, in-memory)
- All 4 mutation handlers (`tx/deposit`, `tx/withdraw`, `tx/add-trustline`, `tx/submit`) now apply both CORS and rate limiting
- All 3 read handlers (`vaults/index`, `vaults/[vaultId]`, `positions/[publicKey]`) now apply CORS
- Tightens the Fastify CORS default from `*` to `https://usemeridian.vercel.app` — still overridable via `ALLOWED_ORIGIN`

The rate limiter is in-memory per invocation instance. It is not shared across Vercel cold starts or parallel instances. The comment in `middleware.ts` documents the upgrade path to Upstash/Vercel KV for a distributed limit.

## Test plan
- [x] All 14 handler tests pass
- [x] 45 SDK tests unaffected

Closes #136