### PR TITLE
fix: upgrade Vercel rate limiter to Upstash Redis for distributed limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,5 +5,13 @@ ALLOWED_ORIGIN=http://localhost:3000
 # DeFindex vault contract address (C-address). Leave empty to disable DeFindex — only Blend positions are returned.
 DEFINDEX_VAULT_ID=
 
+# Upstash Redis (required in production for distributed rate limiting).
+# Get these from your Upstash console: https://console.upstash.com
+# Vercel serverless functions use the REST API:
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+# Fastify API server uses the Redis protocol (ioredis). Format: rediss://default:TOKEN@HOST:PORT
+REDIS_URL=
+
 # Web
 VITE_API_URL=http://localhost:3001

--- a/api/__tests__/middleware.test.ts
+++ b/api/__tests__/middleware.test.ts
@@ -82,66 +82,75 @@ describe("applyCors", () => {
 // checkRateLimit ------------------------------------------------------------------
 
 describe("checkRateLimit", () => {
-  it("allows the first 100 requests from the same IP", () => {
+  it("allows the first 100 requests from the same IP", async () => {
     const ip = "1.2.3.4";
     for (let i = 0; i < 100; i++) {
       const res = fakeRes();
       expect(
-        checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
+        await checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
       ).toBe(true);
       expect(res.statusCode).toBe(200);
     }
   });
 
-  it("blocks the 101st request with 429", () => {
+  it("blocks the 101st request with 429", async () => {
     const ip = "1.2.3.5";
     for (let i = 0; i < 100; i++) {
-      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), fakeRes());
+      await checkRateLimit(
+        fakeReq("POST", { "x-forwarded-for": ip }),
+        fakeRes()
+      );
     }
     const res = fakeRes();
     expect(
-      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
+      await checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
     ).toBe(false);
     expect(res.statusCode).toBe(429);
   });
 
-  it("resets the counter after the 60 s window expires", () => {
+  it("resets the counter after the 60 s window expires", async () => {
     vi.useFakeTimers();
     const ip = "1.2.3.6";
     for (let i = 0; i < 100; i++) {
-      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), fakeRes());
+      await checkRateLimit(
+        fakeReq("POST", { "x-forwarded-for": ip }),
+        fakeRes()
+      );
     }
     // Advance past the 60 s window.
     vi.advanceTimersByTime(61_000);
     const res = fakeRes();
     expect(
-      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
+      await checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
     ).toBe(true);
     expect(res.statusCode).toBe(200);
   });
 
-  it("tracks two different IPs independently", () => {
+  it("tracks two different IPs independently", async () => {
     const ipA = "10.0.0.1";
     const ipB = "10.0.0.2";
     for (let i = 0; i < 100; i++) {
-      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipA }), fakeRes());
+      await checkRateLimit(
+        fakeReq("POST", { "x-forwarded-for": ipA }),
+        fakeRes()
+      );
     }
     // ipA is blocked but ipB should still be allowed.
     const resA = fakeRes();
     expect(
-      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipA }), resA)
+      await checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipA }), resA)
     ).toBe(false);
     const resB = fakeRes();
     expect(
-      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipB }), resB)
+      await checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipB }), resB)
     ).toBe(true);
   });
 
-  it("uses x-vercel-forwarded-for over x-forwarded-for when both are present", () => {
+  it("uses x-vercel-forwarded-for over x-forwarded-for when both are present", async () => {
     const vercelIp = "5.6.7.8";
     const fwdIp = "9.9.9.9";
     for (let i = 0; i < 100; i++) {
-      checkRateLimit(
+      await checkRateLimit(
         fakeReq("POST", {
           "x-vercel-forwarded-for": vercelIp,
           "x-forwarded-for": fwdIp,
@@ -152,7 +161,7 @@ describe("checkRateLimit", () => {
     // vercelIp bucket is full — requests with that header should be blocked
     const resBlocked = fakeRes();
     expect(
-      checkRateLimit(
+      await checkRateLimit(
         fakeReq("POST", {
           "x-vercel-forwarded-for": vercelIp,
           "x-forwarded-for": fwdIp,
@@ -165,7 +174,10 @@ describe("checkRateLimit", () => {
     // fwdIp bucket is untouched — requests without x-vercel-forwarded-for should still pass
     const resAllowed = fakeRes();
     expect(
-      checkRateLimit(fakeReq("POST", { "x-forwarded-for": fwdIp }), resAllowed)
+      await checkRateLimit(
+        fakeReq("POST", { "x-forwarded-for": fwdIp }),
+        resAllowed
+      )
     ).toBe(true);
   });
 });

--- a/api/_lib/middleware.ts
+++ b/api/_lib/middleware.ts
@@ -1,5 +1,7 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { DEFAULT_ALLOWED_ORIGIN } from "@meridian/shared";
+import { Ratelimit } from "@upstash/ratelimit";
+import { Redis } from "@upstash/redis";
 
 const ALLOWED_ORIGIN = process.env.ALLOWED_ORIGIN ?? DEFAULT_ALLOWED_ORIGIN;
 
@@ -19,17 +21,27 @@ export function applyCors(req: VercelRequest, res: VercelResponse): boolean {
   return false;
 }
 
-// In-memory rate limit: per-IP, 100 req / 60 s — matches the Fastify server's
-// @fastify/rate-limit config. Resets on cold start and is not shared across
-// invocation instances. For a distributed limit use Upstash Redis or Vercel KV.
+const LIMIT = 100;
+const WINDOW = "60 s";
+const WINDOW_MS = 60_000;
+
+// Distributed sliding-window limiter via Upstash Redis when env vars are
+// present. Falls back to in-memory per-process counting for local dev — the
+// fallback is not shared across workers and should not be used in production.
+const ratelimit =
+  process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN
+    ? new Ratelimit({
+        redis: Redis.fromEnv(),
+        limiter: Ratelimit.slidingWindow(LIMIT, WINDOW),
+      })
+    : null;
+
 const counts = new Map<string, { n: number; resetAt: number }>();
 
-/** Clears all rate-limit buckets. Exposed for tests only. */
+/** Clears all in-memory rate-limit buckets. Exposed for tests only. */
 export function resetRateLimitForTesting(): void {
   counts.clear();
 }
-const LIMIT = 100;
-const WINDOW_MS = 60_000;
 
 function clientIp(req: VercelRequest): string {
   // x-vercel-forwarded-for is set by the Vercel edge and cannot be spoofed
@@ -52,14 +64,25 @@ function clientIp(req: VercelRequest): string {
  * Writes a 429 response and returns false when the limit is exceeded — the
  * caller should return immediately.
  */
-export function checkRateLimit(
+export async function checkRateLimit(
   req: VercelRequest,
   res: VercelResponse
-): boolean {
+): Promise<boolean> {
   const ip = clientIp(req);
+
+  if (ratelimit) {
+    const { success } = await ratelimit.limit(ip);
+    if (!success) {
+      res
+        .status(429)
+        .json({ error: "Too many requests. Try again in a minute." });
+      return false;
+    }
+    return true;
+  }
+
   const now = Date.now();
   const entry = counts.get(ip);
-
   if (!entry || now > entry.resetAt) {
     counts.set(ip, { n: 1, resetAt: now + WINDOW_MS });
     return true;

--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,9 @@
   "dependencies": {
     "@meridian/shared": "workspace:*",
     "@meridian/stellar-sdk-helpers": "workspace:*",
-    "@stellar/stellar-sdk": "^14.0.0"
+    "@stellar/stellar-sdk": "^14.0.0",
+    "@upstash/ratelimit": "^2.0.8",
+    "@upstash/redis": "^1.38.0"
   },
   "devDependencies": {
     "@vercel/node": "^5.8.17",

--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -9,7 +9,7 @@ import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
-  if (!checkRateLimit(req, res)) return;
+  if (!(await checkRateLimit(req, res))) return;
   const { publicKey } = req.query as { publicKey: string };
 
   if (!publicKey || !isValidStellarAddress(publicKey)) {

--- a/api/v1/tx/add-trustline.ts
+++ b/api/v1/tx/add-trustline.ts
@@ -1,4 +1,4 @@
-import type { VercelRequest, VercelResponse } from "@vercel/node";
+﻿import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildAddTrustlineTx } from "@meridian/stellar-sdk-helpers";
 import {
   APP_NETWORK,
@@ -10,7 +10,7 @@ import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
-  if (!checkRateLimit(req, res)) return;
+  if (!(await checkRateLimit(req, res))) return;
   if (req.method !== "POST")
     return res.status(405).json({ error: "Method not allowed" });
 

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -1,4 +1,4 @@
-import type { VercelRequest, VercelResponse } from "@vercel/node";
+﻿import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildDepositTx } from "@meridian/stellar-sdk-helpers";
 import {
   APP_NETWORK,
@@ -11,7 +11,7 @@ import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
-  if (!checkRateLimit(req, res)) return;
+  if (!(await checkRateLimit(req, res))) return;
   if (req.method !== "POST")
     return res.status(405).json({ error: "Method not allowed" });
 

--- a/api/v1/tx/submit.ts
+++ b/api/v1/tx/submit.ts
@@ -1,4 +1,4 @@
-import type { VercelRequest, VercelResponse } from "@vercel/node";
+﻿import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { submitTx } from "@meridian/stellar-sdk-helpers";
 import {
   APP_NETWORK,
@@ -10,7 +10,7 @@ import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
-  if (!checkRateLimit(req, res)) return;
+  if (!(await checkRateLimit(req, res))) return;
   if (req.method !== "POST")
     return res.status(405).json({ error: "Method not allowed" });
 

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -1,4 +1,4 @@
-import type { VercelRequest, VercelResponse } from "@vercel/node";
+﻿import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildWithdrawTx } from "@meridian/stellar-sdk-helpers";
 import {
   APP_NETWORK,
@@ -11,7 +11,7 @@ import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
-  if (!checkRateLimit(req, res)) return;
+  if (!(await checkRateLimit(req, res))) return;
   if (req.method !== "POST")
     return res.status(405).json({ error: "Method not allowed" });
 

--- a/api/v1/vaults/index.ts
+++ b/api/v1/vaults/index.ts
@@ -15,7 +15,7 @@ const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
-  if (!checkRateLimit(req, res)) return;
+  if (!(await checkRateLimit(req, res))) return;
   try {
     const cached = isVaultCacheWarm();
     const vaults = await fetchAllVaults(APP_NETWORK.network);

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,21 +12,22 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fastify/cors": "^11.2.0",
+    "@fastify/rate-limit": "^11.1.0",
     "@meridian/shared": "workspace:*",
     "@meridian/stellar-sdk-helpers": "workspace:*",
     "@stellar/stellar-sdk": "^14.0.0",
+    "dotenv": "^17.4.2",
     "fastify": "^5.8.5",
-    "@fastify/cors": "^11.2.0",
-    "@fastify/rate-limit": "^11.1.0",
-    "zod": "^4.4.3",
-    "dotenv": "^17.4.2"
+    "ioredis": "^5.11.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.62.0",
+    "@typescript-eslint/parser": "^8.0.0",
     "tsx": "^4.22.1",
     "typescript": "^6.0.3",
-    "vitest": "^4.1.9",
-    "@typescript-eslint/eslint-plugin": "^8.62.0",
-    "@typescript-eslint/parser": "^8.0.0"
+    "vitest": "^4.1.9"
   }
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ config({ path: resolve(process.cwd(), "../../.env") });
 import Fastify from "fastify";
 import cors from "@fastify/cors";
 import rateLimit from "@fastify/rate-limit";
+import Redis from "ioredis";
 import { DEFAULT_ALLOWED_ORIGIN } from "@meridian/shared";
 import { vaultsRoute } from "./routes/vaults";
 import { positionsRoute } from "./routes/positions";
@@ -18,10 +19,18 @@ import { txRoute } from "./routes/tx";
 // Security headers: X-Content-Type-Options and X-Frame-Options on every response.
 const app = Fastify({ logger: true, bodyLimit: 10 * 1024 });
 
+const redisClient = process.env.REDIS_URL
+  ? new Redis(process.env.REDIS_URL)
+  : undefined;
+
 await app.register(cors, {
   origin: process.env.ALLOWED_ORIGIN ?? DEFAULT_ALLOWED_ORIGIN,
 });
-await app.register(rateLimit, { max: 100, timeWindow: "1 minute" });
+await app.register(rateLimit, {
+  max: 100,
+  timeWindow: "1 minute",
+  ...(redisClient ? { redis: redisClient } : {}),
+});
 
 app.addHook("onSend", (_req, reply, _payload, done) => {
   reply.header("X-Content-Type-Options", "nosniff");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,12 @@ importers:
       '@stellar/stellar-sdk':
         specifier: ^14.0.0
         version: 14.4.3
+      '@upstash/ratelimit':
+        specifier: ^2.0.8
+        version: 2.0.8(@upstash/redis@1.38.0)
+      '@upstash/redis':
+        specifier: ^1.38.0
+        version: 1.38.0
     devDependencies:
       '@vercel/node':
         specifier: ^5.8.17
@@ -76,6 +82,9 @@ importers:
       fastify:
         specifier: ^5.8.5
         version: 5.8.5
+      ioredis:
+        specifier: ^5.11.1
+        version: 5.11.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -1051,6 +1060,9 @@ packages:
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
+  '@ioredis/commands@1.10.0':
+    resolution: {integrity: sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==}
+
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
     engines: {node: 20 || >=22}
@@ -1615,6 +1627,18 @@ packages:
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
     deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
+  '@upstash/core-analytics@0.0.10':
+    resolution: {integrity: sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==}
+    engines: {node: '>=16.0.0'}
+
+  '@upstash/ratelimit@2.0.8':
+    resolution: {integrity: sha512-YSTMBJ1YIxsoPkUMX/P4DDks/xV5YYCswWMamU8ZIfK9ly6ppjRnVOyBhMDXBmzjODm4UQKcxsJPvaeFAijp5w==}
+    peerDependencies:
+      '@upstash/redis': ^1.34.3
+
+  '@upstash/redis@1.38.0':
+    resolution: {integrity: sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg==}
+
   '@vercel/build-utils@13.30.0':
     resolution: {integrity: sha512-fLIa8cpELsSoWbcxshaqegwlTCfKnbgsDmA6uIb+oA797xvSmYkPu5a781aRYCRdghgyOZF7NCSVgtZjHjunnQ==}
 
@@ -1995,6 +2019,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.1:
+    resolution: {integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==}
+    engines: {node: '>=0.10.0'}
+
   code-block-writer@10.1.1:
     resolution: {integrity: sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==}
 
@@ -2127,6 +2155,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -2536,6 +2568,10 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  ioredis@5.11.1:
+    resolution: {integrity: sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==}
+    engines: {node: '>=12.22.0'}
 
   ipaddr.js@2.4.0:
     resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
@@ -3131,6 +3167,14 @@ packages:
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
     peerDependencies:
@@ -3292,6 +3336,9 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
@@ -3459,6 +3506,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -4418,6 +4468,8 @@ snapshots:
 
   '@iconify/types@2.0.0': {}
 
+  '@ioredis/commands@1.10.0': {}
+
   '@isaacs/balanced-match@4.0.1': {}
 
   '@isaacs/brace-expansion@5.0.1':
@@ -4941,6 +4993,19 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@upstash/core-analytics@0.0.10':
+    dependencies:
+      '@upstash/redis': 1.38.0
+
+  '@upstash/ratelimit@2.0.8(@upstash/redis@1.38.0)':
+    dependencies:
+      '@upstash/core-analytics': 0.0.10
+      '@upstash/redis': 1.38.0
+
+  '@upstash/redis@1.38.0':
+    dependencies:
+      uncrypto: 0.1.3
+
   '@vercel/build-utils@13.30.0':
     dependencies:
       '@vercel/python-analysis': 0.11.1
@@ -5387,6 +5452,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.1: {}
+
   code-block-writer@10.1.1: {}
 
   color-convert@2.0.1:
@@ -5494,6 +5561,8 @@ snapshots:
       gopd: 1.2.0
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   dequal@2.0.3: {}
 
@@ -5998,6 +6067,18 @@ snapshots:
   inherits@2.0.4: {}
 
   internmap@2.0.3: {}
+
+  ioredis@5.11.1:
+    dependencies:
+      '@ioredis/commands': 1.10.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ipaddr.js@2.4.0: {}
 
@@ -6513,6 +6594,12 @@ snapshots:
       - '@types/react'
       - redux
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:
       redux: 5.0.1
@@ -6687,6 +6774,8 @@ snapshots:
   split2@4.2.0: {}
 
   stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
 
   std-env@4.1.0: {}
 
@@ -6873,6 +6962,8 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## Summary

- Replaced the in-memory `Map` in `api/_lib/middleware.ts` with `@upstash/ratelimit` using a sliding window, so the limit is enforced across all concurrent Vercel worker instances
- `checkRateLimit` falls back to the existing in-memory path when `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` are absent, keeping local dev working without credentials
- Wired `@fastify/rate-limit` in `apps/api` to an ioredis client when `REDIS_URL` is set, for consistency in multi-instance deployments
- Added all three new env vars to `.env.example` with setup instructions

## Test plan

- [x] `pnpm --filter @meridian/api-functions test` - 22 tests pass (in-memory fallback path exercised)
- [x] `pnpm --filter @meridian/api typecheck` exits 0
- [x] Verified `checkRateLimit` callers in all Vercel route handlers updated with `await`

Closes #146