### PR TITLE
perf: add 60s in-memory cache to fetchAllVaults to reduce DeFiLlama calls

### DIFF
--- a/packages/stellar-sdk-helpers/src/vaults.test.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { fetchAllVaults } from "./vaults";
+import { fetchAllVaults, clearVaultCache } from "./vaults";
 
 // Maps to blend-usdc-fixed in known-pools.ts.
 const KNOWN_BLEND = "ecf788e3-d2ef-4fdd-9ece-8a2d96226ddf";
@@ -29,7 +29,10 @@ function stubPools(data: unknown[]) {
 }
 
 describe("fetchAllVaults", () => {
-  afterEach(() => vi.unstubAllGlobals());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearVaultCache();
+  });
 
   it("maps known DeFiLlama pools and rounds APY to two decimals", async () => {
     stubPools([llamaPool()]);
@@ -50,5 +53,17 @@ describe("fetchAllVaults", () => {
     stubPools([]);
     const vaults = await fetchAllVaults();
     expect(vaults.find((v) => v.protocol === "defindex")).toBeUndefined();
+  });
+
+  it("returns cached result and skips DeFiLlama on repeated calls within TTL", async () => {
+    const mockFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ data: [llamaPool()] }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchAllVaults();
+    await fetchAllVaults();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
   });
 });

--- a/packages/stellar-sdk-helpers/src/vaults.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.ts
@@ -13,10 +13,24 @@ export interface ApiVault {
   riskLevel: RiskLevel;
 }
 
+// TTL matches the CDN s-maxage on the vaults endpoint (60 s). Both the Fastify
+// server (long-lived process) and warm Vercel invocations benefit from this
+// without adding any external dependency.
+const CACHE_TTL_MS = 60_000;
+let vaultCache: { vaults: ApiVault[]; expiresAt: number } | null = null;
+
+/** Clears the in-memory vault cache. Exposed for tests only. */
+export function clearVaultCache(): void {
+  vaultCache = null;
+}
+
 // Every vault in the list is backed by live DeFiLlama market data. Protocols
 // without a real on-chain rate feed wired up yet are intentionally omitted
 // rather than shown with placeholder figures.
 export async function fetchAllVaults(): Promise<ApiVault[]> {
+  const now = Date.now();
+  if (vaultCache && now < vaultCache.expiresAt) return vaultCache.vaults;
+
   const pools = await getStellarStablecoinPools();
 
   const vaults: ApiVault[] = [];
@@ -36,5 +50,6 @@ export async function fetchAllVaults(): Promise<ApiVault[]> {
     });
   }
 
+  vaultCache = { vaults, expiresAt: now + CACHE_TTL_MS };
   return vaults;
 }


### PR DESCRIPTION
## Summary
- Adds a module-level 60-second TTL cache to `fetchAllVaults()` in `@meridian/stellar-sdk-helpers`
- The TTL is intentionally aligned with the CDN `s-maxage=60` header on the vaults endpoint — the in-memory cache protects DeFiLlama from concurrent requests within a warm Vercel invocation, and the Fastify long-lived process gets the full benefit for its entire lifetime
- Exports `clearVaultCache()` for test isolation — called in `afterEach` alongside `vi.unstubAllGlobals()`
- Adds a new test asserting that repeated calls within the TTL hit DeFiLlama only once

## Test plan
- [x] All 46 SDK tests pass (1 new test added)

Closes #148