### PR TITLE
fix: raise DeFindex rpc.Server timeout above withSorobanTimeout so outer race fires first

### DIFF
--- a/packages/stellar-sdk-helpers/src/defindex.test.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.test.ts
@@ -75,7 +75,7 @@ describe("fetchDefindexPosition", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => vi.restoreAllMocks());
 
-  it("constructs rpc.Server with an 8 s HTTP timeout", async () => {
+  it("constructs rpc.Server with a 12 s HTTP timeout so the outer race fires first", async () => {
     vi.mocked(simulateView).mockResolvedValue(0n);
     capturedServerArgs.length = 0;
 
@@ -83,7 +83,7 @@ describe("fetchDefindexPosition", () => {
 
     expect(capturedServerArgs).toHaveLength(1);
     expect(capturedServerArgs[0][0]).toBe(network.rpcUrl);
-    expect(capturedServerArgs[0][1]).toMatchObject({ timeout: 8_000 });
+    expect(capturedServerArgs[0][1]).toMatchObject({ timeout: 12_000 });
   });
 
   it("returns [] when the user holds zero shares", async () => {

--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -97,7 +97,7 @@ export async function fetchDefindexPosition(
   reportVaultId: string,
   publicKey: string
 ): Promise<PositionInfo[]> {
-  const server = new rpc.Server(network.rpcUrl, { timeout: 8_000 });
+  const server = new rpc.Server(network.rpcUrl, { timeout: 12_000 });
   const caller = Address.fromString(publicKey).toScVal();
 
   const shares = toBigInt(


### PR DESCRIPTION
## Summary

- Changes the `rpc.Server` HTTP timeout in `fetchDefindexPosition` from `8_000` to `12_000` ms so the SDK-level AbortSignal fires at 12 s, after the `withSorobanTimeout` race at 10 s
- Previously the SDK aborted at 8 s with an opaque Axios/fetch error before the outer race could produce the readable `"Soroban RPC timed out after 10000ms"` message
- Updates the test assertion to match the new value and clarifies why the timeout must exceed `withSorobanTimeout`

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `pnpm --filter @meridian/stellar-sdk-helpers run test` shows 80 passing

Closes #235