### PR TITLE
test: add x-vercel-forwarded-for priority test to rate limit middleware

### DIFF
--- a/api/__tests__/middleware.test.ts
+++ b/api/__tests__/middleware.test.ts
@@ -110,7 +110,7 @@ describe("checkRateLimit", () => {
   it("uses x-vercel-forwarded-for over x-forwarded-for when both are present", () => {
     const vercelIp = "5.6.7.8";
     const fwdIp = "9.9.9.9";
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 100; i++) {
       checkRateLimit(
         fakeReq("POST", { "x-vercel-forwarded-for": vercelIp, "x-forwarded-for": fwdIp }),
         fakeRes()

--- a/api/__tests__/middleware.test.ts
+++ b/api/__tests__/middleware.test.ts
@@ -106,4 +106,30 @@ describe("checkRateLimit", () => {
     const resB = fakeRes();
     expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipB }), resB)).toBe(true);
   });
+
+  it("uses x-vercel-forwarded-for over x-forwarded-for when both are present", () => {
+    const vercelIp = "5.6.7.8";
+    const fwdIp = "9.9.9.9";
+    for (let i = 0; i < 20; i++) {
+      checkRateLimit(
+        fakeReq("POST", { "x-vercel-forwarded-for": vercelIp, "x-forwarded-for": fwdIp }),
+        fakeRes()
+      );
+    }
+    // vercelIp bucket is full — requests with that header should be blocked
+    const resBlocked = fakeRes();
+    expect(
+      checkRateLimit(
+        fakeReq("POST", { "x-vercel-forwarded-for": vercelIp, "x-forwarded-for": fwdIp }),
+        resBlocked
+      )
+    ).toBe(false);
+    expect(resBlocked.statusCode).toBe(429);
+
+    // fwdIp bucket is untouched — requests without x-vercel-forwarded-for should still pass
+    const resAllowed = fakeRes();
+    expect(
+      checkRateLimit(fakeReq("POST", { "x-forwarded-for": fwdIp }), resAllowed)
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Added a test that sends 100 requests with both x-vercel-forwarded-for and x-forwarded-for set to different IPs
- Verifies that the Vercel header is used for bucketing (vercelIp hits 429) while the fallback IP bucket remains untouched

## Test plan
- [x] 22 api-functions tests pass
- [x] New test exercises the priority branch in clientIp() that was previously uncovered

Closes #186