### PR TITLE
fix: add exponential backoff retry for DeFiLlama and Stellar RPC calls

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,9 +6,13 @@
   "types": "./src/index.ts",
   "scripts": {
     "build": "tsc",
+    "test": "vitest run --passWithNoTests",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.8"
   }
 }

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { withRetry } from "./utils";
+
+describe("withRetry", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("resolves immediately when fn succeeds on first attempt", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries and resolves when fn fails then succeeds", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValue("ok");
+
+    const promise = withRetry(fn, 3, 0);
+    await vi.runAllTimersAsync();
+    expect(await promise).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws last error after exhausting all attempts", async () => {
+    const err = new Error("persistent");
+    const fn = vi.fn().mockRejectedValue(err);
+
+    const promise = withRetry(fn, 3, 0);
+    const assertion = expect(promise).rejects.toThrow("persistent");
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("respects maxAttempts=1 by not retrying", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("fail"));
+    const promise = withRetry(fn, 1, 0);
+    const assertion = expect(promise).rejects.toThrow("fail");
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -2,9 +2,32 @@ export function shortenAddress(address: string, chars = 4): string {
   return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }
 
-/** Returns true when \`key\` is a well-formed Stellar G-address (base32, 56 chars). */
+/** Returns true when `key` is a well-formed Stellar G-address (base32, 56 chars). */
 export function isValidStellarAddress(key: string): boolean {
   return /^G[A-Z2-7]{55}$/.test(key);
+}
+
+/**
+ * Retries `fn` up to `maxAttempts` times with exponential backoff starting at
+ * `baseDelayMs`. Throws the last error when all attempts are exhausted.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxAttempts = 3,
+  baseDelayMs = 200
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt < maxAttempts - 1) {
+        await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+      }
+    }
+  }
+  throw lastErr;
 }
 
 import { CONTRACT_ADDRESSES } from "./constants";

--- a/packages/stellar-sdk-helpers/package.json
+++ b/packages/stellar-sdk-helpers/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@blend-capital/blend-sdk": "^3.2.2",
+    "@meridian/shared": "workspace:*",
     "@stellar/stellar-sdk": "^12.0.0",
     "zod": "^3.23.0"
   },

--- a/packages/stellar-sdk-helpers/src/defilamma.ts
+++ b/packages/stellar-sdk-helpers/src/defilamma.ts
@@ -1,3 +1,5 @@
+import { withRetry } from "@meridian/shared";
+
 export interface DefiLlamaPool {
   pool: string;
   project: string;
@@ -47,10 +49,12 @@ const MIN_TVL_USD = 1_000;
 const MIN_APY = 0.01;
 
 export async function getStellarStablecoinPools(): Promise<DefiLlamaPool[]> {
-  const res = await fetch(POOLS_URL, { signal: AbortSignal.timeout(8_000) });
-  if (!res.ok) throw new Error(`DeFiLlama /pools HTTP ${res.status}`);
-  const json = (await res.json()) as { data: DefiLlamaPool[] };
-  return json.data.filter(
-    (p) => p.chain === "Stellar" && p.stablecoin && p.apy >= MIN_APY && p.tvlUsd >= MIN_TVL_USD
-  );
+  return withRetry(async () => {
+    const res = await fetch(POOLS_URL, { signal: AbortSignal.timeout(8_000) });
+    if (!res.ok) throw new Error(`DeFiLlama /pools HTTP ${res.status}`);
+    const json = (await res.json()) as { data: DefiLlamaPool[] };
+    return json.data.filter(
+      (p) => p.chain === "Stellar" && p.stablecoin && p.apy >= MIN_APY && p.tvlUsd >= MIN_TVL_USD
+    );
+  });
 }

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -11,6 +11,7 @@ import {
 } from "@stellar/stellar-sdk";
 import type { StellarNetwork } from "./types";
 import { BASE_FEE, passphraseFor } from "./internal";
+import { withRetry } from "@meridian/shared";
 
 const USDC_ISSUER: Record<string, string> = {
   testnet: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
@@ -95,7 +96,7 @@ export async function prepareSorobanTx(
 ): Promise<{ xdr: string; fee: string }> {
   const passphrase = passphraseFor(network);
   const server = new rpc.Server(network.rpcUrl);
-  const account = await server.getAccount(caller);
+  const account = await withRetry(() => server.getAccount(caller));
   const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
     .addOperation(op)
     .setTimeout(300)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,12 +191,19 @@ importers:
       zod:
         specifier: ^3.23.0
         version: 3.25.76
+    devDependencies:
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@edge-runtime/vm@3.2.0)(@types/node@20.19.39)(jsdom@26.1.0)(vite@8.0.16(@types/node@20.19.39)(esbuild@0.28.0)(jiti@1.21.7)(tsx@4.22.1))
 
   packages/stellar-sdk-helpers:
     dependencies:
       '@blend-capital/blend-sdk':
         specifier: ^3.2.2
         version: 3.2.2
+      '@meridian/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@stellar/stellar-sdk':
         specifier: ^12.0.0
         version: 12.3.0


### PR DESCRIPTION
## Summary

- Added `withRetry<T>()` helper to `@meridian/shared` with exponential backoff (default: 3 attempts, 200 ms base delay doubling each retry)
- Wrapped `getStellarStablecoinPools()` in `defilamma.ts` with `withRetry` so transient DeFiLlama HTTP failures are retried automatically
- Wrapped `server.getAccount(caller)` in `prepareSorobanTx()` with `withRetry` so intermittent Stellar RPC errors don't fail the tx-build flow immediately
- Added `@meridian/shared` as a workspace dependency to `stellar-sdk-helpers`
- Added 4 unit tests for `withRetry` in `packages/shared/src/utils.test.ts` covering: immediate success, retry-then-succeed, exhausted retries, maxAttempts=1

## Test plan

- [x] `pnpm --filter @meridian/shared test` -> 4 tests pass
- [x] `pnpm --filter @meridian/stellar-sdk-helpers test` -> 53 tests pass (no regressions)
- [x] `pnpm --filter @meridian/api-functions test` -> 21 tests pass (no regressions)

Closes #158