### PR TITLE
fix: use stroopsToUnits in positions.ts to prevent precision loss above MAX_SAFE_INTEGER

### DIFF
--- a/packages/stellar-sdk-helpers/src/positions.ts
+++ b/packages/stellar-sdk-helpers/src/positions.ts
@@ -1,4 +1,4 @@
-import { STROOPS_PER_UNIT } from "./internal";
+import { stroopsToUnits } from "./defindex";
 
 export interface PositionInfo {
   vaultId: string;
@@ -40,9 +40,9 @@ export function computePosition(vaultId: string, raw: RawPosition): PositionInfo
   return [
     {
       vaultId,
-      shares: Number(raw.shares) / STROOPS_PER_UNIT,
-      deposited: Number(currentValue) / STROOPS_PER_UNIT,
-      earned: Number(earned) / STROOPS_PER_UNIT,
+      shares: stroopsToUnits(raw.shares),
+      deposited: stroopsToUnits(currentValue),
+      earned: stroopsToUnits(earned),
       entryTime: Number(raw.entryTime),
     },
   ];


### PR DESCRIPTION
## Summary

- `computePosition` in `packages/stellar-sdk-helpers/src/positions.ts` converted bigint stroops to display units via `Number(x) / STROOPS_PER_UNIT`, which silently loses precision for values above `Number.MAX_SAFE_INTEGER` (~922 trillion stroops, ~92M USDC)
- `stroopsToUnits` in `defindex.ts` already handles this correctly using integer-safe arithmetic (bigint division for the whole part, then adding the fractional remainder as a float)
- Replaced all three conversions (`shares`, `deposited`, `earned`) with `stroopsToUnits` and removed the now-unused `STROOPS_PER_UNIT` import

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally

Closes #276