### PR TITLE
chore: enable noUncheckedIndexedAccess and exactOptionalPropertyTypes

### DIFF
--- a/api/_lib/middleware.ts
+++ b/api/_lib/middleware.ts
@@ -35,11 +35,12 @@ function clientIp(req: VercelRequest): string {
   // x-vercel-forwarded-for is set by the Vercel edge and cannot be spoofed
   // by the client, unlike x-forwarded-for which is client-controlled.
   const vercelIp = req.headers["x-vercel-forwarded-for"];
-  if (typeof vercelIp === "string" && vercelIp) return vercelIp.split(",")[0].trim();
+  if (typeof vercelIp === "string" && vercelIp)
+    return vercelIp.split(",")[0]?.trim() ?? vercelIp;
 
   // Fallback for local dev (Fastify / pnpm dev) where Vercel headers are absent.
   const fwd = req.headers["x-forwarded-for"];
-  return (typeof fwd === "string" ? fwd.split(",")[0].trim() : null) ??
+  return (typeof fwd === "string" ? fwd.split(",")[0]?.trim() ?? fwd : null) ??
     req.socket?.remoteAddress ??
     "unknown";
 }

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -9,7 +9,7 @@ const INTERNAL_DETAIL = /https?:\/\/|C[A-Z2-7]{50,}/;
  */
 export function sanitizeTxError(err: unknown, fallback: string): string {
   if (!(err instanceof Error)) return fallback;
-  const first = err.message.split("\n")[0].trim();
+  const first = err.message.split("\n")[0]?.trim();
   if (!first || INTERNAL_DETAIL.test(first)) return fallback;
   return first;
 }

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -153,7 +153,8 @@ export async function buildAddTrustlineTx(
   if (!hasAssetTrustline(balances, "USDC", USDC_ISSUER[network.network] ?? "")) {
     ops.push(Operation.changeTrust({ asset: usdcAsset(network) }));
   }
-  if (MUSDC_ISSUER[network.network] && !hasAssetTrustline(balances, "MUSDC", MUSDC_ISSUER[network.network])) {
+  const musdcIssuer = MUSDC_ISSUER[network.network];
+  if (musdcIssuer && !hasAssetTrustline(balances, "MUSDC", musdcIssuer)) {
     ops.push(Operation.changeTrust({ asset: musdcAsset(network) }));
   }
 
@@ -232,7 +233,7 @@ export async function waitForTransaction(
  * messages. Returns a generic fallback when the string is empty.
  */
 export function simErrorMessage(raw: string): string {
-  return raw.split("\n")[0].trim() || "Simulation failed (no detail)";
+  return raw.split("\n")[0]?.trim() || "Simulation failed (no detail)";
 }
 
 // Best-effort decode of the result code the RPC returns on a rejected submit

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,8 @@
     "noFallthroughCasesInSwitch": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true
   }
 }


### PR DESCRIPTION
## Summary

- Adds `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` to the root `tsconfig.json`, applying to all packages
- Fixes the three type errors surfaced by the new flags:
  - `packages/shared/src/utils.ts`: optional-chains the first element of `.split("\n")` before calling `.trim()`
  - `packages/stellar-sdk-helpers/src/tx.ts`: extracts `MUSDC_ISSUER[network.network]` into a typed local variable so TypeScript narrows it to `string` inside the guard
  - `packages/stellar-sdk-helpers/src/tx.ts`: optional-chains the first element of `.split("\n")` in `simErrorMessage`

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test` pass locally

Closes #270