### PR TITLE
test: add unit tests for CORS and rate-limit middleware

### DIFF
--- a/api/__tests__/middleware.test.ts
+++ b/api/__tests__/middleware.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { applyCors, checkRateLimit, resetRateLimitForTesting } from "../_lib/middleware";
+
+// Minimal fake request / response ------------------------------------------------
+
+function fakeReq(
+  method: string,
+  headers: Record<string, string> = {}
+): VercelRequest {
+  return { method, headers } as unknown as VercelRequest;
+}
+
+interface FakeRes {
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string>;
+  ended: boolean;
+}
+
+function fakeRes(): FakeRes & VercelResponse {
+  const r: FakeRes = { statusCode: 200, body: undefined, headers: {}, ended: false };
+  return Object.assign(r, {
+    status(code: number) { r.statusCode = code; return this; },
+    json(payload: unknown) { r.body = payload; return this; },
+    end() { r.ended = true; return this; },
+    setHeader(k: string, v: string) { r.headers[k] = v; },
+  }) as unknown as FakeRes & VercelResponse;
+}
+
+// ---------------------------------------------------------------------------------
+
+beforeEach(() => resetRateLimitForTesting());
+afterEach(() => vi.useRealTimers());
+
+// applyCors -----------------------------------------------------------------------
+
+describe("applyCors", () => {
+  it("sets CORS headers on every request", () => {
+    const res = fakeRes();
+    applyCors(fakeReq("GET"), res);
+    expect(res.headers["Access-Control-Allow-Origin"]).toBeDefined();
+    expect(res.headers["Access-Control-Allow-Methods"]).toContain("POST");
+  });
+
+  it("returns true and ends the response for OPTIONS preflight", () => {
+    const res = fakeRes();
+    const handled = applyCors(fakeReq("OPTIONS"), res);
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(204);
+    expect(res.ended).toBe(true);
+  });
+
+  it("returns false and does not end the response for POST requests", () => {
+    const res = fakeRes();
+    const handled = applyCors(fakeReq("POST"), res);
+    expect(handled).toBe(false);
+    expect(res.ended).toBe(false);
+  });
+});
+
+// checkRateLimit ------------------------------------------------------------------
+
+describe("checkRateLimit", () => {
+  it("allows the first 20 requests from the same IP", () => {
+    const ip = "1.2.3.4";
+    for (let i = 0; i < 20; i++) {
+      const res = fakeRes();
+      expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)).toBe(true);
+      expect(res.statusCode).toBe(200);
+    }
+  });
+
+  it("blocks the 21st request with 429", () => {
+    const ip = "1.2.3.5";
+    for (let i = 0; i < 20; i++) {
+      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), fakeRes());
+    }
+    const res = fakeRes();
+    expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)).toBe(false);
+    expect(res.statusCode).toBe(429);
+  });
+
+  it("resets the counter after the 60 s window expires", () => {
+    vi.useFakeTimers();
+    const ip = "1.2.3.6";
+    for (let i = 0; i < 20; i++) {
+      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), fakeRes());
+    }
+    // Advance past the 60 s window.
+    vi.advanceTimersByTime(61_000);
+    const res = fakeRes();
+    expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)).toBe(true);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("tracks two different IPs independently", () => {
+    const ipA = "10.0.0.1";
+    const ipB = "10.0.0.2";
+    for (let i = 0; i < 20; i++) {
+      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipA }), fakeRes());
+    }
+    // ipA is blocked but ipB should still be allowed.
+    const resA = fakeRes();
+    expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipA }), resA)).toBe(false);
+    const resB = fakeRes();
+    expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipB }), resB)).toBe(true);
+  });
+});

--- a/api/_lib/middleware.ts
+++ b/api/_lib/middleware.ts
@@ -22,6 +22,11 @@ export function applyCors(req: VercelRequest, res: VercelResponse): boolean {
 // not shared across invocation instances. For a distributed limit use Upstash
 // Redis or Vercel KV and swap this implementation.
 const counts = new Map<string, { n: number; resetAt: number }>();
+
+/** Clears all rate-limit buckets. Exposed for tests only. */
+export function resetRateLimitForTesting(): void {
+  counts.clear();
+}
 const LIMIT = 20;
 const WINDOW_MS = 60_000;
 


### PR DESCRIPTION
## Summary
- Exports `resetRateLimitForTesting()` from `api/_lib/middleware.ts` to allow tests to clear the in-module `counts` Map between runs (same pattern as `clearVaultCache`)
- Adds `api/__tests__/middleware.test.ts` with 7 tests across two suites:
  - **`applyCors`**: sets CORS headers on every request; returns `true` and sends 204 for `OPTIONS`; returns `false` without ending the response for `POST`
  - **`checkRateLimit`**: allows the first 20 requests from the same IP; blocks the 21st with 429; resets the counter after the 60 s window (via `vi.useFakeTimers`); tracks two IPs independently

## Test plan
- [x] All 21 api-functions tests pass (7 new tests added)

Closes #160