### PR TITLE
fix: extract first line of simulation error for readable messages

### DIFF
--- a/packages/stellar-sdk-helpers/src/tx.test.ts
+++ b/packages/stellar-sdk-helpers/src/tx.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { rpc } from "@stellar/stellar-sdk";
-import { toStroops, resolveProtocol, waitForTransaction } from "./tx";
+import { toStroops, resolveProtocol, waitForTransaction, simErrorMessage } from "./tx";
 
 const { SUCCESS, FAILED, NOT_FOUND } = rpc.Api.GetTransactionStatus;
 
@@ -26,6 +26,22 @@ function steppingClock(stepMs: number) {
   let t = 0;
   return () => (t += stepMs);
 }
+
+describe("simErrorMessage", () => {
+  it("returns just the first line of a multi-line diagnostic", () => {
+    const raw = "HostError: Error(Contract, #1)\n  at [0]: ...\n  at [1]: ...";
+    expect(simErrorMessage(raw)).toBe("HostError: Error(Contract, #1)");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(simErrorMessage("  Error(WasmVm, InvalidAction)  ")).toBe("Error(WasmVm, InvalidAction)");
+  });
+
+  it("returns a fallback for empty or whitespace-only errors", () => {
+    expect(simErrorMessage("")).toBe("Simulation failed (no detail)");
+    expect(simErrorMessage("\n\n")).toBe("Simulation failed (no detail)");
+  });
+});
 
 describe("toStroops", () => {
   it("converts whole USDC amounts to 7-decimal stroops", () => {

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -84,7 +84,7 @@ export async function simulateView(
     .setTimeout(0)
     .build();
   const sim = await server.simulateTransaction(tx);
-  if (rpc.Api.isSimulationError(sim)) throw new Error(sim.error);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(simErrorMessage(sim.error));
   if (!rpc.Api.isSimulationSuccess(sim) || !sim.result) return null;
   return scValToNative(sim.result.retval);
 }
@@ -102,7 +102,7 @@ export async function prepareSorobanTx(
     .setTimeout(300)
     .build();
   const sim = await server.simulateTransaction(tx);
-  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${sim.error}`);
+  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${simErrorMessage(sim.error)}`);
   const prepared = rpc.assembleTransaction(tx, sim).build();
   return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
 }
@@ -192,6 +192,13 @@ export async function waitForTransaction(
     }
     await sleep(pollIntervalMs);
   }
+}
+
+// Soroban simulation errors can be multi-line diagnostics. The first line is
+// the actionable summary (e.g. "HostError: Error(Contract, #1)"); subsequent
+// lines are stack frames that belong in server logs, not user-facing messages.
+export function simErrorMessage(raw: string): string {
+  return raw.split("\n")[0].trim() || "Simulation failed (no detail)";
 }
 
 // Best-effort decode of the result code the RPC returns on a rejected submit


### PR DESCRIPTION
## Summary
- Adds `simErrorMessage(raw: string)` helper to `tx.ts` that takes just the first line of a Soroban simulation diagnostic string — the actionable summary (e.g. `HostError: Error(Contract, #1)`) — discarding stack frame lines that belong in server logs, not in user-facing error messages
- Applies it to both simulation error sites: `simulateView` (line 87) and `prepareSorobanTx` (line 105)
- Exports `simErrorMessage` and adds 3 unit tests covering multi-line trimming, whitespace trimming, and the empty-string fallback

## Test plan
- [x] All 49 SDK tests pass (3 new tests added)

Closes #149