### PR TITLE
fix: add runtime type guard to toBigInt

### DIFF
--- a/packages/stellar-sdk-helpers/src/internal.test.ts
+++ b/packages/stellar-sdk-helpers/src/internal.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { toBigInt } from "./internal";
+
+describe("toBigInt", () => {
+  it("passes bigint values through unchanged", () => {
+    expect(toBigInt(42n)).toBe(42n);
+    expect(toBigInt(0n)).toBe(0n);
+  });
+
+  it("converts numbers by truncating the fractional part", () => {
+    expect(toBigInt(10)).toBe(10n);
+    expect(toBigInt(1.9)).toBe(1n);
+  });
+
+  it("returns 0n for null and undefined", () => {
+    expect(toBigInt(null)).toBe(0n);
+    expect(toBigInt(undefined)).toBe(0n);
+  });
+
+  it("throws TypeError for string values", () => {
+    expect(() => toBigInt("42")).toThrow(TypeError);
+    expect(() => toBigInt("42")).toThrow(/unexpected type string/);
+  });
+
+  it("throws TypeError for object and array values", () => {
+    expect(() => toBigInt({})).toThrow(TypeError);
+    expect(() => toBigInt([1n])).toThrow(TypeError);
+  });
+});

--- a/packages/stellar-sdk-helpers/src/internal.ts
+++ b/packages/stellar-sdk-helpers/src/internal.ts
@@ -6,7 +6,10 @@ export const BASE_FEE = "100";
 export const STROOPS_PER_UNIT = 1e7;
 
 export function toBigInt(value: unknown): bigint {
-  return BigInt((value as bigint | number | null) ?? 0);
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") return BigInt(Math.trunc(value));
+  if (value === null || value === undefined) return 0n;
+  throw new TypeError(`toBigInt: unexpected type ${typeof value}: ${String(value)}`);
 }
 
 export function passphraseFor(network: StellarNetwork): string {


### PR DESCRIPTION
## Summary

- Replaced the unchecked `BigInt((value as bigint | number | null) ?? 0)` cast in `toBigInt` with explicit runtime type guards
- `bigint` passes through, `number` is truncated via `Math.trunc`, `null`/`undefined` returns `0n`, anything else throws a descriptive `TypeError` identifying the unexpected type and value
- Added `internal.test.ts` with 5 tests covering all branches including the new error cases

## Test plan

- [x] `pnpm --filter @meridian/stellar-sdk-helpers test` → 58 tests pass

Closes #168