### PR TITLE
fix: rename withdraw amount to shares to reflect protocol semantics

### DIFF
--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -95,17 +95,17 @@ describe("POST /api/v1/tx/deposit", () => {
 });
 
 describe("POST /api/v1/tx/withdraw", () => {
-  it("returns 400 when the amount is missing", async () => {
+  it("returns 400 when shares is missing", async () => {
     const res = makeRes();
     await withdrawHandler({ method: "POST", body: { walletAddress: PUBKEY, vaultId: "v" } }, res);
     expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: "Missing required fields: amount" });
+    expect(res.body).toEqual({ error: "Missing required fields: shares" });
   });
 
   it("builds the withdraw transaction", async () => {
     const res = makeRes();
     await withdrawHandler(
-      { method: "POST", body: { walletAddress: PUBKEY, vaultId: "blend-usdc-fixed", amount: "5" } },
+      { method: "POST", body: { walletAddress: PUBKEY, vaultId: "blend-usdc-fixed", shares: "5" } },
       res
     );
     expect(res.body).toEqual({ xdr: "WITHDRAW_XDR", fee: "100" });

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -11,17 +11,16 @@ export default async function handler(req: any, res: any) {
   if (!checkRateLimit(req, res)) return;
   if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
 
-  // `amount` is the underlying asset amount (USDC/EURC) to withdraw from the pool.
-  const { walletAddress, vaultId, amount } = req.body ?? {};
-  if (!walletAddress || !vaultId || !amount) {
-    const missing = (["walletAddress", "vaultId", "amount"] as const)
+  const { walletAddress, vaultId, shares } = req.body ?? {};
+  if (!walletAddress || !vaultId || !shares) {
+    const missing = (["walletAddress", "vaultId", "shares"] as const)
       .filter((k) => !req.body?.[k])
       .join(", ");
     return res.status(400).json({ error: `Missing required fields: ${missing}` });
   }
 
   try {
-    const result = await buildWithdrawTx(vaultId, walletAddress, amount, {
+    const result = await buildWithdrawTx(vaultId, walletAddress, shares, {
       blendPool: addresses.blend.pool,
       usdc: addresses.usdc,
       eurc: addresses.eurc,

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -43,9 +43,8 @@ export const txRoute: FastifyPluginAsync = async (app) => {
     }
 
     try {
-      const { walletAddress, vaultId, amount } = parsed.data;
-      // For a DeFindex vault, `amount` is the number of dfToken shares to burn.
-      const result = await buildWithdrawTx(vaultId, walletAddress, amount, {
+      const { walletAddress, vaultId, shares } = parsed.data;
+      const result = await buildWithdrawTx(vaultId, walletAddress, shares, {
         blendPool: addresses.blend.pool,
         usdc: addresses.usdc,
         eurc: addresses.eurc,

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -69,7 +69,7 @@ export function useVaultActions() {
     if (!publicKey || !passphrase) return false;
     setIsWithdrawing(true);
     try {
-      const { xdr } = await api.buildWithdraw({ walletAddress: publicKey, vaultId, amount });
+      const { xdr } = await api.buildWithdraw({ walletAddress: publicKey, vaultId, shares: amount });
       await signAndSubmit(xdr);
       queryClient.invalidateQueries({ queryKey: ["positions", publicKey] });
       push("success", `Withdrew ${amount} USDC`);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -59,7 +59,7 @@ export const api = {
       method: "POST",
       body: JSON.stringify(body),
     }),
-  buildWithdraw: (body: { walletAddress: string; vaultId: string; amount: string }) =>
+  buildWithdraw: (body: { walletAddress: string; vaultId: string; shares: string }) =>
     apiFetch<{ xdr: string }>("/api/v1/tx/withdraw", {
       method: "POST",
       body: JSON.stringify(body),

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -9,8 +9,9 @@ export const DepositRequestSchema = z.object({
 export const WithdrawRequestSchema = z.object({
   walletAddress: z.string().length(56),
   vaultId: z.string(),
-  // Underlying asset amount (USDC/EURC) to withdraw from the pool.
-  amount: z.string().regex(/^\d+(\.\d{1,7})?$/),
+  // Protocol share count to burn: bToken collateral for Blend, dfToken count
+  // for DeFindex. Both come from `position.shares` in the frontend.
+  shares: z.string().regex(/^\d+(\.\d{1,7})?$/),
 });
 
 export type DepositRequest = z.infer<typeof DepositRequestSchema>;

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -38,7 +38,7 @@ export async function buildDepositTx(
 export async function buildWithdrawTx(
   vaultId: string,
   walletAddress: string,
-  amount: string,
+  shares: string,
   addresses: ProtocolAddresses,
   network: StellarNetwork
 ): Promise<{ xdr: string; fee: string }> {
@@ -47,7 +47,7 @@ export async function buildWithdrawTx(
     return buildBlendWithdrawTx(
       { poolId: addresses.blendPool, assetId: addresses[asset], network },
       walletAddress,
-      toStroops(amount)
+      toStroops(shares)
     );
   }
   if (!addresses.defindexVault) {
@@ -56,6 +56,6 @@ export async function buildWithdrawTx(
   return buildDefindexWithdrawTx(
     { vaultId: addresses.defindexVault, network },
     walletAddress,
-    toStroops(amount)
+    toStroops(shares)
   );
 }


### PR DESCRIPTION
## Summary
- Renames the `amount` field in `WithdrawRequestSchema` to `shares` with an accurate description: bToken collateral for Blend, dfToken count for DeFindex
- Updates `buildWithdrawTx` parameter name in `orchestration.ts` to match
- Updates both API layers (Fastify route, Vercel handler) to destructure `shares`
- Updates `api.buildWithdraw` call signature and `useVaultActions` in the frontend to send `shares`
- Updates the handler test to use `shares` in the withdraw request body

The schema comment previously said "underlying asset amount (USDC/EURC)" which was wrong for DeFindex. The field has always been shares in both protocols, and the frontend already sent `position.shares`, so no user-facing behaviour changes.

## Test plan
- [x] All 14 handler tests pass
- [x] Web typecheck passes

Closes #138
