### PR TITLE
fix: parallelize Blend and DeFindex position fetches with Promise.all

### DIFF
--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -52,17 +52,17 @@ export async function resolvePositions(
   network: StellarNetwork,
   addresses: ProtocolAddresses,
 ): Promise<PositionInfo[]> {
-  const positions = await fetchBlendPositions(network, addresses.blendPool, publicKey, [
-    { assetId: addresses.usdc, vaultId: "blend-usdc-fixed" },
-    { assetId: addresses.eurc, vaultId: "blend-eurc-fixed" },
+  const [blendPositions, dfxPositions] = await Promise.all([
+    fetchBlendPositions(network, addresses.blendPool, publicKey, [
+      { assetId: addresses.usdc, vaultId: "blend-usdc-fixed" },
+      { assetId: addresses.eurc, vaultId: "blend-eurc-fixed" },
+    ]),
+    addresses.defindexVault
+      ? fetchDefindexPosition(network, addresses.defindexVault, addresses.defindexVaultId, publicKey)
+      : Promise.resolve([]),
   ]);
 
-  if (addresses.defindexVault) {
-    const dfx = await fetchDefindexPosition(network, addresses.defindexVault, addresses.defindexVaultId, publicKey);
-    positions.push(...dfx);
-  }
-
-  return positions;
+  return [...blendPositions, ...dfxPositions];
 }
 
 /**


### PR DESCRIPTION
## Summary

- `resolvePositions` in `packages/stellar-sdk-helpers/src/orchestration.ts` awaited `fetchBlendPositions` to completion before starting `fetchDefindexPosition`
- The two protocols are fully independent, so total latency on a DeFindex-configured request was the serial sum of both network round-trips
- Wrapped both calls in `Promise.all`, short-circuiting the DeFindex fetch to `Promise.resolve([])` when no vault is configured

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] Positions load correctly for wallets with both Blend and DeFindex positions

Closes #266