### PR TITLE
fix: type buildDeposit body instead of unknown

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -54,7 +54,7 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ walletAddress }),
     }),
-  buildDeposit: (body: unknown) =>
+  buildDeposit: (body: { walletAddress: string; vaultId: string; amount: string }) =>
     apiFetch<{ xdr: string }>("/api/v1/tx/deposit", {
       method: "POST",
       body: JSON.stringify(body),


### PR DESCRIPTION
## Summary
- Types `buildDeposit` body in `apps/web/src/lib/api.ts` from `unknown` to `{ walletAddress: string; vaultId: string; amount: string }`, matching the `DepositRequest` type already exported from `@meridian/shared`
- `buildWithdraw` on the same file was already fully typed; this brings `buildDeposit` to parity

## Test plan
- [x] Web typecheck passes

Closes #144