### PR TITLE
fix: add missing fee field to buildDeposit and buildWithdraw return types

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -55,12 +55,12 @@ export const api = {
       body: JSON.stringify({ walletAddress }),
     }),
   buildDeposit: (body: { walletAddress: string; vaultId: string; amount: string }) =>
-    apiFetch<{ xdr: string }>("/api/v1/tx/deposit", {
+    apiFetch<{ xdr: string; fee: string }>("/api/v1/tx/deposit", {
       method: "POST",
       body: JSON.stringify(body),
     }),
   buildWithdraw: (body: { walletAddress: string; vaultId: string; shares: string }) =>
-    apiFetch<{ xdr: string }>("/api/v1/tx/withdraw", {
+    apiFetch<{ xdr: string; fee: string }>("/api/v1/tx/withdraw", {
       method: "POST",
       body: JSON.stringify(body),
     }),


### PR DESCRIPTION
## Summary

- Updated `buildDeposit` and `buildWithdraw` in `apps/web/src/lib/api.ts` to return `{ xdr: string; fee: string }` instead of `{ xdr: string }`
- The actual API has always returned `fee` alongside `xdr`; the missing field in the type meant TypeScript could not surface it for use in confirmation dialogs and would not catch a contract change

## Test plan

- [x] `pnpm --filter @meridian/api-functions test` -> 21 tests pass
- [x] `pnpm typecheck` passes

Closes #192