### PR TITLE
fix: add .js extension to middleware import in middleware.test.ts

### DIFF
--- a/api/__tests__/middleware.test.ts
+++ b/api/__tests__/middleware.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { applyCors, checkRateLimit, resetRateLimitForTesting } from "../_lib/middleware";
+import { applyCors, checkRateLimit, resetRateLimitForTesting } from "../_lib/middleware.js";
 
 // Minimal fake request / response ------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `api/__tests__/middleware.test.ts` was importing `../_lib/middleware` without the `.js` extension required by Node's ESM resolver
- `api/package.json` sets `"type": "module"`, so all imports must use explicit file extensions; all six production route files were already updated but the test was missed
- Without this fix, `pnpm test` in `api/` throws `ERR_MODULE_NOT_FOUND`

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally

Closes #265