### PR TITLE
fix: handle futurenet in passphraseFor instead of silently falling back to testnet

### DIFF
--- a/packages/stellar-sdk-helpers/src/internal.ts
+++ b/packages/stellar-sdk-helpers/src/internal.ts
@@ -13,5 +13,9 @@ export function toBigInt(value: unknown): bigint {
 }
 
 export function passphraseFor(network: StellarNetwork): string {
-  return network.network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+  switch (network.network) {
+    case "mainnet": return Networks.PUBLIC;
+    case "testnet": return Networks.TESTNET;
+    case "futurenet": return Networks.FUTURENET;
+  }
 }


### PR DESCRIPTION
## Summary
- passphraseFor previously returned Networks.TESTNET for any non-mainnet network, silently using the wrong passphrase for futurenet
- Replaced the ternary with an exhaustive switch so each of the three supported networks maps to its correct SDK constant
- TypeScript now enforces exhaustiveness at the switch level

## Test plan
- [x] All 71 sdk-helpers tests pass
- [x] passphraseFor with futurenet returns the futurenet passphrase constant

Closes #172