### PR TITLE
fix: apply rate limiting to GET /vaults and GET /positions Vercel handlers

### DIFF
--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,12 +1,13 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { fetchBlendPositions, fetchDefindexPosition } from "@meridian/stellar-sdk-helpers";
 import { APP_NETWORK, APP_ADDRESSES, isValidStellarAddress } from "@meridian/shared";
-import { applyCors } from "../../_lib/middleware";
+import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault;
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
+  if (!checkRateLimit(req, res)) return;
   const { publicKey } = req.query as { publicKey: string };
 
   if (!publicKey || !isValidStellarAddress(publicKey)) {

--- a/api/v1/vaults/index.ts
+++ b/api/v1/vaults/index.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { fetchAllVaults, selectBestVault, isVaultCacheWarm } from "@meridian/stellar-sdk-helpers";
 import { APP_ADDRESSES } from "@meridian/shared";
-import { applyCors } from "../../_lib/middleware";
+import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 // Cache the aggregated vault list at the Vercel CDN. APY/TVL move slowly, so a
 // short fresh window keeps DeFiLlama call volume low, and the stale-while-
@@ -13,6 +13,7 @@ const defindexConfigured = Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSE
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
+  if (!checkRateLimit(req, res)) return;
   try {
     const cached = isVaultCacheWarm();
     const vaults = await fetchAllVaults();


### PR DESCRIPTION
## Summary
- GET /vaults and GET /positions were missing checkRateLimit, unlike the POST tx handlers
- Added checkRateLimit call after applyCors in both handlers so all four Vercel endpoints share the same 20 req/60s per-IP limit

## Test plan
- [x] All 21 api-functions tests pass
- [x] 21st request from the same IP within 60s returns 429

Closes #176