### PR TITLE
docs: sync .env.example with current env var usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,9 @@
 # API
 PORT=3001
 ALLOWED_ORIGIN=http://localhost:3000
-STELLAR_NETWORK=testnet
 
-# Soroban contracts (testnet)
-VAULT_CONTRACT_ID=           # MeridianVault contract address on testnet
+# DeFindex vault contract address (C-address). Leave empty to disable DeFindex — only Blend positions are returned.
+DEFINDEX_VAULT_ID=
 
 # Web
 VITE_API_URL=http://localhost:3001
-VITE_STELLAR_NETWORK=testnet


### PR DESCRIPTION
## Summary

- Added `DEFINDEX_VAULT_ID` (was used in code but absent from the file)
- Removed `STELLAR_NETWORK`, `VAULT_CONTRACT_ID`, and `VITE_STELLAR_NETWORK` (not referenced anywhere in `api/`, `apps/`, or `packages/`)

Every key in the file now has a corresponding `process.env.*` or `import.meta.env.*` reference in the codebase, and every such reference has an entry in the file.

## Test plan

- [x] `grep -roh "process\.env\.[A-Z_]*\|import\.meta\.env\.[A-Z_]*" api/ apps/ packages/ --include="*.ts" --include="*.tsx" | sort -u` matches the keys in `.env.example`