### PR TITLE
docs: add JSDoc to all undocumented exported functions in stellar-sdk-helpers

### DIFF
--- a/packages/stellar-sdk-helpers/src/blend.ts
+++ b/packages/stellar-sdk-helpers/src/blend.ts
@@ -28,9 +28,10 @@ export interface BlendPoolConfig {
   network: StellarNetwork;
 }
 
-// Map a Meridian vault id (e.g. "blend-usdc-fixed") to the reserve asset whose
-// Stellar Asset Contract the deposit supplies. Pure so the routing is testable
-// without touching the network.
+/**
+ * Map a Meridian vault ID (e.g. "blend-usdc-fixed") to the reserve asset whose
+ * Stellar Asset Contract the deposit supplies. Pure function, no I/O.
+ */
 export function blendAssetForVault(vaultId: string): "usdc" | "eurc" {
   if (vaultId.includes("-usdc")) return "usdc";
   if (vaultId.includes("-eurc")) return "eurc";

--- a/packages/stellar-sdk-helpers/src/defilamma.ts
+++ b/packages/stellar-sdk-helpers/src/defilamma.ts
@@ -48,6 +48,10 @@ const POOLS_URL = "https://yields.llama.fi/pools";
 const MIN_TVL_USD = 1_000;
 const MIN_APY = 0.01;
 
+/**
+ * Fetch all Stellar stablecoin pools from DeFiLlama and return the ones that
+ * meet the minimum TVL and APY thresholds. Retries up to 3 times on failure.
+ */
 export async function getStellarStablecoinPools(): Promise<DefiLlamaPool[]> {
   return withRetry(async () => {
     const res = await fetch(POOLS_URL, { signal: AbortSignal.timeout(8_000) });

--- a/packages/stellar-sdk-helpers/src/horizon.ts
+++ b/packages/stellar-sdk-helpers/src/horizon.ts
@@ -1,6 +1,7 @@
 import { Horizon } from "@stellar/stellar-sdk";
 import type { StellarNetwork } from "./types";
 
+/** Construct a Horizon.Server pointed at the correct URL for the given network. */
 export function buildHorizonServer(config: StellarNetwork): Horizon.Server {
   const urls: Record<StellarNetwork["network"], string> = {
     mainnet: "https://horizon.stellar.org",

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -11,6 +11,12 @@ export interface ProtocolAddresses {
   defindexVault: string;
 }
 
+/**
+ * Build an unsigned deposit transaction for the vault identified by `vaultId`.
+ * Routes to Blend or DeFindex based on the vault ID prefix and returns the
+ * unsigned XDR and estimated fee. Throws if the vault protocol is unrecognised
+ * or the required contract address is not configured.
+ */
 export async function buildDepositTx(
   vaultId: string,
   walletAddress: string,
@@ -63,6 +69,12 @@ export async function resolvePositions(
   return positions;
 }
 
+/**
+ * Build an unsigned withdrawal transaction for the vault identified by `vaultId`.
+ * `shares` is the protocol share count to burn: bToken collateral for Blend,
+ * dfToken count for DeFindex. Routes and throws on the same conditions as
+ * `buildDepositTx`.
+ */
 export async function buildWithdrawTx(
   vaultId: string,
   walletAddress: string,

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -69,18 +69,25 @@ function hasAssetTrustline(
   );
 }
 
+/** Convert a decimal string (up to 7 fractional digits) to stroops as a bigint. */
 export function toStroops(value: string): bigint {
   const [whole = "0", frac = ""] = value.split(".");
   const fracPadded = frac.padEnd(7, "0").slice(0, 7);
   return BigInt(whole) * 10_000_000n + BigInt(fracPadded);
 }
 
+/** Resolve the protocol name ("Blend" or "DeFindex") from a vault ID prefix. Throws for unrecognised prefixes. */
 export function resolveProtocol(vaultId: string): "Blend" | "DeFindex" {
   if (vaultId.startsWith("blend-")) return "Blend";
   if (vaultId.startsWith("defindex-")) return "DeFindex";
   throw new Error(`No protocol mapping for vault: ${vaultId}`);
 }
 
+/**
+ * Execute a read-only Soroban contract call via simulation and return the
+ * decoded native value. Returns `null` when the simulation succeeds but
+ * produces no return value. Throws on simulation errors.
+ */
 export async function simulateView(
   server: rpc.Server,
   contractId: string,
@@ -100,6 +107,11 @@ export async function simulateView(
   return scValToNative(sim.result.retval);
 }
 
+/**
+ * Fetch the caller's account, simulate the operation to obtain the resource
+ * footprint and fee, assemble the transaction, and return the unsigned XDR
+ * and minimum resource fee. Throws if simulation fails.
+ */
 export async function prepareSorobanTx(
   network: StellarNetwork,
   caller: string,
@@ -118,6 +130,11 @@ export async function prepareSorobanTx(
   return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
 }
 
+/**
+ * Build an unsigned Stellar transaction that adds USDC and mUSDC trustlines
+ * for `walletAddress`. Skips any trustline that already exists. Throws if all
+ * required trustlines are already present.
+ */
 export async function buildAddTrustlineTx(
   walletAddress: string,
   network: StellarNetwork
@@ -205,9 +222,11 @@ export async function waitForTransaction(
   }
 }
 
-// Soroban simulation errors can be multi-line diagnostics. The first line is
-// the actionable summary (e.g. "HostError: Error(Contract, #1)"); subsequent
-// lines are stack frames that belong in server logs, not user-facing messages.
+/**
+ * Extract the first-line summary from a Soroban simulation error string.
+ * Subsequent lines are stack frames that belong in logs, not user-facing
+ * messages. Returns a generic fallback when the string is empty.
+ */
 export function simErrorMessage(raw: string): string {
   return raw.split("\n")[0].trim() || "Simulation failed (no detail)";
 }

--- a/packages/stellar-sdk-helpers/src/vaults.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.ts
@@ -29,9 +29,11 @@ export function isVaultCacheWarm(): boolean {
   return vaultCache !== null && Date.now() < vaultCache.expiresAt;
 }
 
-// Every vault in the list is backed by live DeFiLlama market data. Protocols
-// without a real on-chain rate feed wired up yet are intentionally omitted
-// rather than shown with placeholder figures.
+/**
+ * Fetch vaults from DeFiLlama and return those backed by known on-chain pools.
+ * Results are cached for 60 s. If DeFiLlama returns no usable pools, the
+ * previous cache is served rather than returning an empty list.
+ */
 export async function fetchAllVaults(): Promise<ApiVault[]> {
   const now = Date.now();
   if (vaultCache && now < vaultCache.expiresAt) return vaultCache.vaults;


### PR DESCRIPTION
## Summary

- Adds JSDoc to 12 exported functions across `blend.ts`, `defilamma.ts`, `horizon.ts`, `orchestration.ts`, `tx.ts`, and `vaults.ts` that previously had no documentation
- Every function now has a one-paragraph summary covering what it does, key preconditions, and what it throws or returns in the non-obvious cases
- No behaviour changes; all existing tests pass

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `pnpm --filter @meridian/stellar-sdk-helpers exec tsc --noEmit` reports zero errors

Closes #221