### PR TITLE
fix: skip caching empty pool list from DeFiLlama, serve stale cache instead

### DIFF
--- a/packages/stellar-sdk-helpers/src/vaults.test.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.test.ts
@@ -69,6 +69,23 @@ describe("fetchAllVaults", () => {
     expect(mockFetch).toHaveBeenCalledOnce();
   });
 
+  it("serves stale cache instead of empty list when DeFiLlama returns no pools", async () => {
+    // Prime the cache with a valid vault list.
+    stubPools([llamaPool()]);
+    const first = await fetchAllVaults();
+    expect(first).toHaveLength(1);
+
+    // Now simulate a DeFiLlama blip — all pools gone — after TTL expiry.
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(61_000);
+    stubPools([]);
+    const second = await fetchAllVaults();
+
+    // Should return the previous cache, not an empty array.
+    expect(second).toHaveLength(1);
+    expect(second[0].id).toBe("blend-usdc-fixed");
+  });
+
   it("re-fetches from DeFiLlama after the 60 s TTL expires", async () => {
     vi.useFakeTimers();
     const mockFetch = vi.fn(async () =>

--- a/packages/stellar-sdk-helpers/src/vaults.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.ts
@@ -55,6 +55,13 @@ export async function fetchAllVaults(): Promise<ApiVault[]> {
     });
   }
 
-  vaultCache = { vaults, expiresAt: now + CACHE_TTL_MS };
-  return vaults;
+  if (vaults.length > 0) {
+    vaultCache = { vaults, expiresAt: now + CACHE_TTL_MS };
+    return vaults;
+  }
+
+  // DeFiLlama returned no usable pools — likely a transient blip.
+  // Serve the previous cache if still populated so the dashboard stays live;
+  // otherwise return empty and let callers decide how to handle it.
+  return vaultCache?.vaults ?? [];
 }


### PR DESCRIPTION
## Summary
- fetchAllVaults previously cached an empty vault list when DeFiLlama returned no pools, blanking the dashboard for the full 60s TTL
- Empty results are now skipped; the previous cache is served instead so the dashboard stays live through transient blips
- Added a test that primes the cache, advances past TTL, stubs DeFiLlama to return nothing, and asserts the stale vault list is returned

## Test plan
- [x] 73 sdk-helpers tests pass
- [x] New test covers the blip-resilience path

Closes #187