### PR TITLE
fix: add per-route rate limits, body size cap, and security headers to Fastify API

### DIFF
--- a/apps/api/src/__tests__/routes.test.ts
+++ b/apps/api/src/__tests__/routes.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import Fastify from "fastify";
+import rateLimit from "@fastify/rate-limit";
 import { positionsRoute } from "../routes/positions.js";
 import { txRoute } from "../routes/tx.js";
 import { vaultsRoute } from "../routes/vaults.js";
@@ -256,6 +257,32 @@ describe("GET /api/v1/vaults", () => {
 
     const res = await app.inject({ method: "GET", url: "/api/v1/vaults" });
     expect(res.statusCode).toBe(500);
+  });
+});
+
+describe("rate limiting on /api/v1/tx/deposit", () => {
+  it("returns 429 after 10 requests within a minute", async () => {
+    const app = Fastify({ logger: false });
+    await app.register(rateLimit, { max: 1000, timeWindow: "1 minute" });
+    app.register(txRoute, { prefix: "/api/v1/tx" });
+    await app.ready();
+
+    vi.mocked(buildDepositTx).mockResolvedValue({ xdr: "TXXDR", fee: "100" });
+
+    const opts = {
+      method: "POST" as const,
+      url: "/api/v1/tx/deposit",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ walletAddress: WALLET, vaultId: "blend-usdc-fixed", amount: "10" }),
+    };
+
+    for (let i = 0; i < 10; i++) {
+      const res = await app.inject(opts);
+      expect(res.statusCode).toBe(200);
+    }
+
+    const over = await app.inject(opts);
+    expect(over.statusCode).toBe(429);
   });
 });
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -13,10 +13,19 @@ import { vaultsRoute } from "./routes/vaults";
 import { positionsRoute } from "./routes/positions";
 import { txRoute } from "./routes/tx";
 
-const app = Fastify({ logger: true });
+// Rate limits: global 100 req/min; /tx/deposit and /tx/withdraw 10 req/min per IP.
+// Body limit: 10 KB on all routes to block oversized payload attacks.
+// Security headers: X-Content-Type-Options and X-Frame-Options on every response.
+const app = Fastify({ logger: true, bodyLimit: 10 * 1024 });
 
 await app.register(cors, { origin: process.env.ALLOWED_ORIGIN ?? DEFAULT_ALLOWED_ORIGIN });
 await app.register(rateLimit, { max: 100, timeWindow: "1 minute" });
+
+app.addHook("onSend", (_req, reply, _payload, done) => {
+  reply.header("X-Content-Type-Options", "nosniff");
+  reply.header("X-Frame-Options", "DENY");
+  done();
+});
 
 app.register(vaultsRoute, { prefix: "/api/v1/vaults" });
 app.register(positionsRoute, { prefix: "/api/v1/positions" });

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -17,7 +17,7 @@ import {
 } from "@meridian/stellar-sdk-helpers";
 
 export const txRoute: FastifyPluginAsync = async (app) => {
-  app.post("/deposit", async (req, reply) => {
+  app.post("/deposit", { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } }, async (req, reply) => {
     const parsed = DepositRequestSchema.safeParse(req.body);
     if (!parsed.success) return reply.code(400).send({ error: formatZodError(parsed.error) });
 
@@ -34,7 +34,7 @@ export const txRoute: FastifyPluginAsync = async (app) => {
     }
   });
 
-  app.post("/withdraw", async (req, reply) => {
+  app.post("/withdraw", { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } }, async (req, reply) => {
     const parsed = WithdrawRequestSchema.safeParse(req.body);
     if (!parsed.success) return reply.code(400).send({ error: formatZodError(parsed.error) });
 


### PR DESCRIPTION
## Summary

- Added `bodyLimit: 10 * 1024` to the Fastify instance to cap all request bodies at 10 KB; oversized payloads now return 413
- Added `config.rateLimit: { max: 10, timeWindow: "1 minute" }` to `/tx/deposit` and `/tx/withdraw` routes; those routes now return 429 after 10 requests per IP per minute (global 100/min limit still applies to other routes)
- Added an `onSend` hook that sets `X-Content-Type-Options: nosniff` and `X-Frame-Options: DENY` on every response
- Documented all rate and size limits in a comment block at the top of `index.ts`

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] New test asserts 429 is returned from `/tx/deposit` after 10 requests within the same minute (21 tests pass total)

Closes #16