### PR TITLE
fix: pass vault asset to toast instead of hardcoding USDC

### DIFF
--- a/apps/web/src/__tests__/hooks/useVaultActions.test.ts
+++ b/apps/web/src/__tests__/hooks/useVaultActions.test.ts
@@ -39,20 +39,20 @@ describe("useVaultActions — deposit", () => {
     const { result } = renderHook(() => useVaultActions());
 
     let ok: boolean | undefined;
-    await act(async () => { ok = await result.current.deposit("10", "blend-usdc-fixed"); });
+    await act(async () => { ok = await result.current.deposit("10", "blend-usdc-fixed", "USDC"); });
 
     expect(ok).toBe(true);
     expect(api.buildDeposit).toHaveBeenCalledWith({ walletAddress: KEY, vaultId: "blend-usdc-fixed", amount: "10" });
     expect(signTransaction).toHaveBeenCalledWith("DEPOSIT_XDR", expect.stringContaining("Test SDF"));
     expect(api.submitTx).toHaveBeenCalledWith({ xdr: "SIGNED_XDR" });
-    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "success" });
+    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "success", message: "Deposited 10 USDC" });
   });
 
   it("sets needsTrustline when the API signals a missing trustline", async () => {
     vi.mocked(api.buildDeposit).mockRejectedValueOnce(new Error("USDC trustline missing"));
     const { result } = renderHook(() => useVaultActions());
 
-    await act(async () => { await result.current.deposit("10", "blend-usdc-fixed"); });
+    await act(async () => { await result.current.deposit("10", "blend-usdc-fixed", "USDC"); });
 
     expect(result.current.needsTrustline).toBe(true);
     expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "error" });
@@ -63,7 +63,7 @@ describe("useVaultActions — deposit", () => {
     const { result } = renderHook(() => useVaultActions());
 
     let ok: boolean | undefined;
-    await act(async () => { ok = await result.current.deposit("10", "v"); });
+    await act(async () => { ok = await result.current.deposit("10", "v", "USDC"); });
 
     expect(ok).toBe(false);
     expect(api.buildDeposit).not.toHaveBeenCalled();
@@ -75,12 +75,12 @@ describe("useVaultActions — withdraw", () => {
     const { result } = renderHook(() => useVaultActions());
 
     let ok: boolean | undefined;
-    await act(async () => { ok = await result.current.withdraw("5", "blend-usdc-fixed"); });
+    await act(async () => { ok = await result.current.withdraw("5", "blend-usdc-fixed", "USDC"); });
 
     expect(ok).toBe(true);
     expect(api.buildWithdraw).toHaveBeenCalledWith({ walletAddress: KEY, vaultId: "blend-usdc-fixed", shares: "5" });
     expect(signTransaction).toHaveBeenCalled();
-    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "success" });
+    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "success", message: "Withdrew 5 USDC" });
   });
 
   it("pushes an error toast and returns false when withdraw fails", async () => {
@@ -88,7 +88,7 @@ describe("useVaultActions — withdraw", () => {
     const { result } = renderHook(() => useVaultActions());
 
     let ok: boolean | undefined;
-    await act(async () => { ok = await result.current.withdraw("5", "blend-usdc-fixed"); });
+    await act(async () => { ok = await result.current.withdraw("5", "blend-usdc-fixed", "USDC"); });
 
     expect(ok).toBe(false);
     expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "error" });

--- a/apps/web/src/components/dashboard/VaultPanel.tsx
+++ b/apps/web/src/components/dashboard/VaultPanel.tsx
@@ -53,13 +53,13 @@ export function VaultPanel() {
 
   async function handleDeposit() {
     if (!amount || !bestVault) return;
-    const ok = await deposit(amount, bestVault.id);
+    const ok = await deposit(amount, bestVault.id, bestVault.asset);
     if (ok) setAmount("");
   }
 
   async function handleWithdraw() {
     if (!amount || !bestVault) return;
-    const ok = await withdraw(amount, bestVault.id);
+    const ok = await withdraw(amount, bestVault.id, bestVault.asset);
     if (ok) setAmount("");
   }
 

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -39,7 +39,7 @@ export function useVaultActions() {
     }
   }
 
-  async function deposit(amount: string, vaultId: string): Promise<boolean> {
+  async function deposit(amount: string, vaultId: string, asset: string): Promise<boolean> {
     if (!publicKey || !passphrase) return false;
     setIsDepositing(true);
     try {
@@ -47,7 +47,7 @@ export function useVaultActions() {
       await signAndSubmit(xdr);
       setNeedsTrustline(false);
       queryClient.invalidateQueries({ queryKey: ["positions", publicKey] });
-      push("success", `Deposited ${amount} USDC`);
+      push("success", `Deposited ${amount} ${asset}`);
       return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Deposit failed";
@@ -61,14 +61,14 @@ export function useVaultActions() {
     }
   }
 
-  async function withdraw(shares: string, vaultId: string): Promise<boolean> {
+  async function withdraw(shares: string, vaultId: string, asset: string): Promise<boolean> {
     if (!publicKey || !passphrase) return false;
     setIsWithdrawing(true);
     try {
       const { xdr } = await api.buildWithdraw({ walletAddress: publicKey, vaultId, shares });
       await signAndSubmit(xdr);
       queryClient.invalidateQueries({ queryKey: ["positions", publicKey] });
-      push("success", `Withdrew ${shares} USDC`);
+      push("success", `Withdrew ${shares} ${asset}`);
       return true;
     } catch (err) {
       push("error", err instanceof Error ? err.message : "Withdrawal failed");


### PR DESCRIPTION
## Summary
- `deposit` and `withdraw` in `useVaultActions` now accept an `asset` string parameter
- Success toasts show the actual asset symbol (e.g. USDC, EURC) from the vault data
- `VaultPanel` passes `bestVault.asset` at the callsites
- Tests updated to pass the asset arg and assert the toast message content

Closes #190