### PR TITLE
feat: export isDefindexConfigured helper from shared constants

### DIFF
--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -41,6 +41,10 @@ export const STELLAR_NETWORKS = {
 export const APP_NETWORK = STELLAR_NETWORKS.testnet;
 export const APP_ADDRESSES = CONTRACT_ADDRESSES.testnet;
 
+export function isDefindexConfigured(): boolean {
+  return Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault);
+}
+
 /** Build the ProtocolAddresses object consumed by stellar-sdk-helpers, allowing
  *  the DeFindex vault contract address to be overridden at runtime via DEFINDEX_VAULT_ID. */
 export function buildTxAddresses(defindexOverride?: string) {


### PR DESCRIPTION
## Summary

- Both `api/v1/vaults/index.ts` and `apps/api/src/routes/vaults.ts` duplicate the expression `Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault)` to gate DeFindex routes
- Exported a shared `isDefindexConfigured()` function from `packages/shared/src/constants.ts` so both route files can call a single authoritative source
- Prerequisite for moving the check inside request handlers (issue #267)

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally

Closes #273