### PR TITLE
fix: add KNOWN_POOLS guard before fetchAllVaults in vaults/[vaultId].ts

### DIFF
--- a/api/v1/vaults/[vaultId].ts
+++ b/api/v1/vaults/[vaultId].ts
@@ -1,14 +1,16 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { fetchAllVaults } from "@meridian/stellar-sdk-helpers";
+import { fetchAllVaults, KNOWN_POOLS } from "@meridian/stellar-sdk-helpers";
 import { applyCors } from "../../_lib/middleware.js";
 
 const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
+const KNOWN_VAULT_IDS = new Set(Object.values(KNOWN_POOLS).map((p) => p.id));
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   const raw = req.query["vaultId"];
   const vaultId = typeof raw === "string" ? raw : undefined;
   if (!vaultId) return res.status(400).json({ error: "vaultId is required" });
+  if (!KNOWN_VAULT_IDS.has(vaultId)) return res.status(404).json({ error: "vault not found", vaultId });
 
   try {
     const vaults = await fetchAllVaults();

--- a/packages/stellar-sdk-helpers/src/index.ts
+++ b/packages/stellar-sdk-helpers/src/index.ts
@@ -2,6 +2,7 @@ export * from "./blend";
 export * from "./defilamma";
 export * from "./defindex";
 export * from "./horizon";
+export * from "./known-pools";
 export * from "./orchestration";
 export * from "./positions";
 export * from "./routing";


### PR DESCRIPTION
## Summary

- `api/v1/vaults/[vaultId].ts` called `fetchAllVaults()` (a full DeFiLlama round-trip on cache miss) before checking whether the requested vault ID is actually known
- An unrecognised ID triggered the full fetch only to return a 404, wasting network and time
- Added a module-scope `KNOWN_VAULT_IDS` set derived from `KNOWN_POOLS` values and check it before calling `fetchAllVaults()`, returning 404 immediately for unrecognised IDs without any I/O

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] A request for an unknown vault ID returns 404 instantly without triggering DeFiLlama calls

Closes #279