### PR TITLE
fix: clear timeout handle on resolve and consolidate withRaceTimeout

### DIFF
--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { withRetry, sanitizeTxError } from "./utils";
+import { withRetry, withRaceTimeout, sanitizeTxError } from "./utils";
 
 describe("sanitizeTxError", () => {
   it("returns the fallback for non-Error values", () => {
@@ -76,5 +76,40 @@ describe("withRetry", () => {
     await vi.runAllTimersAsync();
     await assertion;
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withRaceTimeout", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("resolves with fn's value when fn completes before the timeout", async () => {
+    const fn = vi.fn().mockResolvedValue("result");
+    const result = await withRaceTimeout(fn, 1_000, "test");
+    expect(result).toBe("result");
+  });
+
+  it("rejects with a timeout error when fn does not complete in time", async () => {
+    const fn = vi.fn().mockImplementation(() => new Promise(() => {}));
+    const promise = withRaceTimeout(fn, 500, "test op");
+    const assertion = expect(promise).rejects.toThrow("test op timed out after 500ms");
+    await vi.runAllTimersAsync();
+    await assertion;
+  });
+
+  it("clears the timeout handle when fn resolves so no lingering timer fires", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    const fn = vi.fn().mockResolvedValue("ok");
+    await withRaceTimeout(fn, 1_000, "test");
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
+  });
+
+  it("clears the timeout handle when fn rejects", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    const fn = vi.fn().mockRejectedValue(new Error("boom"));
+    await expect(withRaceTimeout(fn, 1_000, "test")).rejects.toThrow("boom");
+    expect(clearSpy).toHaveBeenCalled();
+    clearSpy.mockRestore();
   });
 });

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -24,6 +24,20 @@ export function isValidStellarAddress(key: string): boolean {
 }
 
 /**
+ * Races `fn` against a timeout. Clears the timer if `fn` resolves first so no
+ * handle lingers in the event loop after a successful call.
+ */
+export function withRaceTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const handle = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    fn().then(
+      (val) => { clearTimeout(handle); resolve(val); },
+      (err) => { clearTimeout(handle); reject(err); }
+    );
+  });
+}
+
+/**
  * Retries `fn` up to `maxAttempts` times with exponential backoff starting at
  * `baseDelayMs`. Throws the last error when all attempts are exhausted.
  */

--- a/packages/stellar-sdk-helpers/src/blend.ts
+++ b/packages/stellar-sdk-helpers/src/blend.ts
@@ -1,6 +1,6 @@
 import { xdr } from "@stellar/stellar-sdk";
 import { PoolContractV2, PoolV2, RequestType } from "@blend-capital/blend-sdk";
-import { withRetry } from "@meridian/shared";
+import { withRetry, withRaceTimeout } from "@meridian/shared";
 import { prepareSorobanTx } from "./tx";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
@@ -11,14 +11,8 @@ const BLEND_RPC_TIMEOUT_MS = 10_000;
 // manual timeout rejection. The underlying fetch will still complete, but the
 // caller gets a fast failure it can retry rather than waiting for Vercel's
 // function-level deadline.
-function withTimeout<T>(fn: () => Promise<T>, ms = BLEND_RPC_TIMEOUT_MS): Promise<T> {
-  return Promise.race([
-    fn(),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`Blend RPC timed out after ${ms}ms`)), ms)
-    ),
-  ]);
-}
+const withBlendTimeout = <T>(fn: () => Promise<T>, ms = BLEND_RPC_TIMEOUT_MS) =>
+  withRaceTimeout(fn, ms, "Blend RPC");
 
 export interface BlendPoolConfig {
   // Blend pool contract (C...) the request is submitted to.
@@ -113,9 +107,9 @@ export async function fetchBlendPositions(
   reserves: BlendReserveRef[]
 ): Promise<PositionInfo[]> {
   const pool = await withRetry(() =>
-    withTimeout(() => PoolV2.load({ rpc: network.rpcUrl, passphrase: network.passphrase }, poolId))
+    withBlendTimeout(() => PoolV2.load({ rpc: network.rpcUrl, passphrase: network.passphrase }, poolId))
   );
-  const user = await withRetry(() => withTimeout(() => pool.loadUser(publicKey)));
+  const user = await withRetry(() => withBlendTimeout(() => pool.loadUser(publicKey)));
 
   const positions: PositionInfo[] = [];
   for (const { assetId, vaultId } of reserves) {

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -11,7 +11,7 @@ import {
 } from "@stellar/stellar-sdk";
 import type { StellarNetwork } from "./types";
 import { BASE_FEE, passphraseFor } from "./internal";
-import { withRetry } from "@meridian/shared";
+import { withRetry, withRaceTimeout } from "@meridian/shared";
 import { buildHorizonServer } from "./horizon";
 
 // The Soroban RPC SDK does not surface an AbortSignal option, so we race each
@@ -20,14 +20,8 @@ import { buildHorizonServer } from "./horizon";
 // the Vercel function-level deadline fires.
 const SOROBAN_RPC_TIMEOUT_MS = 10_000;
 
-function withSorobanTimeout<T>(fn: () => Promise<T>, ms = SOROBAN_RPC_TIMEOUT_MS): Promise<T> {
-  return Promise.race([
-    fn(),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error(`Soroban RPC timed out after ${ms}ms`)), ms)
-    ),
-  ]);
-}
+const withSorobanTimeout = <T>(fn: () => Promise<T>, ms = SOROBAN_RPC_TIMEOUT_MS) =>
+  withRaceTimeout(fn, ms, "Soroban RPC");
 
 const USDC_ISSUER: Record<string, string> = {
   testnet: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",


### PR DESCRIPTION
## Summary

- Extracts a single `withRaceTimeout` helper in `packages/shared` that properly calls `clearTimeout` on both resolve and reject paths, eliminating the timer leak present in the old `Promise.race` pattern
- Replaces the duplicate `withSorobanTimeout` in `tx.ts` and `withTimeout` in `blend.ts` with thin wrappers over `withRaceTimeout`, removing the two independent copies of the same leaky implementation
- Adds four tests for `withRaceTimeout` covering the happy path, timeout path, and clearTimeout-on-resolve/reject behavior

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `pnpm --filter @meridian/shared run test` shows 14 passing (4 new)
- [x] `pnpm --filter @meridian/stellar-sdk-helpers run test` shows 80 passing

Closes #233