### PR TITLE
fix: centralize ALLOWED_ORIGIN default in shared constants

### DIFF
--- a/api/_lib/middleware.ts
+++ b/api/_lib/middleware.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
+import { DEFAULT_ALLOWED_ORIGIN } from "@meridian/shared";
 
-const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? "https://usemeridian.vercel.app";
+const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? DEFAULT_ALLOWED_ORIGIN;
 
 /**
  * Set CORS headers and handle preflight. Returns true when the request was a

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,13 +8,14 @@ config({ path: resolve(process.cwd(), "../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import rateLimit from "@fastify/rate-limit";
+import { DEFAULT_ALLOWED_ORIGIN } from "@meridian/shared";
 import { vaultsRoute } from "./routes/vaults";
 import { positionsRoute } from "./routes/positions";
 import { txRoute } from "./routes/tx";
 
 const app = Fastify({ logger: true });
 
-await app.register(cors, { origin: process.env.ALLOWED_ORIGIN ?? "https://usemeridian.vercel.app" });
+await app.register(cors, { origin: process.env.ALLOWED_ORIGIN ?? DEFAULT_ALLOWED_ORIGIN });
 await app.register(rateLimit, { max: 100, timeWindow: "1 minute" });
 
 app.register(vaultsRoute, { prefix: "/api/v1/vaults" });

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_ALLOWED_ORIGIN = "https://usemeridian.vercel.app";
+
 export const SUPPORTED_STABLECOINS = ["USDC", "EURC"] as const;
 export type SupportedStablecoin = (typeof SUPPORTED_STABLECOINS)[number];
 


### PR DESCRIPTION
## Summary

- `"https://usemeridian.vercel.app"` was hardcoded as the `ALLOWED_ORIGIN` fallback in two separate files: `api/_lib/middleware.ts` and `apps/api/src/index.ts`
- A change to the production origin would require updating both independently
- Exported `DEFAULT_ALLOWED_ORIGIN` from `packages/shared/src/constants.ts` and replaced both hardcoded strings with imports

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] Verify CORS headers are still set correctly when `ALLOWED_ORIGIN` env var is unset

Closes #275