### PR TITLE
test: fix no-op restoreAllMocks and move capturedServerArgs reset to beforeEach

### DIFF
--- a/packages/stellar-sdk-helpers/src/defindex.test.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.test.ts
@@ -72,12 +72,13 @@ describe("fetchDefindexPosition", () => {
   const VAULT_ID = "CVAULT000000000000000000000000000000000000000000000000000";
   const PUBKEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
-  beforeEach(() => vi.clearAllMocks());
-  afterEach(() => vi.restoreAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedServerArgs.length = 0;
+  });
 
   it("constructs rpc.Server with an 8 s HTTP timeout", async () => {
     vi.mocked(simulateView).mockResolvedValue(0n);
-    capturedServerArgs.length = 0;
 
     await fetchDefindexPosition(network, VAULT_ID, "defindex-usdc", PUBKEY);
 


### PR DESCRIPTION
## Summary

- Removes `vi.restoreAllMocks()` from `afterEach` in `defindex.test.ts`; it has no effect on mocks created with `vi.mock()` factories and created a false impression of cleanup between tests
- Moves `capturedServerArgs.length = 0` from inside the first test body into `beforeEach` so the array is always cleared before each test regardless of execution order, fixing ordering fragility under `--sequence.randomize`

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `pnpm --filter @meridian/stellar-sdk-helpers run test -- --sequence.randomize` passes

Closes #237