### PR TITLE
fix: prefer x-vercel-forwarded-for over x-forwarded-for for rate limit IP

### DIFF
--- a/api/_lib/middleware.ts
+++ b/api/_lib/middleware.ts
@@ -26,6 +26,12 @@ const LIMIT = 20;
 const WINDOW_MS = 60_000;
 
 function clientIp(req: VercelRequest): string {
+  // x-vercel-forwarded-for is set by the Vercel edge and cannot be spoofed
+  // by the client, unlike x-forwarded-for which is client-controlled.
+  const vercelIp = req.headers["x-vercel-forwarded-for"];
+  if (typeof vercelIp === "string" && vercelIp) return vercelIp.split(",")[0].trim();
+
+  // Fallback for local dev (Fastify / pnpm dev) where Vercel headers are absent.
   const fwd = req.headers["x-forwarded-for"];
   return (typeof fwd === "string" ? fwd.split(",")[0].trim() : null) ??
     req.socket?.remoteAddress ??


### PR DESCRIPTION
## Summary
- `clientIp()` in `api/_lib/middleware.ts` now reads `x-vercel-forwarded-for` first — this header is injected by the Vercel edge and cannot be set by clients, unlike `x-forwarded-for` which is client-controlled and spoofable
- Falls back to `x-forwarded-for` (first entry) only when the Vercel header is absent, which covers local dev behind a reverse proxy or `pnpm dev`
- Falls back further to `req.socket.remoteAddress` for direct connections (bare Node.js)

## Test plan
- [x] All 14 handler tests pass

Closes #159