### PR TITLE
fix: add Cache-Control header to vaults/[vaultId] endpoint

### DIFF
--- a/api/v1/vaults/[vaultId].ts
+++ b/api/v1/vaults/[vaultId].ts
@@ -2,6 +2,8 @@ import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { fetchAllVaults } from "@meridian/stellar-sdk-helpers";
 import { applyCors } from "../../_lib/middleware";
 
+const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   const { vaultId } = req.query as { vaultId: string };
@@ -10,6 +12,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const vaults = await fetchAllVaults();
     const vault = vaults.find((v) => v.id === vaultId);
     if (!vault) return res.status(404).json({ error: "vault not found", vaultId });
+    res.setHeader("Cache-Control", CACHE_CONTROL);
     res.json(vault);
   } catch (err) {
     console.error("[vaults] fetch error:", err);


### PR DESCRIPTION
## Summary
- Added `Cache-Control: public, s-maxage=60, stale-while-revalidate=300` to the single-vault GET handler
- Matches the header already set on the `/vaults` index endpoint — same data source, same TTL

## Test plan
- [x] `GET /api/v1/vaults/:id` response includes `Cache-Control` header
- [x] 404 responses are not cached (header only set on the success path)

Closes #191