### PR TITLE
fix: replace withSorobanTimeout implementation with withRaceTimeout from shared

### DIFF
--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -11,7 +11,7 @@ import {
 } from "@stellar/stellar-sdk";
 import type { StellarNetwork } from "./types";
 import { BASE_FEE, passphraseFor } from "./internal";
-import { withRetry } from "@meridian/shared";
+import { withRetry, withRaceTimeout } from "@meridian/shared";
 import { buildHorizonServer } from "./horizon";
 
 // The Soroban RPC SDK does not surface an AbortSignal option, so we race each
@@ -28,12 +28,9 @@ export class SorobanTimeoutError extends Error {
 }
 
 const withSorobanTimeout = <T>(fn: () => Promise<T>, ms = SOROBAN_RPC_TIMEOUT_MS): Promise<T> =>
-  new Promise<T>((resolve, reject) => {
-    const handle = setTimeout(() => reject(new SorobanTimeoutError(ms)), ms);
-    fn().then(
-      (val) => { clearTimeout(handle); resolve(val); },
-      (err) => { clearTimeout(handle); reject(err); }
-    );
+  withRaceTimeout(fn, ms, "Soroban RPC").catch((err: unknown): never => {
+    if (err instanceof Error && err.message.includes("timed out")) throw new SorobanTimeoutError(ms);
+    throw err;
   });
 
 const USDC_ISSUER: Record<string, string> = {


### PR DESCRIPTION
## Summary

- `packages/stellar-sdk-helpers/src/tx.ts` had a hand-rolled `withSorobanTimeout` that raced a promise against a `setTimeout`, structurally identical to `withRaceTimeout` already exported from `@meridian/shared` (and already used by `blend.ts` for the same purpose)
- Replaced the implementation with a call to `withRaceTimeout`, then re-maps its generic timeout error to `SorobanTimeoutError` so the existing `shouldRetry: (err) => !(err instanceof SorobanTimeoutError)` guard in `prepareSorobanTx` is preserved
- Eliminates the duplicate implementation while keeping the callable surface (`withSorobanTimeout` signature) and error type unchanged

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test` pass locally

Closes #271