### PR TITLE
fix: align Vercel rate limit from 20 to 100 req/min to match Fastify

### DIFF
--- a/api/__tests__/middleware.test.ts
+++ b/api/__tests__/middleware.test.ts
@@ -62,18 +62,18 @@ describe("applyCors", () => {
 // checkRateLimit ------------------------------------------------------------------
 
 describe("checkRateLimit", () => {
-  it("allows the first 20 requests from the same IP", () => {
+  it("allows the first 100 requests from the same IP", () => {
     const ip = "1.2.3.4";
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       const res = fakeRes();
       expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)).toBe(true);
       expect(res.statusCode).toBe(200);
     }
   });
 
-  it("blocks the 21st request with 429", () => {
+  it("blocks the 101st request with 429", () => {
     const ip = "1.2.3.5";
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), fakeRes());
     }
     const res = fakeRes();
@@ -84,7 +84,7 @@ describe("checkRateLimit", () => {
   it("resets the counter after the 60 s window expires", () => {
     vi.useFakeTimers();
     const ip = "1.2.3.6";
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), fakeRes());
     }
     // Advance past the 60 s window.
@@ -97,7 +97,7 @@ describe("checkRateLimit", () => {
   it("tracks two different IPs independently", () => {
     const ipA = "10.0.0.1";
     const ipB = "10.0.0.2";
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipA }), fakeRes());
     }
     // ipA is blocked but ipB should still be allowed.

--- a/api/_lib/middleware.ts
+++ b/api/_lib/middleware.ts
@@ -18,16 +18,16 @@ export function applyCors(req: VercelRequest, res: VercelResponse): boolean {
   return false;
 }
 
-// In-memory rate limit: per-IP, 20 req / 60 s. Resets on cold start and is
-// not shared across invocation instances. For a distributed limit use Upstash
-// Redis or Vercel KV and swap this implementation.
+// In-memory rate limit: per-IP, 100 req / 60 s — matches the Fastify server's
+// @fastify/rate-limit config. Resets on cold start and is not shared across
+// invocation instances. For a distributed limit use Upstash Redis or Vercel KV.
 const counts = new Map<string, { n: number; resetAt: number }>();
 
 /** Clears all rate-limit buckets. Exposed for tests only. */
 export function resetRateLimitForTesting(): void {
   counts.clear();
 }
-const LIMIT = 20;
+const LIMIT = 100;
 const WINDOW_MS = 60_000;
 
 function clientIp(req: VercelRequest): string {


### PR DESCRIPTION
## Summary
- Vercel middleware was capped at 20 req/60s while Fastify uses 100 req/60s via @fastify/rate-limit
- Raised LIMIT constant to 100 and updated the comment referencing it
- Updated middleware tests to match the new threshold (101st request gets 429)

## Test plan
- [x] All 21 api-functions tests pass with the new limit
- [x] Verified 101st request returns 429, 100th still returns 200

Closes #177