### PR TITLE
fix: add withRetry and timeout to fetchBlendPositions RPC calls

### DIFF
--- a/packages/stellar-sdk-helpers/src/blend.ts
+++ b/packages/stellar-sdk-helpers/src/blend.ts
@@ -1,8 +1,24 @@
 import { xdr } from "@stellar/stellar-sdk";
 import { PoolContractV2, PoolV2, RequestType } from "@blend-capital/blend-sdk";
+import { withRetry } from "@meridian/shared";
 import { prepareSorobanTx } from "./tx";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
+
+const BLEND_RPC_TIMEOUT_MS = 10_000;
+
+// The Blend SDK does not accept an AbortSignal, so we race the call against a
+// manual timeout rejection. The underlying fetch will still complete, but the
+// caller gets a fast failure it can retry rather than waiting for Vercel's
+// function-level deadline.
+function withTimeout<T>(fn: () => Promise<T>, ms = BLEND_RPC_TIMEOUT_MS): Promise<T> {
+  return Promise.race([
+    fn(),
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Blend RPC timed out after ${ms}ms`)), ms)
+    ),
+  ]);
+}
 
 export interface BlendPoolConfig {
   // Blend pool contract (C...) the request is submitted to.
@@ -96,8 +112,10 @@ export async function fetchBlendPositions(
   publicKey: string,
   reserves: BlendReserveRef[]
 ): Promise<PositionInfo[]> {
-  const pool = await PoolV2.load({ rpc: network.rpcUrl, passphrase: network.passphrase }, poolId);
-  const user = await pool.loadUser(publicKey);
+  const pool = await withRetry(() =>
+    withTimeout(() => PoolV2.load({ rpc: network.rpcUrl, passphrase: network.passphrase }, poolId))
+  );
+  const user = await withRetry(() => withTimeout(() => pool.loadUser(publicKey)));
 
   const positions: PositionInfo[] = [];
   for (const { assetId, vaultId } of reserves) {


### PR DESCRIPTION
## Summary

- Wrapped `PoolV2.load` and `pool.loadUser` in `fetchBlendPositions` with `withRetry` (3 attempts, exponential backoff) so transient RPC failures are retried automatically
- Added a local `withTimeout` helper that races the Blend SDK call against a 10s rejection — the SDK does not accept an AbortSignal, so this bounds latency without patching the dependency
- Both protections compose: a timed-out attempt counts as a failure and is retried

## Test plan

- [x] `pnpm --filter @meridian/stellar-sdk-helpers test` -> 53 tests pass

Closes #169