### PR TITLE
fix: add try/catch error handling to Fastify vaults routes

### DIFF
--- a/apps/api/src/routes/vaults.ts
+++ b/apps/api/src/routes/vaults.ts
@@ -7,21 +7,31 @@ const defindexConfigured = Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSE
 
 export const vaultsRoute: FastifyPluginAsync = async (app) => {
   app.get("/", async (_req, reply) => {
-    const vaults = await fetchAllVaults();
-    const best = selectBestVault(vaults, { defindexConfigured });
-    return reply.send({
-      vaults,
-      recommendedVaultId: best?.id ?? null,
-      updatedAt: new Date().toISOString(),
-      cached: false,
-    });
+    try {
+      const vaults = await fetchAllVaults();
+      const best = selectBestVault(vaults, { defindexConfigured });
+      return reply.send({
+        vaults,
+        recommendedVaultId: best?.id ?? null,
+        updatedAt: new Date().toISOString(),
+        cached: false,
+      });
+    } catch (err) {
+      app.log.error(err, "[vaults] failed to fetch vaults");
+      return reply.code(500).send({ error: "Failed to fetch vaults" });
+    }
   });
 
   app.get("/:vaultId", async (req, reply) => {
-    const { vaultId } = req.params as { vaultId: string };
-    const vaults = await fetchAllVaults();
-    const vault = vaults.find((v) => v.id === vaultId);
-    if (!vault) return reply.code(404).send({ error: "vault not found", vaultId });
-    return reply.send(vault);
+    try {
+      const { vaultId } = req.params as { vaultId: string };
+      const vaults = await fetchAllVaults();
+      const vault = vaults.find((v) => v.id === vaultId);
+      if (!vault) return reply.code(404).send({ error: "vault not found", vaultId });
+      return reply.send(vault);
+    } catch (err) {
+      app.log.error(err, "[vaults] failed to fetch vault by id");
+      return reply.code(500).send({ error: "Failed to fetch vault" });
+    }
   });
 };


### PR DESCRIPTION
## Summary
- Wrapped both GET /vaults and GET /vaults/:vaultId handlers in try/catch
- Errors are logged via app.log.error and a 500 JSON is returned
- Previously an unhandled rejection would leak the raw error through Fastify default error handling

## Test plan
- [x] Simulating a DeFiLlama failure returns status 500 with an error JSON
- [x] Normal requests still return vault data correctly

Closes #185