### PR TITLE
fix: guard empty signedTxXdr before forwarding to submitTx

### DIFF
--- a/apps/web/src/lib/wallet.ts
+++ b/apps/web/src/lib/wallet.ts
@@ -21,5 +21,6 @@ export async function signTransaction(
 ): Promise<string> {
   const result = await freighterSign(xdr, { networkPassphrase });
   if (result.error) throw new Error(result.error.message);
+  if (!result.signedTxXdr) throw new Error("Signing cancelled");
   return result.signedTxXdr;
 }


### PR DESCRIPTION
## Summary

- `signTransaction` in `apps/web/src/lib/wallet.ts` only checked for `result.error` before returning `result.signedTxXdr`
- Some Freighter builds return an empty-string `signedTxXdr` with no `error` set when the user dismisses the popup; the empty XDR then reaches `api.submitTx` and produces an unhelpful parse error from the Stellar RPC
- Added a guard so a missing `signedTxXdr` throws `"Signing cancelled"` immediately, giving the UI a clean error to surface

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] Manually cancel a Freighter signing popup and confirm the error toast reads "Signing cancelled" instead of a raw RPC error

Closes #268