### PR TITLE
fix: scrub RPC URLs and contract addresses from 500 error responses

### DIFF
--- a/api/v1/tx/add-trustline.ts
+++ b/api/v1/tx/add-trustline.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildAddTrustlineTx } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, TrustlineRequestSchema, formatZodError } from "@meridian/shared";
+import { APP_NETWORK, TrustlineRequestSchema, formatZodError, sanitizeTxError } from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -15,7 +15,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const result = await buildAddTrustlineTx(parsed.data.walletAddress, APP_NETWORK);
     res.json(result);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "Failed to build trustline transaction";
-    res.status(500).json({ error: msg });
+    res.status(500).json({ error: sanitizeTxError(err, "Failed to build trustline transaction") });
   }
 }

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildDepositTx } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, buildTxAddresses, DepositRequestSchema, formatZodError } from "@meridian/shared";
+import { APP_NETWORK, buildTxAddresses, DepositRequestSchema, formatZodError, sanitizeTxError } from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -20,7 +20,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     );
     return res.json(result);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "Failed to build deposit transaction";
-    res.status(500).json({ error: msg });
+    res.status(500).json({ error: sanitizeTxError(err, "Failed to build deposit transaction") });
   }
 }

--- a/api/v1/tx/submit.ts
+++ b/api/v1/tx/submit.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { submitTx } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, SubmitRequestSchema, formatZodError } from "@meridian/shared";
+import { APP_NETWORK, SubmitRequestSchema, formatZodError, sanitizeTxError } from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -15,7 +15,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const result = await submitTx(parsed.data.xdr, APP_NETWORK);
     res.json(result);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "Failed to submit transaction";
-    res.status(500).json({ error: msg });
+    res.status(500).json({ error: sanitizeTxError(err, "Failed to submit transaction") });
   }
 }

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildWithdrawTx } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, buildTxAddresses, WithdrawRequestSchema, formatZodError } from "@meridian/shared";
+import { APP_NETWORK, buildTxAddresses, WithdrawRequestSchema, formatZodError, sanitizeTxError } from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -20,7 +20,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     );
     return res.json(result);
   } catch (err) {
-    const msg = err instanceof Error ? err.message : "Failed to build withdraw transaction";
-    res.status(500).json({ error: msg });
+    res.status(500).json({ error: sanitizeTxError(err, "Failed to build withdraw transaction") });
   }
 }

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -7,6 +7,7 @@ import {
   TrustlineRequestSchema,
   SubmitRequestSchema,
   formatZodError,
+  sanitizeTxError,
 } from "@meridian/shared";
 import {
   buildDepositTx,
@@ -29,8 +30,7 @@ export const txRoute: FastifyPluginAsync = async (app) => {
       );
       reply.send(result);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Failed to build deposit transaction";
-      reply.code(500).send({ error: msg });
+      reply.code(500).send({ error: sanitizeTxError(err, "Failed to build deposit transaction") });
     }
   });
 
@@ -47,8 +47,7 @@ export const txRoute: FastifyPluginAsync = async (app) => {
       );
       reply.send(result);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Failed to build withdraw transaction";
-      reply.code(500).send({ error: msg });
+      reply.code(500).send({ error: sanitizeTxError(err, "Failed to build withdraw transaction") });
     }
   });
 
@@ -60,8 +59,7 @@ export const txRoute: FastifyPluginAsync = async (app) => {
       const result = await buildAddTrustlineTx(parsed.data.walletAddress, APP_NETWORK);
       reply.send(result);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Failed to build trustline transaction";
-      reply.code(500).send({ error: msg });
+      reply.code(500).send({ error: sanitizeTxError(err, "Failed to build trustline transaction") });
     }
   });
 
@@ -73,8 +71,7 @@ export const txRoute: FastifyPluginAsync = async (app) => {
       const result = await submitTx(parsed.data.xdr, APP_NETWORK);
       reply.send(result);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : "Failed to submit transaction";
-      reply.code(500).send({ error: msg });
+      reply.code(500).send({ error: sanitizeTxError(err, "Failed to submit transaction") });
     }
   });
 };

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -1,5 +1,39 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { withRetry } from "./utils";
+import { withRetry, sanitizeTxError } from "./utils";
+
+describe("sanitizeTxError", () => {
+  it("returns the fallback for non-Error values", () => {
+    expect(sanitizeTxError("string error", "fallback")).toBe("fallback");
+    expect(sanitizeTxError(42, "fallback")).toBe("fallback");
+    expect(sanitizeTxError(null, "fallback")).toBe("fallback");
+    expect(sanitizeTxError(undefined, "fallback")).toBe("fallback");
+  });
+
+  it("returns the first line of a clean multi-line error message", () => {
+    const err = new Error("Transaction simulation failed\n  at contract: ...\n  context: ...");
+    expect(sanitizeTxError(err, "fallback")).toBe("Transaction simulation failed");
+  });
+
+  it("returns the fallback when the first line contains an RPC URL", () => {
+    const err = new Error("fetch failed: https://soroban-testnet.stellar.org\nmore detail");
+    expect(sanitizeTxError(err, "fallback")).toBe("fallback");
+  });
+
+  it("returns the fallback when the first line contains a contract C-address", () => {
+    const err = new Error("CCQNJ4SJM5NKRBJK3G4YATDUZPTLWVKWKJTPBFHIFVQMQJDQVLSEHWA: not found");
+    expect(sanitizeTxError(err, "fallback")).toBe("fallback");
+  });
+
+  it("returns the fallback for an empty or whitespace-only message", () => {
+    expect(sanitizeTxError(new Error(""), "fallback")).toBe("fallback");
+    expect(sanitizeTxError(new Error("  \n  "), "fallback")).toBe("fallback");
+  });
+
+  it("passes through safe user-facing error messages unchanged", () => {
+    const err = new Error("All required trustlines already exist");
+    expect(sanitizeTxError(err, "fallback")).toBe("All required trustlines already exist");
+  });
+});
 
 describe("withRetry", () => {
   beforeEach(() => vi.useFakeTimers());

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,3 +1,19 @@
+// Matches patterns that reveal internal deployment details: RPC URLs and
+// Stellar contract (C-address) identifiers embedded in SDK error messages.
+const INTERNAL_DETAIL = /https?:\/\/|C[A-Z2-7]{50,}/;
+
+/**
+ * Extracts a safe, first-line summary from an unknown catch value.
+ * Strips multi-line SDK diagnostics, RPC URLs, and contract addresses.
+ * Returns `fallback` when no clean message can be derived.
+ */
+export function sanitizeTxError(err: unknown, fallback: string): string {
+  if (!(err instanceof Error)) return fallback;
+  const first = err.message.split("\n")[0].trim();
+  if (!first || INTERNAL_DETAIL.test(first)) return fallback;
+  return first;
+}
+
 export function shortenAddress(address: string, chars = 4): string {
   return `${address.slice(0, chars)}...${address.slice(-chars)}`;
 }


### PR DESCRIPTION
﻿## Summary

- Added `sanitizeTxError(err, fallback)` helper to `@meridian/shared` that extracts only the first line of an error message and drops it if it contains an RPC URL or Stellar contract address
- Replaced all raw `err.message` exposures in the four Vercel tx handlers and the Fastify tx route with `sanitizeTxError`, keeping user-facing messages (e.g. "All required trustlines already exist") while scrubbing deployment details

## Test plan

- [x] `sanitizeTxError` unit tests in `packages/shared/src/utils.test.ts` cover: non-Error values, multi-line messages, RPC URL in first line, C-address in first line, empty message, and clean user-facing message
- [x] All 10 tests in `packages/shared` pass

Closes #180
