### PR TITLE
fix: rethrow DeFindex errors in resolvePositions instead of returning partial data

### DIFF
--- a/packages/stellar-sdk-helpers/src/orchestration.test.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.test.ts
@@ -151,9 +151,8 @@ describe("resolvePositions", () => {
     expect(positions).toEqual([BLEND_USDC]);
   });
 
-  it("returns Blend positions even when the DeFindex fetch throws", async () => {
+  it("propagates DeFindex fetch errors to the caller", async () => {
     vi.mocked(fetchDefindexPosition).mockRejectedValueOnce(new Error("RPC down"));
-    const positions = await resolvePositions(WALLET, network, addresses);
-    expect(positions).toEqual([BLEND_USDC]);
+    await expect(resolvePositions(WALLET, network, addresses)).rejects.toThrow("RPC down");
   });
 });

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -38,8 +38,7 @@ export async function buildDepositTx(
 
 /**
  * Fetches all positions for `publicKey` across Blend reserves and (optionally)
- * the DeFindex vault. The DeFindex call is isolated — a failure there is logged
- * and swallowed so the Blend positions are always returned.
+ * the DeFindex vault. Errors from either protocol propagate to the caller.
  */
 export async function resolvePositions(
   publicKey: string,
@@ -52,12 +51,8 @@ export async function resolvePositions(
   ]);
 
   if (addresses.defindexVault) {
-    try {
-      const dfx = await fetchDefindexPosition(network, addresses.defindexVault, "defindex-usdc", publicKey);
-      positions.push(...dfx);
-    } catch (err) {
-      console.warn("[positions] defindex read failed:", err);
-    }
+    const dfx = await fetchDefindexPosition(network, addresses.defindexVault, "defindex-usdc", publicKey);
+    positions.push(...dfx);
   }
 
   return positions;


### PR DESCRIPTION
## Summary

- Removes the `try/catch` that swallowed `fetchDefindexPosition` errors in `resolvePositions`, replacing it with a direct `await`
- Previously a DeFindex RPC failure returned HTTP 200 with only Blend positions and no signal that data was missing; now the error propagates and the API route's existing `try/catch` returns 503
- Updates the orchestration test to assert the error propagates instead of asserting it was swallowed

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `pnpm --filter @meridian/stellar-sdk-helpers run test` shows 80 passing
- [x] Manually verify that a DeFindex RPC failure returns 503 from the positions endpoint instead of a silent 200

Closes #234