### PR TITLE
fix: import ApiVault and ApiPosition from stellar-sdk-helpers instead of redeclaring

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,3 +1,8 @@
+import type { ApiVault, PositionInfo } from "@meridian/stellar-sdk-helpers";
+
+export type { ApiVault };
+export type ApiPosition = PositionInfo;
+
 const API_BASE = import.meta.env.VITE_API_URL ?? "";
 
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
@@ -28,26 +33,6 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-// JSON-safe vault shape (bigints serialised as numbers by the API)
-export interface ApiVault {
-  id: string;
-  protocol: "blend" | "defindex";
-  asset: string;
-  name: string;
-  label: string;
-  apy: number;
-  tvl: number;
-  userBalance: number;
-  riskLevel: "safe" | "caution" | "risky";
-}
-
-export interface ApiPosition {
-  vaultId: string;
-  shares: number;
-  deposited: number;
-  earned: number;
-  entryTime: number;
-}
 
 export const api = {
   getVaults: () =>


### PR DESCRIPTION
## Summary

- `apps/web/src/lib/api.ts` redeclared `ApiVault` and `ApiPosition` interfaces that are already exported from `packages/stellar-sdk-helpers`
- Any field added to the canonical types in the SDK would need to be manually mirrored here
- Removed both local declarations and re-exported `ApiVault` directly and aliased `ApiPosition = PositionInfo` from `@meridian/stellar-sdk-helpers`; the public API of `api.ts` is unchanged for all callers

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally

Closes #274