### PR TITLE
fix: remove phantom VaultInfo import from horizon.test.ts

### DIFF
--- a/packages/stellar-sdk-helpers/src/horizon.test.ts
+++ b/packages/stellar-sdk-helpers/src/horizon.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { Horizon } from "@stellar/stellar-sdk";
 import { buildHorizonServer } from "./horizon";
-import type { StellarNetwork, VaultInfo } from "./types";
+import type { StellarNetwork } from "./types";
 
 function network(name: StellarNetwork["network"]): StellarNetwork {
   return { network: name, rpcUrl: "", passphrase: "" };
@@ -28,18 +28,3 @@ describe("buildHorizonServer", () => {
   });
 });
 
-describe("VaultInfo shape", () => {
-  it("accepts a well-formed vault object", () => {
-    const vault = {
-      id: "blend-usdc",
-      protocol: "blend",
-      asset: "USDC",
-      apy: 5.25,
-      tvl: 1_000_000,
-      userBalance: 0,
-    } satisfies VaultInfo;
-
-    expect(vault.protocol).toBe("blend");
-    expect(typeof vault.apy).toBe("number");
-  });
-});


### PR DESCRIPTION
## Summary

- Removed the stale `VaultInfo` import from `horizon.test.ts` — the type was never defined in `types.ts`, causing a silent `tsc --noEmit` failure while tests continued to pass under Vitest
- Removed the `VaultInfo shape` describe block that depended on it — the two assertions (`protocol === blend`, `typeof apy === number`) were testing plain JS properties with no type-safety value since `satisfies VaultInfo` resolved to an unknown type

## Test plan

- [x] `pnpm --filter @meridian/stellar-sdk-helpers test` -> 71 tests pass
- [x] `pnpm typecheck` passes with no errors

Closes #175