### PR TITLE
test: add cache TTL expiry test to vaults.test.ts

### DIFF
--- a/packages/stellar-sdk-helpers/src/vaults.test.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { fetchAllVaults, clearVaultCache } from "./vaults";
 
 // Maps to blend-usdc-fixed in known-pools.ts.
@@ -29,8 +29,10 @@ function stubPools(data: unknown[]) {
 }
 
 describe("fetchAllVaults", () => {
+  beforeEach(() => clearVaultCache());
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
     clearVaultCache();
   });
 
@@ -65,5 +67,19 @@ describe("fetchAllVaults", () => {
     await fetchAllVaults();
 
     expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it("re-fetches from DeFiLlama after the 60 s TTL expires", async () => {
+    vi.useFakeTimers();
+    const mockFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ data: [llamaPool()] }), { status: 200 })
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchAllVaults();
+    vi.advanceTimersByTime(61_000);
+    await fetchAllVaults();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- The existing cache test only verified that repeated calls within the TTL skip DeFiLlama
- Added a new test using fake timers that advances 61s past the first fetch and confirms a second fetch is triggered

## Test plan
- [x] 72 sdk-helpers tests pass including the new TTL expiry test

Closes #188