### PR TITLE
fix: report actual cache hit status instead of hardcoding cached false

### DIFF
--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -11,6 +11,7 @@ vi.mock("@meridian/stellar-sdk-helpers", () => ({
   submitTx: vi.fn(async () => ({ hash: "HASH" })),
   fetchAllVaults: vi.fn(async () => [{ id: "blend-usdc-fixed", protocol: "blend" }]),
   selectBestVault: vi.fn(() => ({ id: "blend-usdc-fixed" })),
+  isVaultCacheWarm: vi.fn(() => false),
   fetchBlendPositions: vi.fn(async () => [
     { vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 },
   ]),

--- a/api/v1/vaults/index.ts
+++ b/api/v1/vaults/index.ts
@@ -1,5 +1,5 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { fetchAllVaults, selectBestVault } from "@meridian/stellar-sdk-helpers";
+import { fetchAllVaults, selectBestVault, isVaultCacheWarm } from "@meridian/stellar-sdk-helpers";
 import { APP_ADDRESSES } from "@meridian/shared";
 import { applyCors } from "../../_lib/middleware";
 
@@ -14,6 +14,7 @@ const defindexConfigured = Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSE
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   try {
+    const cached = isVaultCacheWarm();
     const vaults = await fetchAllVaults();
     const best = selectBestVault(vaults, { defindexConfigured });
     res.setHeader("Cache-Control", CACHE_CONTROL);
@@ -21,7 +22,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       vaults,
       recommendedVaultId: best?.id ?? null,
       updatedAt: new Date().toISOString(),
-      cached: false,
+      cached,
     });
   } catch (err) {
     console.error("[vaults] fetch error:", err);

--- a/apps/api/src/routes/vaults.ts
+++ b/apps/api/src/routes/vaults.ts
@@ -1,5 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import { selectBestVault } from "@meridian/stellar-sdk-helpers";
+import { selectBestVault, isVaultCacheWarm } from "@meridian/stellar-sdk-helpers";
 import { APP_ADDRESSES } from "@meridian/shared";
 import { fetchAllVaults } from "../services/vaults.js";
 
@@ -8,13 +8,14 @@ const defindexConfigured = Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSE
 export const vaultsRoute: FastifyPluginAsync = async (app) => {
   app.get("/", async (_req, reply) => {
     try {
+      const cached = isVaultCacheWarm();
       const vaults = await fetchAllVaults();
       const best = selectBestVault(vaults, { defindexConfigured });
       return reply.send({
         vaults,
         recommendedVaultId: best?.id ?? null,
         updatedAt: new Date().toISOString(),
-        cached: false,
+        cached,
       });
     } catch (err) {
       app.log.error(err, "[vaults] failed to fetch vaults");

--- a/packages/stellar-sdk-helpers/src/vaults.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.ts
@@ -24,6 +24,11 @@ export function clearVaultCache(): void {
   vaultCache = null;
 }
 
+/** Returns true if a valid cached result exists and will be returned by fetchAllVaults. */
+export function isVaultCacheWarm(): boolean {
+  return vaultCache !== null && Date.now() < vaultCache.expiresAt;
+}
+
 // Every vault in the list is backed by live DeFiLlama market data. Protocols
 // without a real on-chain rate feed wired up yet are intentionally omitted
 // rather than shown with placeholder figures.


### PR DESCRIPTION
## Summary
- Added `isVaultCacheWarm()` to `@meridian/stellar-sdk-helpers` to expose whether a valid in-memory cache entry exists
- Both the Vercel handler and the Fastify route now call it before `fetchAllVaults()` and return the real `cached` boolean
- No change to `fetchAllVaults` return type; the helper is a pure state check on the module-level cache variable

## Test plan
- [x] First request returns `cached: false`; subsequent request within 60s returns `cached: true`
- [x] All sdk-helpers tests pass

Closes #184