### PR TITLE
docs: fix stale and inaccurate content across architecture and operations pages

### DIFF
--- a/apps/docs/architecture/api.md
+++ b/apps/docs/architecture/api.md
@@ -29,12 +29,13 @@ Returns all available vaults with live APY and TVL.
       "riskLevel": "safe"
     }
   ],
+  "recommendedVaultId": "blend-usdc-variable",
   "updatedAt": "2026-05-26T12:00:00.000Z",
   "cached": false
 }
 ```
 
-APY data is sourced from DeFiLlama's `/pools` endpoint filtered to Stellar stablecoins. Pools are matched against a curated registry (`known-pools.ts`) that maps DeFiLlama pool UUIDs to protocol metadata.
+APY data is sourced from DeFiLlama's `/pools` endpoint filtered to Stellar stablecoins. Pools are matched against a curated registry (`known-pools.ts`) that maps DeFiLlama pool UUIDs to protocol metadata. `recommendedVaultId` is the vault with the highest APY, or `null` if none qualifies.
 
 ### `GET /api/v1/vaults/:vaultId`
 
@@ -99,6 +100,20 @@ Builds an unsigned Soroban withdraw transaction.
 
 **Response:** same shape as deposit: `{ xdr, fee }`.
 
+### `POST /api/v1/tx/add-trustline`
+
+Builds an unsigned transaction that adds the mUSDC trustline to the caller's account. Must be submitted before a first deposit.
+
+**Request**
+```json
+{ "walletAddress": "G..." }
+```
+
+**Response**
+```json
+{ "xdr": "AAAAAgAAAAA..." }
+```
+
 ### `POST /api/v1/tx/submit`
 
 Submits a Freighter-signed XDR to the Stellar network.
@@ -117,9 +132,11 @@ A `PENDING` or `DUPLICATE` status from the Stellar RPC is treated as success and
 
 ## Serverless vs Fastify
 
-The Vercel serverless functions (`api/v1/`) cannot import from workspace packages (`@meridian/shared`, `@meridian/stellar-sdk-helpers`). All logic is inlined in `_shared.ts` files alongside each route group. This constraint was introduced to avoid build-time workspace resolution issues on Vercel.
+Both implementations share the same handler logic and import from the same workspace packages (`@meridian/shared`, `@meridian/stellar-sdk-helpers`).
 
-The Fastify server (`apps/api/`) has no such restriction and imports freely from workspace packages. It is only used during local development.
+The Vercel functions (`api/v1/`) import workspace packages that are pre-built into self-contained JS bundles by `scripts/build-vercel.sh` before deployment. The build script runs esbuild on each package's entry point with `--bundle --packages=external`, inlining all relative imports while leaving npm packages external. Vercel then bundles the resulting `dist/index.js` files alongside the function handlers at deploy time.
+
+The Fastify server (`apps/api/`) runs the same packages directly via `tsx`, which handles TypeScript natively in the development process.
 
 ## Vault ID to protocol mapping
 
@@ -130,4 +147,4 @@ When building a deposit transaction, the `vaultId` is mapped to the `Protocol` e
 | `blend-` | `Blend` |
 | `defindex-` | `DeFindex` |
 
-Any other prefix returns a 500 with a clear mapping error. The Ondo protocol (`ondo-`) is not currently supported by the vault contract.
+Any other prefix returns a 500 with a clear mapping error.

--- a/apps/docs/architecture/frontend.md
+++ b/apps/docs/architecture/frontend.md
@@ -4,8 +4,8 @@
 
 | Concern | Library |
 |---|---|
-| Bundler | Vite 6 |
-| UI | React 18 |
+| Bundler | Vite 8 |
+| UI | React 19 |
 | Styling | Tailwind CSS |
 | Server state | TanStack Query v5 |
 | Client state | Zustand |

--- a/apps/docs/architecture/monorepo.md
+++ b/apps/docs/architecture/monorepo.md
@@ -5,21 +5,22 @@ Meridian is a pnpm workspace managed by Turborepo.
 ```
 meridian/
 ├── api/                          # Vercel serverless functions (production API)
+│   ├── _lib/
+│   │   └── middleware.ts         # CORS + rate-limit helpers shared by handlers
 │   └── v1/
 │       ├── vaults/               # GET /api/v1/vaults, GET /api/v1/vaults/:id
 │       │   ├── index.ts
-│       │   ├── [vaultId].ts
-│       │   └── _shared.ts        # DeFiLlama fetcher, pool risk logic
-│       ├── tx/                   # POST /api/v1/tx/deposit|withdraw|submit
+│       │   └── [vaultId].ts
+│       ├── tx/                   # POST /api/v1/tx/*
 │       │   ├── deposit.ts
 │       │   ├── withdraw.ts
-│       │   ├── submit.ts
-│       │   └── _shared.ts        # Soroban XDR builder
+│       │   ├── add-trustline.ts
+│       │   └── submit.ts
 │       └── positions/
 │           └── [publicKey].ts    # GET /api/v1/positions/:publicKey
 │
 ├── apps/
-│   ├── web/                      # Vite + React 18 dashboard
+│   ├── web/                      # Vite + React 19 dashboard
 │   │   └── src/
 │   │       ├── components/
 │   │       │   ├── dashboard/VaultPanel.tsx   # Main deposit/withdraw UI
@@ -52,7 +53,12 @@ meridian/
 │   │       ├── defindex.ts       # DeFindex helpers
 │   │       ├── defilamma.ts      # DeFiLlama pool fetcher
 │   │       ├── horizon.ts        # Horizon server helper
-│   │       └── known-pools.ts    # Curated pool registry
+│   │       ├── internal.ts       # Shared internal utilities
+│   │       ├── known-pools.ts    # Curated pool registry
+│   │       ├── orchestration.ts  # Cross-protocol routing orchestration
+│   │       ├── positions.ts      # On-chain position fetching
+│   │       ├── routing.ts        # Best-rate routing logic
+│   │       └── types.ts          # Shared TypeScript types
 │   │
 │   ├── shared/                   # Cross-package types and constants
 │   │   └── src/
@@ -73,8 +79,8 @@ meridian/
 
 | Boundary | Rule |
 |---|---|
-| `api/` serverless functions | No workspace package imports. All logic is self-contained or uses npm packages only. |
-| `apps/api` Fastify server | Can import from `@meridian/shared` and `@meridian/stellar-sdk-helpers`. Used for local development. |
+| `api/` serverless functions | Imports from `@meridian/shared` and `@meridian/stellar-sdk-helpers` via pre-built `dist/` bundles. `scripts/build-vercel.sh` runs esbuild on each package before the Vercel build so the handlers can import compiled JS rather than TypeScript source. |
+| `apps/api` Fastify server | Imports the same workspace packages directly via `tsx` (TypeScript-native). Used for local development only. |
 | `apps/web` | No direct Soroban SDK usage. All blockchain interaction goes through the API. |
 | `packages/contracts` | Rust only. No TypeScript. |
 

--- a/apps/docs/architecture/vault-contract.md
+++ b/apps/docs/architecture/vault-contract.md
@@ -19,29 +19,39 @@ Called once at deployment. Sets the admin, USDC contract address, and mUSDC cont
 
 ### `deposit(caller, amount, route_to) -> i128`
 
-Transfers `amount` USDC from the caller into the vault, mints proportional mUSDC shares, and records the routing protocol.
+Transfers `amount` USDC from the caller into the vault, mints proportional mUSDC shares, and records the routing protocol. Panics if deposits are paused.
 
 ```
-shares_minted = amount * total_shares / vault_balance
+shares_minted = amount * (total_shares + OFFSET) / (vault_balance + OFFSET)
 ```
 
-At genesis (no outstanding shares), `shares = amount` (1:1). Returns the number of shares minted.
+At genesis (no outstanding shares), `shares = amount` (1:1). The virtual `OFFSET` (1,000 stroops) neutralises the first-depositor inflation attack: an attacker who donates USDC to inflate the share price before a victim deposits recovers only a negligible fraction of the donation, making the skim strictly unprofitable. Returns the number of shares minted.
 
 `route_to` is a `Protocol` enum value (`Blend` or `DeFindex`), passed by the API based on the current best rate. It is stored in contract instance storage so any observer can read where funds currently sit.
+
+Stamps `Entry(caller)` with the current ledger timestamp on the caller's first deposit. Top-ups do not reset the original entry time. Accumulates `Principal(caller)` with `amount` on every deposit.
 
 ### `withdraw(caller, shares) -> i128`
 
 Burns `shares` mUSDC from the caller and returns proportional USDC.
 
 ```
-usdc_out = shares * vault_balance / total_shares
+usdc_out = shares * (vault_balance + OFFSET) / (total_shares + OFFSET)
 ```
 
-The caller must hold at least `shares` mUSDC or the transaction panics with "insufficient shares".
+The caller must hold at least `shares` mUSDC or the transaction panics with "insufficient shares". Reduces `Principal(caller)` proportionally. A full exit clears both `Entry(caller)` and `Principal(caller)`.
 
 ### `get_position(address) -> i128`
 
 Returns the mUSDC balance recorded for `address` in persistent contract storage.
+
+### `get_entry_time(address) -> u64`
+
+Returns the ledger timestamp of the address's current deposit, or `0` if it holds no position. Cleared on a full withdrawal so a later re-deposit starts a fresh clock.
+
+### `get_principal(address) -> i128`
+
+Returns the address's cost basis: the net USDC it has deposited and not yet withdrawn. Yield earned off-chain is computed as `current_share_value - principal`.
 
 ### `get_active_protocol() -> Protocol`
 
@@ -54,6 +64,22 @@ Returns the vault's current USDC balance in stroops.
 ### `get_total_shares() -> i128`
 
 Returns total outstanding mUSDC shares.
+
+### `set_paused(paused: bool)` (admin only)
+
+Emergency switch. While paused, new deposits are rejected. Withdrawals remain open so a pause can never trap user funds.
+
+### `is_paused() -> bool`
+
+Returns whether deposits are currently paused.
+
+### `set_admin(new_admin)` (admin only)
+
+Rotates the admin key. Lets a compromised or retired admin key be replaced without redeploying the vault.
+
+### `get_admin() -> Address`
+
+Returns the current admin address.
 
 ## Share price example
 
@@ -68,7 +94,7 @@ USDC on Stellar uses 7 decimal places. 1 USDC = `10_000_000` stroops. All contra
 
 ## Authorization
 
-`caller.require_auth()` is called at the start of both `deposit` and `withdraw`. Soroban's auth framework enforces that the caller's signature covers the exact function call, preventing replay and impersonation attacks.
+`caller.require_auth()` is called at the start of both `deposit` and `withdraw`. Soroban's auth framework enforces that the caller's signature covers the exact function call, preventing replay and impersonation attacks. Admin functions call an internal `require_admin` helper that reads the stored admin address and calls `require_auth()` on it.
 
 ## Contract storage
 
@@ -79,4 +105,7 @@ USDC on Stellar uses 7 decimal places. 1 USDC = `10_000_000` stroops. All contra
 | `MUSDC` | Instance | mUSDC contract `Address` |
 | `PROTOCOL` | Instance | Last-used `Protocol` enum |
 | `TOTAL_SH` | Instance | Total mUSDC shares outstanding (`i128`) |
+| `PAUSED` | Instance | Deposit pause flag (`bool`) |
 | `Balance(address)` | Persistent | Per-address mUSDC share balance (`i128`) |
+| `Entry(address)` | Persistent | Per-address deposit entry timestamp (`u64`) |
+| `Principal(address)` | Persistent | Per-address net USDC deposited, not yet withdrawn (`i128`) |

--- a/apps/docs/operations/environment-variables.md
+++ b/apps/docs/operations/environment-variables.md
@@ -10,16 +10,16 @@
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `VAULT_CONTRACT_ID` | Yes (for tx routes) | `""` | Deployed `MeridianVault` contract address on Stellar. Without this, deposit and withdraw return 500 "Vault contract not yet deployed". |
+| `DEFINDEX_VAULT_ID` | No | `""` | Overrides the DeFindex vault contract address at runtime. When empty, the address from `CONTRACT_ADDRESSES.testnet.defindex.vault` in `packages/shared/src/constants.ts` is used. Blend and vault contract addresses are always sourced from constants. |
 | `PORT` | No | `3001` | Fastify server port (local dev only). |
-| `ALLOWED_ORIGIN` | No | `"*"` | CORS allowed origin for the Fastify server. Set to your frontend domain in production if running Fastify as a standalone server. |
+| `ALLOWED_ORIGIN` | No | `"https://usemeridian.vercel.app"` | CORS allowed origin for the Fastify server. Set to your frontend domain in production if running Fastify as a standalone server. |
 
 ## Vercel
 
 Set environment variables in the Vercel dashboard under **Project Settings > Environment Variables**, or via the CLI:
 
 ```bash
-vercel env add VAULT_CONTRACT_ID
+vercel env add DEFINDEX_VAULT_ID
 ```
 
 Variables prefixed with `VITE_` are inlined at build time and exposed to the browser. Do not put secrets in `VITE_` variables.
@@ -31,7 +31,7 @@ Create `.env` files at the package level if needed:
 ```bash
 # apps/api/.env
 PORT=3001
-VAULT_CONTRACT_ID=C...   # optional, leave empty if contract not yet deployed
+DEFINDEX_VAULT_ID=C...   # optional, leave empty to use the address in constants.ts
 ```
 
 The Fastify server loads `.env` via the `dotenv` package on startup.

--- a/apps/docs/operations/testnet-deployment.md
+++ b/apps/docs/operations/testnet-deployment.md
@@ -30,19 +30,25 @@ This produces `target/wasm32-unknown-unknown/release/meridian_vault.wasm`.
 
 ## Deploy USDC and mUSDC (testnet only)
 
-On testnet, deploy mock SAC (Stellar Asset Contract) instances for USDC and mUSDC. On mainnet, use the real USDC contract address from `CONTRACT_ADDRESSES.testnet.usdc`.
+On testnet, deploy mock Stellar Asset Contracts (SAC) for USDC and mUSDC. On mainnet, use the real USDC contract address already present in `CONTRACT_ADDRESSES.testnet.usdc`.
+
+To deploy a SAC you first need a funded keypair to act as the asset issuer, then wrap that classic asset as a Soroban contract:
 
 ```bash
-# Deploy mock USDC
-stellar contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/meridian_vault.wasm \
+# Generate an issuer keypair
+stellar keys generate --network testnet issuer
+curl "https://friendbot.stellar.org/?addr=$(stellar keys address issuer)"
+
+# Deploy a SAC for mock USDC
+stellar contract asset deploy \
+  --asset USDC:$(stellar keys address issuer) \
   --network testnet \
   --source deployer
 ```
 
 Record the returned contract ID as `USDC_CONTRACT_ID`.
 
-Repeat for mUSDC and record as `MUSDC_CONTRACT_ID`.
+Repeat with a different asset code (e.g. `MUSDC`) for the share token and record as `MUSDC_CONTRACT_ID`.
 
 ## Deploy the vault contract
 
@@ -76,34 +82,34 @@ The vault must be the admin of the mUSDC asset in order to mint and burn share t
 stellar contract invoke \
   --id $MUSDC_CONTRACT_ID \
   --network testnet \
-  --source deployer \
+  --source issuer \
   -- set_admin \
   --new_admin $VAULT_CONTRACT_ID
 ```
 
 ## Update contract addresses
 
-Add the deployed `VAULT_CONTRACT_ID` to `packages/shared/src/constants.ts`:
+Add the deployed contract IDs to `packages/shared/src/constants.ts`:
 
 ```typescript
 export const CONTRACT_ADDRESSES = {
   testnet: {
-    vault: "C...", // paste VAULT_CONTRACT_ID here
-    usdc: "C...",
-    musdc: "C...",
-    // ...
+    blend: {
+      pool: "C...",
+    },
+    defindex: {
+      factory: "C...",
+      vault: "",
+    },
+    usdc: "C...",   // USDC_CONTRACT_ID
+    eurc: "C...",
+    musdc: "C...",  // MUSDC_CONTRACT_ID
+    vault: "C...",  // VAULT_CONTRACT_ID
   },
-};
+} as const;
 ```
 
-## Set the Vercel environment variable
-
-```bash
-vercel env add VAULT_CONTRACT_ID
-# paste the deployed contract ID when prompted
-```
-
-Or set it in the Vercel dashboard under **Project Settings > Environment Variables**.
+The vault contract address is read from constants at build time. There is no runtime environment variable for it.
 
 ## Verify the deployment
 
@@ -120,7 +126,7 @@ A return value of `0` confirms the contract is initialized and responding.
 
 ## Run the signing flow end-to-end
 
-With the contract deployed and `VAULT_CONTRACT_ID` set:
+With the contract deployed and constants updated:
 
 1. Open the app, connect Freighter (testnet mode).
 2. Enter a USDC amount and click **Deposit**.


### PR DESCRIPTION
## Summary

- Fix `architecture/api.md`: add missing `POST /api/v1/tx/add-trustline` endpoint; add `recommendedVaultId` to the `GET /api/v1/vaults` response shape; rewrite the Serverless vs Fastify section to accurately describe the esbuild pre-build approach (the old text claimed workspace imports were impossible, which is the opposite of reality); remove the stale Ondo protocol note
- Fix `architecture/monorepo.md`: remove fictional `_shared.ts` files from the API tree; add `add-trustline.ts` and `_lib/middleware.ts`; list the missing `stellar-sdk-helpers` source files; correct the key boundary rule for `api/`; update React version to 19
- Fix `architecture/frontend.md`: Vite 6 and React 18 updated to Vite 8 and React 19
- Fix `architecture/vault-contract.md`: document `PAUSED`, `Entry(address)`, and `Principal(address)` storage keys; add `get_entry_time`, `get_principal`, `set_paused`, `is_paused`, `set_admin`, and `get_admin` to the interface; note the virtual offset used to neutralise the first-depositor inflation attack
- Fix `operations/environment-variables.md`: replace non-existent `VAULT_CONTRACT_ID` with `DEFINDEX_VAULT_ID`; correct `ALLOWED_ORIGIN` default from `"*"` to `"https://usemeridian.vercel.app"`
- Fix `operations/testnet-deployment.md`: replace the incorrect vault WASM deploy commands for USDC and mUSDC with the correct `stellar contract asset deploy` SAC workflow; update the `CONTRACT_ADDRESSES` example to match the actual shape in `constants.ts`; remove the stale `vercel env add VAULT_CONTRACT_ID` instruction

## Test plan

- [x] `pnpm --filter @meridian/docs dev` serves the docs at `localhost:3000/docs/` with no broken links or rendering errors
- [x] All changed pages render correctly in the browser