### PR TITLE
fix: remove duplicate STROOPS constant and import STROOPS_PER_UNIT from internal

### DIFF
--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -8,15 +8,14 @@ import {
 import { simulateView, prepareSorobanTx } from "./tx";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
-import { toBigInt } from "./internal";
-
-const STROOPS = 10_000_000n;
+import { toBigInt, STROOPS_PER_UNIT } from "./internal";
 
 // Converts a stroop-denominated bigint to a floating-point unit value without
 // precision loss: the whole-unit part stays in bigint space until it fits
 // safely in a Number, then the sub-unit remainder is added as a fraction.
 export function stroopsToUnits(stroops: bigint): number {
-  return Number(stroops / STROOPS) + Number(stroops % STROOPS) / 1e7;
+  const s = BigInt(STROOPS_PER_UNIT);
+  return Number(stroops / s) + Number(stroops % s) / STROOPS_PER_UNIT;
 }
 
 export interface DefindexVaultConfig {


### PR DESCRIPTION
## Summary

- `packages/stellar-sdk-helpers/src/defindex.ts` declared `const STROOPS = 10_000_000n` locally, duplicating the identical value already exported as `STROOPS_PER_UNIT` from `internal.ts`
- Removed the local constant, imported `STROOPS_PER_UNIT` from `./internal`, and replaced usages with `BigInt(STROOPS_PER_UNIT)` (to keep bigint arithmetic) and `STROOPS_PER_UNIT` (for the float division)
- Single source of truth for the stroop unit now lives in `internal.ts`

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally

Closes #272