### PR TITLE
docs: rewrite README roadmap and fix stale references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ Meridian is a **testnet technical preview**, not a finished product. Be clear-ey
 **Working today (testnet)**
 - Live APY / TVL feed across Stellar stablecoin pools (via DeFiLlama) with a risk heuristic
 - Non-custodial signing flow: the API builds an unsigned Soroban XDR, your wallet (Freighter) signs and submits it — keys never leave the browser
-- **Direct deposit / withdraw against a real Blend pool** (#4): funds supply straight into Blend from your wallet and the resulting bToken position is yours — no Meridian-controlled custody
+- **Direct deposit / withdraw against a real Blend pool**: funds supply straight into Blend from your wallet and the resulting bToken position is yours — no Meridian-controlled custody
 - Live position reads from the Blend pool and (when a DeFindex vault is configured) DeFindex vault — current supplied value
-- Best-rate routing (#6): the API recommends the highest-APY vault it can actually deposit into, skipping display-only protocols and pools flagged risky
-- `MeridianVault` Soroban contract (ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails) with unit tests — reserved for the v2 single-transaction rebalancing router (#8)
+- Best-rate routing: the API recommends the highest-APY vault it can actually deposit into, skipping display-only protocols and pools flagged risky
+- `MeridianVault` Soroban contract (ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails) with unit tests — reserved for the v2 single-transaction rebalancing router
 
 **In progress — the core promise is not finished**
-- Direct deposit/withdraw against real DeFindex vaults (#5) — *transaction builders are implemented locally (no hosted API); gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired*
+
+- Direct deposit/withdraw against real DeFindex vaults — *transaction builders are implemented; gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired*
 - Per-position yield earned (cost-basis tracking for direct Blend/DeFindex positions)
 - Mainnet configuration and a security audit before any real-funds use
 
-Until a DeFindex vault is configured, DeFindex routes return `501` rather than silently routing elsewhere. Track progress in the [Roadmap](#roadmap) and [open issues](../../issues).
+Until a DeFindex vault is configured, the DeFindex deposit path throws a configuration error rather than silently routing elsewhere. Track progress in the [Roadmap](#roadmap) and [open issues](../../issues).
 
 ---
 
@@ -40,8 +41,10 @@ Inflation in many West African economies regularly exceeds 20 % annually. Access
 ```text
 meridian/
 ├── apps/
-│   ├── web/          # Vite + React 18 dashboard (TypeScript, Tailwind, Zustand)
-│   └── api/          # Fastify REST API (local dev): builds Soroban txs, aggregates APY
+│   ├── web/          # Vite + React 19 dashboard (TypeScript, Tailwind, Zustand)
+│   ├── api/          # Fastify REST API (local dev): builds Soroban txs, aggregates APY
+│   ├── docs/         # Internal architecture and operations docs
+│   └── landing/      # Marketing landing page
 ├── packages/
 │   ├── stellar-sdk-helpers/  # Blend & DeFindex client wrappers
 │   ├── shared/               # Zod schemas, constants, pure utils
@@ -73,7 +76,7 @@ The API never holds private keys. It builds an unsigned Soroban transaction, ret
 
 | Layer | Technology |
 | --- | --- |
-| Frontend | Vite 5, React 18, Tailwind CSS, Zustand, TanStack Query |
+| Frontend | Vite 8, React 19, Tailwind CSS, Zustand, TanStack Query |
 | Backend (prod) | Vercel Serverless Functions, Zod validation |
 | Backend (local) | Fastify |
 | Blockchain | Stellar Soroban, `@stellar/stellar-sdk` v12 |
@@ -154,7 +157,7 @@ We welcome contributions. See [open issues](../../issues) for a range of tasks a
 3. Run `pnpm lint && pnpm typecheck && pnpm test` before opening a PR
 4. Reference the relevant GitHub issue in your PR description
 
-Issues are tagged `good first issue`, `medium`, and `hard`, and carry the `Stellar Wave` label. Pick your level.
+Issues are tagged `good first issue`, `medium`, and `hard`. Pick your level.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pnpm install
 
 ```bash
 cp .env.example .env
-# Edit .env: set STELLAR_NETWORK=testnet for local dev
+# Set DEFINDEX_VAULT_ID if you have a DeFindex vault configured; leave empty otherwise
 ```
 
 ### Run locally
@@ -160,15 +160,21 @@ Issues are tagged `good first issue`, `medium`, and `hard`, and carry the `Stell
 
 ## Roadmap
 
-- [ ] Freighter wallet integration (#2)
-- [ ] Live Blend pool APY (#4)
-- [ ] Live DeFindex vault APY (#5)
-- [ ] APY aggregation + best-rate routing API (#6)
-- [ ] Unsigned Soroban deposit/withdraw TX builder (#7)
-- [ ] Yield history chart (#9)
-- [ ] Mobile-first responsive layout (#1)
-- [ ] Soroban router contract for single-tx rebalancing (#8)
-- [ ] Multi-language support: English + French (#10)
+### Q2 2026: Deposit, withdraw and earn (testnet)
+
+Non-custodial USDC deposits into Blend and DeFindex vaults on Stellar testnet. Freighter wallet connects in one click, the best-rate vault is selected automatically, and the signed transaction never leaves the browser. Live APY and TVL across protocols with risk-tier labelling. Withdraw at any time, no lock-up.
+
+### Q3 2026: Yield tracking and position history
+
+Per-position yield tracking with a cost-basis model so users see their actual earnings, not just current balance. A yield history chart broken down by protocol, entry time, and cumulative earned. Position-level analytics that work whether funds are in Blend, DeFindex, or split across both.
+
+### Q4 2026: Atomic rebalancing
+
+A Soroban router contract that rebalances between vaults in one atomic transaction. No manual withdraw-then-deposit cycle: when a better rate appears, funds move in a single ledger close. Auto-rebalancing triggers with user-defined APY thresholds. The groundwork for supporting new protocols without UI changes.
+
+### Q1 2027: Mainnet and scale
+
+Third-party security audit, mainnet deployment, and a production-grade rate-limit and caching layer that handles real user load. French and English localisation to open the product to West African users who are not comfortable in English. Mobile-first UI pass targeting low-end Android devices common in the target market.
 
 ---
 


### PR DESCRIPTION
## Summary

- Rewrote roadmap section as quarterly product milestones (Q2 2026 through Q1 2027) instead of an atomic implementation task list with stale issue numbers
- Fixed stale tech stack versions: Vite 5 + React 18 -> Vite 8 + React 19
- Added missing `apps/docs` and `apps/landing` to the architecture diagram
- Removed stale GitHub issue refs (`#4`, `#5`, `#6`, `#8`) from Project status — those numbers no longer match the actual issues
- Fixed false claim that DeFindex returns `501` when unconfigured (it throws a 500 configuration error)
- Removed non-existent `Stellar Wave` GitHub label from Contributing section
- Updated Configure section comment to reference `DEFINDEX_VAULT_ID` instead of the removed `STELLAR_NETWORK`

## Test plan

- [x] Read through the full README and verify every factual claim against the codebase
- [x] Confirm no markdownlint warnings remain