### PR TITLE
fix: validate vaultId query param type before use

### DIFF
--- a/api/v1/vaults/[vaultId].ts
+++ b/api/v1/vaults/[vaultId].ts
@@ -6,7 +6,9 @@ const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
-  const { vaultId } = req.query as { vaultId: string };
+  const raw = req.query["vaultId"];
+  const vaultId = typeof raw === "string" ? raw : undefined;
+  if (!vaultId) return res.status(400).json({ error: "vaultId is required" });
 
   try {
     const vaults = await fetchAllVaults();


### PR DESCRIPTION
## Summary
- `req.query[vaultId]` can be `string | string[] | undefined` at runtime; the previous cast `as { vaultId: string }` silently allowed invalid values through
- Added a type guard: if the value is not a plain string, return 400 immediately
- 404 and 500 paths are unchanged

## Test plan
- [x] Sending `?vaultId[]=foo` or omitting the param returns 400
- [x] Valid `?vaultId=blend-usdc-fixed` still resolves to the correct vault

Closes #173