### PR TITLE
fix: evaluate defindexConfigured per-request via isDefindexConfigured helper

### DIFF
--- a/api/v1/vaults/index.ts
+++ b/api/v1/vaults/index.ts
@@ -1,6 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { fetchAllVaults, selectBestVault, isVaultCacheWarm } from "@meridian/stellar-sdk-helpers";
-import { APP_ADDRESSES } from "@meridian/shared";
+import { isDefindexConfigured } from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 // Cache the aggregated vault list at the Vercel CDN. APY/TVL move slowly, so a
@@ -9,15 +9,13 @@ import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 // transient DeFiLlama outage instead of failing the whole dashboard.
 const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
 
-const defindexConfigured = Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault);
-
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   if (!checkRateLimit(req, res)) return;
   try {
     const cached = isVaultCacheWarm();
     const vaults = await fetchAllVaults();
-    const best = selectBestVault(vaults, { defindexConfigured });
+    const best = selectBestVault(vaults, { defindexConfigured: isDefindexConfigured() });
     res.setHeader("Cache-Control", CACHE_CONTROL);
     res.json({
       vaults,

--- a/apps/api/src/routes/vaults.ts
+++ b/apps/api/src/routes/vaults.ts
@@ -1,16 +1,14 @@
 import type { FastifyPluginAsync } from "fastify";
 import { selectBestVault, isVaultCacheWarm } from "@meridian/stellar-sdk-helpers";
-import { APP_ADDRESSES } from "@meridian/shared";
+import { isDefindexConfigured } from "@meridian/shared";
 import { fetchAllVaults } from "../services/vaults.js";
-
-const defindexConfigured = Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault);
 
 export const vaultsRoute: FastifyPluginAsync = async (app) => {
   app.get("/", async (_req, reply) => {
     try {
       const cached = isVaultCacheWarm();
       const vaults = await fetchAllVaults();
-      const best = selectBestVault(vaults, { defindexConfigured });
+      const best = selectBestVault(vaults, { defindexConfigured: isDefindexConfigured() });
       return reply.send({
         vaults,
         recommendedVaultId: best?.id ?? null,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -41,6 +41,10 @@ export const STELLAR_NETWORKS = {
 export const APP_NETWORK = STELLAR_NETWORKS.testnet;
 export const APP_ADDRESSES = CONTRACT_ADDRESSES.testnet;
 
+export function isDefindexConfigured(): boolean {
+  return Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault);
+}
+
 /** Build the ProtocolAddresses object consumed by stellar-sdk-helpers, allowing
  *  the DeFindex vault contract address to be overridden at runtime via DEFINDEX_VAULT_ID. */
 export function buildTxAddresses(defindexOverride?: string) {


### PR DESCRIPTION
## Summary

- `api/v1/vaults/index.ts` and `apps/api/src/routes/vaults.ts` both computed `defindexConfigured` at module load time, freezing the value on the first cold start; any `DEFINDEX_VAULT_ID` set after the module loaded would be ignored for the instance lifetime
- Replaced the module-level constant in both files with a per-request call to `isDefindexConfigured()` from `@meridian/shared` (introduced in #273), which reads `process.env` on every invocation

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] Confirm that setting `DEFINDEX_VAULT_ID` in a running process is reflected in subsequent requests without a restart

Closes #267