### PR TITLE
fix: filter undefined fieldErrors in formatZodError before joining

### DIFF
--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -34,5 +34,5 @@ export type SubmitRequest = z.infer<typeof SubmitRequestSchema>;
 
 export function formatZodError(err: z.ZodError): string {
   const fields = err.flatten().fieldErrors as Record<string, string[] | undefined>;
-  return Object.entries(fields).map(([k, v]) => `${k}: ${v?.join(", ")}`).join("; ") || "Invalid request";
+  return Object.entries(fields).filter(([, v]) => v && v.length > 0).map(([k, v]) => `${k}: ${v!.join(", ")}`).join("; ") || "Invalid request";
 }


### PR DESCRIPTION
## Summary

- `formatZodError` in `packages/shared/src/schemas.ts` mapped over all entries in `flatten().fieldErrors` including those with `undefined` values
- When `v` is `undefined`, `v?.join(", ")` returns `undefined` and the template literal coerces it to the string `"undefined"`, producing responses like `"walletAddress: undefined"` in 400 bodies
- Added a `filter` step to drop entries where `v` is falsy or empty before mapping, so only fields with actual messages are included

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] Send a malformed request and confirm the 400 body contains only fields that have actual error messages

Closes #269