### PR TITLE
chore: remove dead exports YieldPosition, fetchPosition, defindexContractForVault

### DIFF
--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -30,22 +30,3 @@ export async function withRetry<T>(
   throw lastErr;
 }
 
-import { CONTRACT_ADDRESSES } from "./constants";
-
-type TestnetAddresses = (typeof CONTRACT_ADDRESSES)["testnet"];
-
-/**
- * Resolves the on-chain contract address for a logical DeFindex vault ID.
- * Returns an empty string when the vault is not yet configured.
- * The DEFINDEX_VAULT_ID env var overrides the defindex-usdc entry for
- * backward compatibility with the single-vault setup.
- */
-export function defindexContractForVault(
-  logicalVaultId: string,
-  addresses: TestnetAddresses
-): string {
-  const registry: Record<string, string> = {
-    "defindex-usdc": process.env.DEFINDEX_VAULT_ID || addresses.defindex.vault,
-  };
-  return registry[logicalVaultId] ?? "";
-}

--- a/packages/stellar-sdk-helpers/src/positions.ts
+++ b/packages/stellar-sdk-helpers/src/positions.ts
@@ -1,7 +1,4 @@
-import { rpc, Address, xdr } from "@stellar/stellar-sdk";
-import { simulateView } from "./tx";
-import type { StellarNetwork } from "./types";
-import { STROOPS_PER_UNIT, toBigInt } from "./internal";
+import { STROOPS_PER_UNIT } from "./internal";
 
 export interface PositionInfo {
   vaultId: string;
@@ -51,41 +48,3 @@ export function computePosition(vaultId: string, raw: RawPosition): PositionInfo
   ];
 }
 
-/**
- * Read an address's vault position via read-only contract simulation. Returns
- * `[]` if the address holds nothing. `get_principal` is fetched defensively so
- * the call still succeeds against a vault deployed before principal tracking
- * existed (earned simply reads 0 until the contract is upgraded).
- */
-export async function fetchPosition(
-  network: StellarNetwork,
-  vaultContractId: string,
-  publicKey: string
-): Promise<PositionInfo[]> {
-  const server = new rpc.Server(network.rpcUrl);
-  const caller = Address.fromString(publicKey).toScVal();
-  const view = (method: string, ...args: xdr.ScVal[]) =>
-    simulateView(server, vaultContractId, network.passphrase, method, ...args);
-
-  const [shares, totalShares, totalAssets, entryTime] = await Promise.all([
-    view("get_position", caller),
-    view("get_total_shares"),
-    view("get_total_assets"),
-    view("get_entry_time", caller),
-  ]);
-
-  let principal: bigint | null;
-  try {
-    principal = toBigInt(await view("get_principal", caller));
-  } catch {
-    principal = null;
-  }
-
-  return computePosition(vaultContractId, {
-    shares: toBigInt(shares),
-    totalShares: toBigInt(totalShares),
-    totalAssets: toBigInt(totalAssets),
-    principal,
-    entryTime: toBigInt(entryTime),
-  });
-}

--- a/packages/stellar-sdk-helpers/src/types.ts
+++ b/packages/stellar-sdk-helpers/src/types.ts
@@ -1,10 +1,3 @@
-export interface YieldPosition {
-  vaultId: string;
-  deposited: number;
-  earned: number;
-  entryTime: number;
-}
-
 export interface StellarNetwork {
   network: "mainnet" | "testnet" | "futurenet";
   rpcUrl: string;


### PR DESCRIPTION
## Summary

- Removed `YieldPosition` interface from `types.ts` — `PositionInfo` from `positions.ts` is used everywhere instead
- Removed `fetchPosition` function from `positions.ts` — no route or handler imports it; `fetchBlendPositions` and `fetchDefindexPosition` are used directly
- Removed `defindexContractForVault` from `packages/shared/src/utils.ts` — the env-override pattern is handled by `buildTxAddresses` instead; also removed the now-unused `CONTRACT_ADDRESSES` import it carried

## Test plan

- [x] `pnpm --filter @meridian/stellar-sdk-helpers test` -> 72 tests pass
- [x] `pnpm --filter @meridian/shared test` -> 4 tests pass
- [x] `pnpm --filter @meridian/api-functions test` -> 21 tests pass

Closes #174