### PR TITLE
fix: derive defindexVaultId from ProtocolAddresses instead of hardcoding defindex-usdc

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -42,12 +42,13 @@ export const APP_NETWORK = STELLAR_NETWORKS.testnet;
 export const APP_ADDRESSES = CONTRACT_ADDRESSES.testnet;
 
 /** Build the ProtocolAddresses object consumed by stellar-sdk-helpers, allowing
- *  the DeFindex vault id to be overridden at runtime via DEFINDEX_VAULT_ID. */
+ *  the DeFindex vault contract address to be overridden at runtime via DEFINDEX_VAULT_ID. */
 export function buildTxAddresses(defindexOverride?: string) {
   return {
     blendPool: APP_ADDRESSES.blend.pool,
     usdc: APP_ADDRESSES.usdc,
     eurc: APP_ADDRESSES.eurc,
     defindexVault: defindexOverride ?? APP_ADDRESSES.defindex.vault,
+    defindexVaultId: "defindex-usdc",
   };
 }

--- a/packages/stellar-sdk-helpers/src/orchestration.test.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.test.ts
@@ -41,6 +41,7 @@ const addresses: ProtocolAddresses = {
   usdc: "CUSDC",
   eurc: "CEURC",
   defindexVault: "CDFX",
+  defindexVaultId: "defindex-usdc",
 };
 
 const WALLET = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -9,6 +9,7 @@ export interface ProtocolAddresses {
   usdc: string;
   eurc: string;
   defindexVault: string;
+  defindexVaultId: string;
 }
 
 export async function buildDepositTx(
@@ -53,7 +54,7 @@ export async function resolvePositions(
 
   if (addresses.defindexVault) {
     try {
-      const dfx = await fetchDefindexPosition(network, addresses.defindexVault, "defindex-usdc", publicKey);
+      const dfx = await fetchDefindexPosition(network, addresses.defindexVault, addresses.defindexVaultId, publicKey);
       positions.push(...dfx);
     } catch (err) {
       console.warn("[positions] defindex read failed:", err);


### PR DESCRIPTION
## Summary

- Adds `defindexVaultId: string` to the `ProtocolAddresses` interface in `orchestration.ts` so the vault ID is passed in alongside the contract address rather than hardcoded at the call site
- Updates `buildTxAddresses` in `packages/shared/src/constants.ts` to include `defindexVaultId: "defindex-usdc"` so callers get the right default without touching orchestration code
- Removes the `"defindex-usdc"` string literal from `resolvePositions`; adding a second DeFindex vault now only requires a change to `buildTxAddresses`, not a hunt through orchestration logic

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `pnpm --filter @meridian/stellar-sdk-helpers run test` shows 80 passing
- [x] `pnpm --filter @meridian/api exec tsc --noEmit` passes

Closes #236