### PR TITLE
fix: add 8 s HTTP timeout to rpc.Server in fetchDefindexPosition

### DIFF
--- a/packages/stellar-sdk-helpers/src/defindex.test.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.test.ts
@@ -1,6 +1,24 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { buildDefindexDepositTx, buildDefindexWithdrawTx, stroopsToUnits, fetchDefindexPosition } from "./defindex";
 import type { StellarNetwork } from "./types";
+
+// Track rpc.Server constructor calls so we can assert on the timeout option.
+const capturedServerArgs: unknown[][] = [];
+vi.mock("@stellar/stellar-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@stellar/stellar-sdk")>();
+  return {
+    ...actual,
+    rpc: {
+      ...actual.rpc,
+      Server: class extends actual.rpc.Server {
+        constructor(...args: ConstructorParameters<typeof actual.rpc.Server>) {
+          capturedServerArgs.push(args);
+          super(...args);
+        }
+      },
+    },
+  };
+});
 
 vi.mock("./tx", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./tx")>();
@@ -55,6 +73,18 @@ describe("fetchDefindexPosition", () => {
   const PUBKEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
   beforeEach(() => vi.clearAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("constructs rpc.Server with an 8 s HTTP timeout", async () => {
+    vi.mocked(simulateView).mockResolvedValue(0n);
+    capturedServerArgs.length = 0;
+
+    await fetchDefindexPosition(network, VAULT_ID, "defindex-usdc", PUBKEY);
+
+    expect(capturedServerArgs).toHaveLength(1);
+    expect(capturedServerArgs[0][0]).toBe(network.rpcUrl);
+    expect(capturedServerArgs[0][1]).toMatchObject({ timeout: 8_000 });
+  });
 
   it("returns [] when the user holds zero shares", async () => {
     vi.mocked(simulateView).mockResolvedValue(0n);

--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -97,7 +97,7 @@ export async function fetchDefindexPosition(
   reportVaultId: string,
   publicKey: string
 ): Promise<PositionInfo[]> {
-  const server = new rpc.Server(network.rpcUrl);
+  const server = new rpc.Server(network.rpcUrl, { timeout: 8_000 });
   const caller = Address.fromString(publicKey).toScVal();
 
   const shares = toBigInt(


### PR DESCRIPTION
﻿## Summary

- Passed `{ timeout: 8_000 }` to the `rpc.Server` constructor in `fetchDefindexPosition`, matching the 8 s pattern already used by `AbortSignal.timeout(8_000)` in `defilamma.ts`
- The Blend path (`fetchBlendPositions`) already had a `withTimeout` wrapper — no change needed there
- The HTTP-level timeout fires at 8 s, giving the caller a clean rejection well before Vercel's 10 s function deadline

## Test plan

- [x] New test in `defindex.test.ts` captures `rpc.Server` constructor args via a module-level class override and asserts `{ timeout: 8_000 }` is passed
- [x] All 80 tests in `@meridian/stellar-sdk-helpers` pass

Closes #161
