### PR TITLE
fix: harden Soroban RPC timeouts on the write path

### DIFF
--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -106,7 +106,7 @@ export async function prepareSorobanTx(
   op: xdr.Operation
 ): Promise<{ xdr: string; fee: string }> {
   const passphrase = passphraseFor(network);
-  const server = new rpc.Server(network.rpcUrl);
+  const server = new rpc.Server(network.rpcUrl, { timeout: 8_000 });
   const account = await withRetry(() => withSorobanTimeout(() => server.getAccount(caller)));
   const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
     .addOperation(op)
@@ -192,7 +192,7 @@ export async function waitForTransaction(
   const deadline = now() + timeoutMs;
 
   for (;;) {
-    const res = await server.getTransaction(hash);
+    const res = await withSorobanTimeout(() => server.getTransaction(hash));
     if (res.status === rpc.Api.GetTransactionStatus.SUCCESS) return res;
     if (res.status === rpc.Api.GetTransactionStatus.FAILED) {
       throw new Error(`Transaction ${hash} failed on-chain`);
@@ -234,7 +234,7 @@ export async function submitTx(
   opts: ConfirmOptions = {}
 ): Promise<SubmitResult> {
   const passphrase = passphraseFor(network);
-  const server = new rpc.Server(network.rpcUrl);
+  const server = new rpc.Server(network.rpcUrl, { timeout: 8_000 });
   const tx = TransactionBuilder.fromXDR(signedXdr, passphrase);
 
   const sent = await withSorobanTimeout(() => server.sendTransaction(tx));


### PR DESCRIPTION
## Summary

- \`prepareSorobanTx\` and \`submitTx\` now pass \`{ timeout: 8_000 }\` to \`rpc.Server\`, matching the fix already applied to \`fetchDefindexPosition\` in \`defindex.ts\`; the SDK wires an abort signal into the underlying fetch so the connection is actually closed when the timeout fires
- \`getTransaction\` inside \`waitForTransaction\` is now wrapped in \`withSorobanTimeout\`, consistent with every other RPC call in the file; previously a hung HTTP response could block the polling loop indefinitely past the 60 s wall-clock deadline
- With the HTTP-layer abort in place, \`withRetry\` retrying on timeout no longer leaks in-flight connections

## Test plan

- [x] \`pnpm --filter @meridian/stellar-sdk-helpers test\` passes (79 tests)
- [x] \`pnpm typecheck\` passes

Closes #226
Closes #227
Closes #228