### PR TITLE
fix: skip timeout errors in withRetry via shouldRetry predicate

### DIFF
--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -77,4 +77,29 @@ describe("withRetry", () => {
     await assertion;
     expect(fn).toHaveBeenCalledTimes(1);
   });
+
+  it("stops after first failure when shouldRetry returns false", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("timeout"));
+    const shouldRetry = vi.fn().mockReturnValue(false);
+    const promise = withRetry(fn, 3, 0, shouldRetry);
+    const assertion = expect(promise).rejects.toThrow("timeout");
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(shouldRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries transient errors but not excluded error types", async () => {
+    class TimeoutError extends Error {}
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockRejectedValueOnce(new TimeoutError("deadline"))
+      .mockResolvedValue("ok");
+    const promise = withRetry(fn, 3, 0, (err) => !(err instanceof TimeoutError));
+    const assertion = expect(promise).rejects.toBeInstanceOf(TimeoutError);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -26,11 +26,16 @@ export function isValidStellarAddress(key: string): boolean {
 /**
  * Retries `fn` up to `maxAttempts` times with exponential backoff starting at
  * `baseDelayMs`. Throws the last error when all attempts are exhausted.
+ *
+ * Pass `shouldRetry` to exclude certain errors from the retry loop — for
+ * example, to avoid retrying a deadline-exceeded error while the previous
+ * in-flight request is still running.
  */
 export async function withRetry<T>(
   fn: () => Promise<T>,
   maxAttempts = 3,
-  baseDelayMs = 200
+  baseDelayMs = 200,
+  shouldRetry: (err: unknown) => boolean = () => true
 ): Promise<T> {
   let lastErr: unknown;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -38,8 +43,10 @@ export async function withRetry<T>(
       return await fn();
     } catch (err) {
       lastErr = err;
-      if (attempt < maxAttempts - 1) {
+      if (attempt < maxAttempts - 1 && shouldRetry(err)) {
         await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+      } else {
+        break;
       }
     }
   }

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -20,11 +20,18 @@ import { buildHorizonServer } from "./horizon";
 // the Vercel function-level deadline fires.
 const SOROBAN_RPC_TIMEOUT_MS = 10_000;
 
+export class SorobanTimeoutError extends Error {
+  constructor(ms: number) {
+    super(`Soroban RPC timed out after ${ms}ms`);
+    this.name = "SorobanTimeoutError";
+  }
+}
+
 function withSorobanTimeout<T>(fn: () => Promise<T>, ms = SOROBAN_RPC_TIMEOUT_MS): Promise<T> {
   return Promise.race([
     fn(),
     new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`Soroban RPC timed out after ${ms}ms`)), ms)
+      setTimeout(() => reject(new SorobanTimeoutError(ms)), ms)
     ),
   ]);
 }
@@ -107,7 +114,12 @@ export async function prepareSorobanTx(
 ): Promise<{ xdr: string; fee: string }> {
   const passphrase = passphraseFor(network);
   const server = new rpc.Server(network.rpcUrl, { timeout: 8_000 });
-  const account = await withRetry(() => withSorobanTimeout(() => server.getAccount(caller)));
+  const account = await withRetry(
+    () => withSorobanTimeout(() => server.getAccount(caller)),
+    3,
+    200,
+    (err) => !(err instanceof SorobanTimeoutError)
+  );
   const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
     .addOperation(op)
     .setTimeout(300)


### PR DESCRIPTION
## Summary

- Added `shouldRetry: (err: unknown) => boolean` parameter to `withRetry` in `packages/shared` (default `() => true`, fully backward-compatible)
- Added `SorobanTimeoutError` class in `tx.ts` -- `withSorobanTimeout` now throws it instead of a generic `Error`, making timeout rejections identifiable by type
- Updated the `prepareSorobanTx` call site to pass `(err) => !(err instanceof SorobanTimeoutError)` so `withRetry` does not retry on deadline-exceeded errors
- Added two new tests covering the `shouldRetry` predicate in `utils.test.ts`

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `withRetry` exits immediately on `SorobanTimeoutError` without issuing a second attempt
- [x] Existing retry behavior on transient errors is unchanged (all 12 tests in `utils.test.ts` pass)

Closes #232