### PR TITLE
chore: extract resolvePositions to eliminate position-fetch duplication

### DIFF
--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -12,10 +12,9 @@ vi.mock("@meridian/stellar-sdk-helpers", () => ({
   fetchAllVaults: vi.fn(async () => [{ id: "blend-usdc-fixed", protocol: "blend" }]),
   selectBestVault: vi.fn(() => ({ id: "blend-usdc-fixed" })),
   isVaultCacheWarm: vi.fn(() => false),
-  fetchBlendPositions: vi.fn(async () => [
+  resolvePositions: vi.fn(async () => [
     { vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 },
   ]),
-  fetchDefindexPosition: vi.fn(async () => []),
 }));
 
 import depositHandler from "../v1/tx/deposit";
@@ -24,7 +23,7 @@ import trustlineHandler from "../v1/tx/add-trustline";
 import submitHandler from "../v1/tx/submit";
 import vaultsHandler from "../v1/vaults/index";
 import positionsHandler from "../v1/positions/[publicKey]";
-import { buildDepositTx, fetchBlendPositions } from "@meridian/stellar-sdk-helpers";
+import { buildDepositTx, resolvePositions } from "@meridian/stellar-sdk-helpers";
 
 // A 56-char Stellar public key shape (only the length is validated).
 const PUBKEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
@@ -164,7 +163,7 @@ describe("GET /api/v1/positions/:publicKey", () => {
     const res = makeRes();
     await positionsHandler(fakeReq({ method: "GET", query: { publicKey: "too-short" } }), res);
     expect(res.statusCode).toBe(400);
-    expect(fetchBlendPositions).not.toHaveBeenCalled();
+    expect(resolvePositions).not.toHaveBeenCalled();
   });
 
   it("returns the resolved positions for a valid key", async () => {
@@ -173,11 +172,11 @@ describe("GET /api/v1/positions/:publicKey", () => {
     expect(res.body).toEqual({
       positions: [{ vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 }],
     });
-    expect(fetchBlendPositions).toHaveBeenCalledOnce();
+    expect(resolvePositions).toHaveBeenCalledOnce();
   });
 
   it("returns 503 when the Blend read throws", async () => {
-    vi.mocked(fetchBlendPositions).mockRejectedValueOnce(new Error("rpc down"));
+    vi.mocked(resolvePositions).mockRejectedValueOnce(new Error("rpc down"));
     const res = makeRes();
     await positionsHandler(fakeReq({ method: "GET", query: { publicKey: PUBKEY } }), res);
     expect(res.statusCode).toBe(503);

--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,9 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { fetchBlendPositions, fetchDefindexPosition } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, APP_ADDRESSES, isValidStellarAddress } from "@meridian/shared";
+import { resolvePositions } from "@meridian/stellar-sdk-helpers";
+import { APP_NETWORK, buildTxAddresses, isValidStellarAddress } from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware";
-
-const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault;
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
@@ -15,21 +13,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const positions = await fetchBlendPositions(APP_NETWORK, APP_ADDRESSES.blend.pool, publicKey, [
-      { assetId: APP_ADDRESSES.usdc, vaultId: "blend-usdc-fixed" },
-      { assetId: APP_ADDRESSES.eurc, vaultId: "blend-eurc-fixed" },
-    ]);
-
-    if (defindexVaultId) {
-      // Isolated so a DeFindex read failure can't drop the Blend positions.
-      try {
-        const dfx = await fetchDefindexPosition(APP_NETWORK, defindexVaultId, "defindex-usdc", publicKey);
-        positions.push(...dfx);
-      } catch (err) {
-        console.error("[positions] defindex read failed:", err);
-      }
-    }
-
+    const positions = await resolvePositions(publicKey, APP_NETWORK, buildTxAddresses(process.env.DEFINDEX_VAULT_ID));
     res.json({ positions });
   } catch (err) {
     console.error("[positions] error:", err);

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -1,8 +1,6 @@
 import type { FastifyPluginAsync } from "fastify";
-import { APP_NETWORK, APP_ADDRESSES, isValidStellarAddress } from "@meridian/shared";
-import { fetchBlendPositions, fetchDefindexPosition } from "@meridian/stellar-sdk-helpers";
-
-const defindexVaultId = process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault;
+import { APP_NETWORK, buildTxAddresses, isValidStellarAddress } from "@meridian/shared";
+import { resolvePositions } from "@meridian/stellar-sdk-helpers";
 
 export const positionsRoute: FastifyPluginAsync = async (app) => {
   app.get("/:publicKey", async (req, reply) => {
@@ -13,21 +11,7 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
     }
 
     try {
-      const positions = await fetchBlendPositions(APP_NETWORK, APP_ADDRESSES.blend.pool, publicKey, [
-        { assetId: APP_ADDRESSES.usdc, vaultId: "blend-usdc-fixed" },
-        { assetId: APP_ADDRESSES.eurc, vaultId: "blend-eurc-fixed" },
-      ]);
-
-      if (defindexVaultId) {
-        // Isolated so a DeFindex read failure can't drop the Blend positions.
-        try {
-          const dfx = await fetchDefindexPosition(APP_NETWORK, defindexVaultId, "defindex-usdc", publicKey);
-          positions.push(...dfx);
-        } catch (err) {
-          app.log.error(err, "[positions] defindex read failed");
-        }
-      }
-
+      const positions = await resolvePositions(publicKey, APP_NETWORK, buildTxAddresses(process.env.DEFINDEX_VAULT_ID));
       reply.send({ positions });
     } catch (err) {
       app.log.error(err, "[positions] read failed");

--- a/packages/stellar-sdk-helpers/src/orchestration.test.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.test.ts
@@ -1,25 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { buildDepositTx, buildWithdrawTx, type ProtocolAddresses } from "./orchestration";
+import { buildDepositTx, buildWithdrawTx, resolvePositions, type ProtocolAddresses } from "./orchestration";
 import type { StellarNetwork } from "./types";
+import type { PositionInfo } from "./positions";
+
+const BLEND_USDC: PositionInfo = { vaultId: "blend-usdc-fixed", shares: 10, deposited: 10, earned: 0, entryTime: 0 };
+const DFX_USDC: PositionInfo = { vaultId: "defindex-usdc", shares: 5, deposited: 5, earned: 0, entryTime: 0 };
 
 vi.mock("./blend", () => ({
   blendAssetForVault: vi.fn((vaultId: string) => (vaultId.includes("-eurc") ? "eurc" : "usdc")),
   buildBlendDepositTx: vi.fn(async () => ({ xdr: "BLEND_DEPOSIT_XDR", fee: "200" })),
   buildBlendWithdrawTx: vi.fn(async () => ({ xdr: "BLEND_WITHDRAW_XDR", fee: "200" })),
+  fetchBlendPositions: vi.fn(async () => [BLEND_USDC]),
 }));
 
 vi.mock("./defindex", () => ({
   buildDefindexDepositTx: vi.fn(async () => ({ xdr: "DFX_DEPOSIT_XDR", fee: "300" })),
   buildDefindexWithdrawTx: vi.fn(async () => ({ xdr: "DFX_WITHDRAW_XDR", fee: "300" })),
+  fetchDefindexPosition: vi.fn(async () => [DFX_USDC]),
 }));
 
 import {
   buildBlendDepositTx,
   buildBlendWithdrawTx,
+  fetchBlendPositions,
 } from "./blend";
 import {
   buildDefindexDepositTx,
   buildDefindexWithdrawTx,
+  fetchDefindexPosition,
 } from "./defindex";
 
 const network: StellarNetwork = {
@@ -117,5 +125,35 @@ describe("buildWithdrawTx", () => {
     await expect(buildWithdrawTx("ondo-usdy", WALLET, "5", addresses, network)).rejects.toThrow(
       /No protocol mapping/
     );
+  });
+});
+
+describe("resolvePositions", () => {
+  it("calls fetchBlendPositions with the correct reserves and returns its result", async () => {
+    const positions = await resolvePositions(WALLET, network, addresses);
+    expect(fetchBlendPositions).toHaveBeenCalledWith(network, "CPOOL", WALLET, [
+      { assetId: "CUSDC", vaultId: "blend-usdc-fixed" },
+      { assetId: "CEURC", vaultId: "blend-eurc-fixed" },
+    ]);
+    expect(positions).toContainEqual(BLEND_USDC);
+  });
+
+  it("appends DeFindex positions when defindexVault is set", async () => {
+    const positions = await resolvePositions(WALLET, network, addresses);
+    expect(fetchDefindexPosition).toHaveBeenCalledWith(network, "CDFX", "defindex-usdc", WALLET);
+    expect(positions).toContainEqual(DFX_USDC);
+  });
+
+  it("skips DeFindex fetch when defindexVault is empty", async () => {
+    const noVault = { ...addresses, defindexVault: "" };
+    const positions = await resolvePositions(WALLET, network, noVault);
+    expect(fetchDefindexPosition).not.toHaveBeenCalled();
+    expect(positions).toEqual([BLEND_USDC]);
+  });
+
+  it("returns Blend positions even when the DeFindex fetch throws", async () => {
+    vi.mocked(fetchDefindexPosition).mockRejectedValueOnce(new Error("RPC down"));
+    const positions = await resolvePositions(WALLET, network, addresses);
+    expect(positions).toEqual([BLEND_USDC]);
   });
 });

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -1,7 +1,8 @@
-import { buildBlendDepositTx, buildBlendWithdrawTx, blendAssetForVault } from "./blend";
-import { buildDefindexDepositTx, buildDefindexWithdrawTx } from "./defindex";
+import { buildBlendDepositTx, buildBlendWithdrawTx, blendAssetForVault, fetchBlendPositions } from "./blend";
+import { buildDefindexDepositTx, buildDefindexWithdrawTx, fetchDefindexPosition } from "./defindex";
 import { toStroops, resolveProtocol } from "./tx";
 import type { StellarNetwork } from "./types";
+import type { PositionInfo } from "./positions";
 
 export interface ProtocolAddresses {
   blendPool: string;
@@ -33,6 +34,33 @@ export async function buildDepositTx(
     walletAddress,
     toStroops(amount)
   );
+}
+
+/**
+ * Fetches all positions for `publicKey` across Blend reserves and (optionally)
+ * the DeFindex vault. The DeFindex call is isolated — a failure there is logged
+ * and swallowed so the Blend positions are always returned.
+ */
+export async function resolvePositions(
+  publicKey: string,
+  network: StellarNetwork,
+  addresses: ProtocolAddresses,
+): Promise<PositionInfo[]> {
+  const positions = await fetchBlendPositions(network, addresses.blendPool, publicKey, [
+    { assetId: addresses.usdc, vaultId: "blend-usdc-fixed" },
+    { assetId: addresses.eurc, vaultId: "blend-eurc-fixed" },
+  ]);
+
+  if (addresses.defindexVault) {
+    try {
+      const dfx = await fetchDefindexPosition(network, addresses.defindexVault, "defindex-usdc", publicKey);
+      positions.push(...dfx);
+    } catch (err) {
+      console.warn("[positions] defindex read failed:", err);
+    }
+  }
+
+  return positions;
 }
 
 export async function buildWithdrawTx(


### PR DESCRIPTION
﻿## Summary

- Added `resolvePositions(publicKey, network, addresses)` to `packages/stellar-sdk-helpers/src/orchestration.ts`, consolidating the Blend reserve list, the DeFindex isolation try/catch, and the `defindexVaultId` lookup that were duplicated in both API layers
- Both the Vercel handler and Fastify route now delegate entirely to `resolvePositions`; their catch blocks only handle the outer 503 case

## Test plan

- [x] Four new `resolvePositions` tests in `orchestration.test.ts`: correct reserves passed to Blend, DeFindex appended when configured, DeFindex skipped when vault is empty, Blend positions returned when DeFindex throws
- [x] `handlers.test.ts` updated to mock `resolvePositions` instead of the lower-level `fetchBlendPositions`/`fetchDefindexPosition`
- [x] All 22 `@meridian/api-functions` tests pass; all 78 `@meridian/stellar-sdk-helpers` tests pass

Closes #179
