### PR TITLE
refactor: extract isValidStellarAddress to eliminate regex duplication

### DIFF
--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { fetchBlendPositions, fetchDefindexPosition } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, APP_ADDRESSES } from "@meridian/shared";
+import { APP_NETWORK, APP_ADDRESSES, isValidStellarAddress } from "@meridian/shared";
 import { applyCors } from "../../_lib/middleware";
 
 const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault;
@@ -9,7 +9,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   const { publicKey } = req.query as { publicKey: string };
 
-  if (!publicKey || !/^G[A-Z2-7]{55}$/.test(publicKey)) {
+  if (!publicKey || !isValidStellarAddress(publicKey)) {
     return res.status(400).json({ error: "Invalid public key" });
   }
 

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -1,5 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import { APP_NETWORK, APP_ADDRESSES } from "@meridian/shared";
+import { APP_NETWORK, APP_ADDRESSES, isValidStellarAddress } from "@meridian/shared";
 import { fetchBlendPositions, fetchDefindexPosition } from "@meridian/stellar-sdk-helpers";
 
 const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault;
@@ -8,7 +8,7 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
   app.get("/:publicKey", async (req, reply) => {
     const { publicKey } = req.params as { publicKey: string };
 
-    if (!publicKey || !/^G[A-Z2-7]{55}$/.test(publicKey)) {
+    if (!publicKey || !isValidStellarAddress(publicKey)) {
       return reply.code(400).send({ error: "Invalid public key" });
     }
 

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -1,11 +1,9 @@
 import { z } from "zod";
+import { isValidStellarAddress } from "./utils";
 
-// Stellar G-address: starts with 'G', followed by 55 chars from the base32
-// alphabet (A-Z and 2-7), totalling 56 characters. This catches all malformed
-// addresses without requiring the full CRC16 checksum from the Stellar SDK.
 const stellarAddress = z
   .string()
-  .regex(/^G[A-Z2-7]{55}$/, "Invalid Stellar public key");
+  .refine(isValidStellarAddress, { message: "Invalid Stellar public key" });
 
 export const DepositRequestSchema = z.object({
   walletAddress: stellarAddress,

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -2,6 +2,11 @@ export function shortenAddress(address: string, chars = 4): string {
   return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }
 
+/** Returns true when \`key\` is a well-formed Stellar G-address (base32, 56 chars). */
+export function isValidStellarAddress(key: string): boolean {
+  return /^G[A-Z2-7]{55}$/.test(key);
+}
+
 import { CONTRACT_ADDRESSES } from "./constants";
 
 type TestnetAddresses = (typeof CONTRACT_ADDRESSES)["testnet"];


### PR DESCRIPTION
## Summary
- Adds `isValidStellarAddress(key: string): boolean` to `packages/shared/src/utils.ts` — single source of truth for the G-address regex (`/^G[A-Z2-7]{55}$/`)
- Updates `packages/shared/src/schemas.ts` to use `.refine(isValidStellarAddress)` instead of an inline `.regex(...)`, removing the comment that duplicated the rationale
- Replaces the inline `!/^G[A-Z2-7]{55}$/.test(publicKey)` guards in both `api/v1/positions/[publicKey].ts` and `apps/api/src/routes/positions.ts` with `!isValidStellarAddress(publicKey)`

## Test plan
- [x] All 14 handler tests pass
- [x] All shared package tests pass

Closes #157