### PR TITLE
chore: add CI quality gates for formatting, commits, PR titles, and deps

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug Report
 about: Report a bug in Meridian — include enough detail to reproduce it
 title: "[Bug] "
 labels: bug
-assignees: ''
+assignees: ""
 ---
 
 ## Description
@@ -26,14 +26,14 @@ assignees: ''
 
 ## Environment
 
-| Field | Value |
-|---|---|
-| Network | <!-- testnet / mainnet --> |
-| Wallet | <!-- Freighter / Albedo / other --> |
-| Protocol affected | <!-- Blend / DeFindex / API / Frontend / None --> |
-| Browser (if frontend) | <!-- e.g. Chrome 124, Firefox 126 --> |
-| Node.js version | <!-- `node -v` --> |
-| pnpm version | <!-- `pnpm -v` --> |
+| Field                 | Value                                             |
+| --------------------- | ------------------------------------------------- |
+| Network               | <!-- testnet / mainnet -->                        |
+| Wallet                | <!-- Freighter / Albedo / other -->               |
+| Protocol affected     | <!-- Blend / DeFindex / API / Frontend / None --> |
+| Browser (if frontend) | <!-- e.g. Chrome 124, Firefox 126 -->             |
+| Node.js version       | <!-- `node -v` -->                                |
+| pnpm version          | <!-- `pnpm -v` -->                                |
 
 ## Transaction Details (if on-chain)
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature Request
 about: Propose a new feature or improvement for Meridian
 title: "[Feature] "
 labels: enhancement
-assignees: ''
+assignees: ""
 ---
 
 ## Summary
@@ -20,12 +20,12 @@ assignees: ''
 
 ## Scope
 
-| Field | Value |
-| --- | --- |
-| Area | <!-- Frontend / API / SDK / Contracts / Docs / CI --> |
-| Protocol affected | <!-- Blend / DeFindex / Both / None --> |
-| Network | <!-- testnet / mainnet / both --> |
-| Breaking change? | <!-- Yes / No --> |
+| Field             | Value                                                 |
+| ----------------- | ----------------------------------------------------- |
+| Area              | <!-- Frontend / API / SDK / Contracts / Docs / CI --> |
+| Protocol affected | <!-- Blend / DeFindex / Both / None -->               |
+| Network           | <!-- testnet / mainnet / both -->                     |
+| Breaking change?  | <!-- Yes / No -->                                     |
 
 ## Alternatives Considered
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           node-version: 20
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - run: pnpm format:check
       - run: pnpm lint
       - run: pnpm typecheck
       # The Vercel serverless functions in api/ live outside the pnpm workspace,
@@ -36,6 +37,49 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
+
+  commitlint:
+    name: Commit Messages
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.mjs
+
+  pr-lint:
+    name: PR Title
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            style
+            ci
+            perf
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    # Requires the Dependency graph to be enabled in repository settings
+    # (Settings > Security and analysis > Dependency graph).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v4
 
   contracts:
     name: Soroban Contract Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,14 @@ jobs:
             ci
             perf
 
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/dependency-review-action@v4
+
   contracts:
     name: Soroban Contract Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,17 +70,6 @@ jobs:
             ci
             perf
 
-  dependency-review:
-    name: Dependency Review
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    # Requires the Dependency graph to be enabled in repository settings
-    # (Settings > Security and analysis > Dependency graph).
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/dependency-review-action@v4
-
   contracts:
     name: Soroban Contract Tests
     runs-on: ubuntu-latest

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+node_modules/
+dist/
+.turbo/
+target/
+pnpm-lock.yaml
+apps/docs/.vitepress/dist/
+apps/docs/.vitepress/cache/
+packages/contracts/

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **`/api/v1/vaults`: cache at the CDN edge.** Added `Cache-Control:
-  s-maxage=60, stale-while-revalidate=300` so the aggregated vault list is served
+s-maxage=60, stale-while-revalidate=300` so the aggregated vault list is served
   from Vercel's edge — cutting DeFiLlama call volume and letting the edge keep
   serving the last good payload through a transient DeFiLlama outage instead of
   failing the dashboard.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,12 +68,12 @@ If this is your first open-source contribution, start here:
 
 Before cloning, confirm you have the required tools installed:
 
-| Tool | Required version | Check |
-| --- | --- | --- |
-| Node.js | `>=20` | `node --version` |
-| pnpm | `9.x` | `pnpm --version` |
-| Rust toolchain | stable (latest) | `rustc --version` |
-| Soroban CLI | latest | `soroban --version` |
+| Tool           | Required version | Check               |
+| -------------- | ---------------- | ------------------- |
+| Node.js        | `>=20`           | `node --version`    |
+| pnpm           | `9.x`            | `pnpm --version`    |
+| Rust toolchain | stable (latest)  | `rustc --version`   |
+| Soroban CLI    | latest           | `soroban --version` |
 
 Rust and Soroban CLI are only required if you are working on the smart contracts in `packages/contracts`. TypeScript-only contributors can skip them.
 
@@ -122,12 +122,12 @@ npm install -g pnpm@9
 
    Edit `.env` and set the values you need:
 
-   | Variable | Required for | Description |
-   | --- | --- | --- |
-   | `PORT` | API | Port for the Fastify API server. Default `3001`. |
-   | `ALLOWED_ORIGIN` | API | CORS allowed origin. Default `http://localhost:3000`. |
-   | `DEFINDEX_VAULT_ID` | API | DeFindex vault contract address (C-address). Leave empty to disable DeFindex; only Blend positions are returned. |
-   | `VITE_API_URL` | Web | URL the web app uses to reach the API. Default `http://localhost:3001`. |
+   | Variable            | Required for | Description                                                                                                      |
+   | ------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+   | `PORT`              | API          | Port for the Fastify API server. Default `3001`.                                                                 |
+   | `ALLOWED_ORIGIN`    | API          | CORS allowed origin. Default `http://localhost:3000`.                                                            |
+   | `DEFINDEX_VAULT_ID` | API          | DeFindex vault contract address (C-address). Leave empty to disable DeFindex; only Blend positions are returned. |
+   | `VITE_API_URL`      | Web          | URL the web app uses to reach the API. Default `http://localhost:3001`.                                          |
 
 6. Start the development servers:
 
@@ -179,14 +179,14 @@ Every issue title must use the bracket prefix format:
 [Type] Short imperative description
 ```
 
-| Prefix | When to use |
-| --- | --- |
+| Prefix             | When to use                                 |
+| ------------------ | ------------------------------------------- |
 | `[Bug]` or `[Fix]` | Something is broken or behaving incorrectly |
-| `[Feature]` | New capability or significant enhancement |
-| `[Frontend]` | Frontend-scoped work (React, UI, Tailwind) |
-| `[Test]` | Adds or improves test coverage |
-| `[Docs]` | Documentation, README, JSDoc, guides |
-| `[Chore]` | Refactor, cleanup, dependency update, CI |
+| `[Feature]`        | New capability or significant enhancement   |
+| `[Frontend]`       | Frontend-scoped work (React, UI, Tailwind)  |
+| `[Test]`           | Adds or improves test coverage              |
+| `[Docs]`           | Documentation, README, JSDoc, guides        |
+| `[Chore]`          | Refactor, cleanup, dependency update, CI    |
 
 ### Which template to use
 
@@ -197,11 +197,11 @@ Every issue title must use the bracket prefix format:
 
 Apply labels from all three categories before submitting. PRs linked to unlabelled issues will be asked to add labels before review begins.
 
-| Category | Pick | Options |
-| --- | --- | --- |
-| Purpose | one | `bug`, `enhancement`, `docs`, `testing`, `chore`, `security` |
-| Area | all that apply | `frontend`, `api`, `sdk`, `contracts`, `ci`, `ui`, `i18n`, `stellar`, `soroban` |
-| Complexity | one | `trivial`, `medium`, `hard` |
+| Category   | Pick           | Options                                                                         |
+| ---------- | -------------- | ------------------------------------------------------------------------------- |
+| Purpose    | one            | `bug`, `enhancement`, `docs`, `testing`, `chore`, `security`                    |
+| Area       | all that apply | `frontend`, `api`, `sdk`, `contracts`, `ci`, `ui`, `i18n`, `stellar`, `soroban` |
+| Complexity | one            | `trivial`, `medium`, `hard`                                                     |
 
 Use `good first issue` in place of a complexity label for tasks that are fully isolated and require no Stellar or Soroban knowledge.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Submitted to the **Drips Stellar Wave Program**.
 Meridian is a **testnet technical preview**, not a finished product. Be clear-eyed about what exists today before depositing real funds (you can't yet — mainnet is not wired).
 
 **Working today (testnet)**
+
 - Live APY / TVL feed across Stellar stablecoin pools (via DeFiLlama) with a risk heuristic
 - Non-custodial signing flow: the API builds an unsigned Soroban XDR, your wallet (Freighter) signs and submits it — keys never leave the browser
 - **Direct deposit / withdraw against a real Blend pool**: funds supply straight into Blend from your wallet and the resulting bToken position is yours — no Meridian-controlled custody
@@ -22,7 +23,7 @@ Meridian is a **testnet technical preview**, not a finished product. Be clear-ey
 
 **In progress — the core promise is not finished**
 
-- Direct deposit/withdraw against real DeFindex vaults — *transaction builders are implemented; gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired*
+- Direct deposit/withdraw against real DeFindex vaults — _transaction builders are implemented; gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired_
 - Per-position yield earned (cost-basis tracking for direct Blend/DeFindex positions)
 - Mainnet configuration and a security audit before any real-funds use
 
@@ -74,16 +75,16 @@ The API never holds private keys. It builds an unsigned Soroban transaction, ret
 
 ## Tech Stack
 
-| Layer | Technology |
-| --- | --- |
-| Frontend | Vite 8, React 19, Tailwind CSS, Zustand, TanStack Query |
-| Backend (prod) | Vercel Serverless Functions, Zod validation |
-| Backend (local) | Fastify |
-| Blockchain | Stellar Soroban, `@stellar/stellar-sdk` v12 |
-| Protocols | Blend Capital, DeFindex |
-| Contracts | Rust / Soroban SDK |
-| Monorepo | pnpm workspaces, Turborepo |
-| CI | GitHub Actions |
+| Layer           | Technology                                              |
+| --------------- | ------------------------------------------------------- |
+| Frontend        | Vite 8, React 19, Tailwind CSS, Zustand, TanStack Query |
+| Backend (prod)  | Vercel Serverless Functions, Zod validation             |
+| Backend (local) | Fastify                                                 |
+| Blockchain      | Stellar Soroban, `@stellar/stellar-sdk` v12             |
+| Protocols       | Blend Capital, DeFindex                                 |
+| Contracts       | Rust / Soroban SDK                                      |
+| Monorepo        | pnpm workspaces, Turborepo                              |
+| CI              | GitHub Actions                                          |
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,12 +82,12 @@ We will keep you informed at each stage. If you do not receive an acknowledgemen
 
 ## Severity Guidance
 
-| Severity     | Examples                                                        |
-| ------------ | --------------------------------------------------------------- |
-| **Critical** | Drain funds via mainnet contract exploit; private key exposure  |
-| **High**     | Unauthorised tx signing; testnet exploit with mainnet path      |
-| **Medium**   | API auth bypass without fund access; XSS in wallet flow         |
-| **Low**      | Information disclosure; input gap with no fund risk             |
+| Severity     | Examples                                                       |
+| ------------ | -------------------------------------------------------------- |
+| **Critical** | Drain funds via mainnet contract exploit; private key exposure |
+| **High**     | Unauthorised tx signing; testnet exploit with mainnet path     |
+| **Medium**   | API auth bypass without fund access; XSS in wallet flow        |
+| **Low**      | Information disclosure; input gap with no fund risk            |
 
 **On-chain contracts deployed to mainnet are always treated as Critical severity regardless of the apparent difficulty of exploitation.** Even a theoretical vulnerability in a contract holding user funds warrants immediate response.
 

--- a/api/__tests__/handlers.test.ts
+++ b/api/__tests__/handlers.test.ts
@@ -9,11 +9,19 @@ vi.mock("@meridian/stellar-sdk-helpers", () => ({
   buildWithdrawTx: vi.fn(async () => ({ xdr: "WITHDRAW_XDR", fee: "100" })),
   buildAddTrustlineTx: vi.fn(async () => ({ xdr: "TRUST_XDR" })),
   submitTx: vi.fn(async () => ({ hash: "HASH" })),
-  fetchAllVaults: vi.fn(async () => [{ id: "blend-usdc-fixed", protocol: "blend" }]),
+  fetchAllVaults: vi.fn(async () => [
+    { id: "blend-usdc-fixed", protocol: "blend" },
+  ]),
   selectBestVault: vi.fn(() => ({ id: "blend-usdc-fixed" })),
   isVaultCacheWarm: vi.fn(() => false),
   resolvePositions: vi.fn(async () => [
-    { vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 },
+    {
+      vaultId: "blend-usdc-fixed",
+      shares: 1,
+      deposited: 1,
+      earned: 0,
+      entryTime: 0,
+    },
   ]),
 }));
 
@@ -23,12 +31,16 @@ import trustlineHandler from "../v1/tx/add-trustline";
 import submitHandler from "../v1/tx/submit";
 import vaultsHandler from "../v1/vaults/index";
 import positionsHandler from "../v1/positions/[publicKey]";
-import { buildDepositTx, resolvePositions } from "@meridian/stellar-sdk-helpers";
+import {
+  buildDepositTx,
+  resolvePositions,
+} from "@meridian/stellar-sdk-helpers";
 
 // A 56-char Stellar public key shape (only the length is validated).
 const PUBKEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
-const fakeReq = (obj: object) => ({ headers: {}, ...obj }) as unknown as VercelRequest;
+const fakeReq = (obj: object) =>
+  ({ headers: {}, ...obj }) as unknown as VercelRequest;
 
 interface FakeRes {
   statusCode: number;
@@ -70,15 +82,28 @@ describe("POST /api/v1/tx/deposit", () => {
 
   it("returns 400 listing the missing fields", async () => {
     const res = makeRes();
-    await depositHandler(fakeReq({ method: "POST", body: { walletAddress: PUBKEY } }), res);
+    await depositHandler(
+      fakeReq({ method: "POST", body: { walletAddress: PUBKEY } }),
+      res
+    );
     expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: "vaultId: Invalid input: expected string, received undefined; amount: Invalid input: expected string, received undefined" });
+    expect(res.body).toEqual({
+      error:
+        "vaultId: Invalid input: expected string, received undefined; amount: Invalid input: expected string, received undefined",
+    });
   });
 
   it("builds the deposit transaction and returns the XDR", async () => {
     const res = makeRes();
     await depositHandler(
-      fakeReq({ method: "POST", body: { walletAddress: PUBKEY, vaultId: "blend-usdc-fixed", amount: "10" } }),
+      fakeReq({
+        method: "POST",
+        body: {
+          walletAddress: PUBKEY,
+          vaultId: "blend-usdc-fixed",
+          amount: "10",
+        },
+      }),
       res
     );
     expect(res.statusCode).toBe(200);
@@ -87,10 +112,19 @@ describe("POST /api/v1/tx/deposit", () => {
   });
 
   it("surfaces builder errors as 500", async () => {
-    vi.mocked(buildDepositTx).mockRejectedValueOnce(new Error("USDC trustline missing"));
+    vi.mocked(buildDepositTx).mockRejectedValueOnce(
+      new Error("USDC trustline missing")
+    );
     const res = makeRes();
     await depositHandler(
-      fakeReq({ method: "POST", body: { walletAddress: PUBKEY, vaultId: "blend-usdc-fixed", amount: "10" } }),
+      fakeReq({
+        method: "POST",
+        body: {
+          walletAddress: PUBKEY,
+          vaultId: "blend-usdc-fixed",
+          amount: "10",
+        },
+      }),
       res
     );
     expect(res.statusCode).toBe(500);
@@ -101,15 +135,30 @@ describe("POST /api/v1/tx/deposit", () => {
 describe("POST /api/v1/tx/withdraw", () => {
   it("returns 400 when shares is missing", async () => {
     const res = makeRes();
-    await withdrawHandler(fakeReq({ method: "POST", body: { walletAddress: PUBKEY, vaultId: "v" } }), res);
+    await withdrawHandler(
+      fakeReq({
+        method: "POST",
+        body: { walletAddress: PUBKEY, vaultId: "v" },
+      }),
+      res
+    );
     expect(res.statusCode).toBe(400);
-    expect(res.body).toEqual({ error: "shares: Invalid input: expected string, received undefined" });
+    expect(res.body).toEqual({
+      error: "shares: Invalid input: expected string, received undefined",
+    });
   });
 
   it("builds the withdraw transaction", async () => {
     const res = makeRes();
     await withdrawHandler(
-      fakeReq({ method: "POST", body: { walletAddress: PUBKEY, vaultId: "blend-usdc-fixed", shares: "5" } }),
+      fakeReq({
+        method: "POST",
+        body: {
+          walletAddress: PUBKEY,
+          vaultId: "blend-usdc-fixed",
+          shares: "5",
+        },
+      }),
       res
     );
     expect(res.body).toEqual({ xdr: "WITHDRAW_XDR", fee: "100" });
@@ -125,7 +174,10 @@ describe("POST /api/v1/tx/add-trustline", () => {
 
   it("returns the trustline XDR", async () => {
     const res = makeRes();
-    await trustlineHandler(fakeReq({ method: "POST", body: { walletAddress: PUBKEY } }), res);
+    await trustlineHandler(
+      fakeReq({ method: "POST", body: { walletAddress: PUBKEY } }),
+      res
+    );
     expect(res.body).toEqual({ xdr: "TRUST_XDR" });
   });
 });
@@ -139,7 +191,10 @@ describe("POST /api/v1/tx/submit", () => {
 
   it("submits and returns the tx hash", async () => {
     const res = makeRes();
-    await submitHandler(fakeReq({ method: "POST", body: { xdr: "SIGNED" } }), res);
+    await submitHandler(
+      fakeReq({ method: "POST", body: { xdr: "SIGNED" } }),
+      res
+    );
     expect(res.body).toEqual({ hash: "HASH" });
   });
 });
@@ -161,16 +216,30 @@ describe("GET /api/v1/vaults", () => {
 describe("GET /api/v1/positions/:publicKey", () => {
   it("rejects a malformed public key with 400", async () => {
     const res = makeRes();
-    await positionsHandler(fakeReq({ method: "GET", query: { publicKey: "too-short" } }), res);
+    await positionsHandler(
+      fakeReq({ method: "GET", query: { publicKey: "too-short" } }),
+      res
+    );
     expect(res.statusCode).toBe(400);
     expect(resolvePositions).not.toHaveBeenCalled();
   });
 
   it("returns the resolved positions for a valid key", async () => {
     const res = makeRes();
-    await positionsHandler(fakeReq({ method: "GET", query: { publicKey: PUBKEY } }), res);
+    await positionsHandler(
+      fakeReq({ method: "GET", query: { publicKey: PUBKEY } }),
+      res
+    );
     expect(res.body).toEqual({
-      positions: [{ vaultId: "blend-usdc-fixed", shares: 1, deposited: 1, earned: 0, entryTime: 0 }],
+      positions: [
+        {
+          vaultId: "blend-usdc-fixed",
+          shares: 1,
+          deposited: 1,
+          earned: 0,
+          entryTime: 0,
+        },
+      ],
     });
     expect(resolvePositions).toHaveBeenCalledOnce();
   });
@@ -178,7 +247,10 @@ describe("GET /api/v1/positions/:publicKey", () => {
   it("returns 503 when the Blend read throws", async () => {
     vi.mocked(resolvePositions).mockRejectedValueOnce(new Error("rpc down"));
     const res = makeRes();
-    await positionsHandler(fakeReq({ method: "GET", query: { publicKey: PUBKEY } }), res);
+    await positionsHandler(
+      fakeReq({ method: "GET", query: { publicKey: PUBKEY } }),
+      res
+    );
     expect(res.statusCode).toBe(503);
     expect(res.body).toEqual({ error: "Failed to read positions" });
   });

--- a/api/__tests__/middleware.test.ts
+++ b/api/__tests__/middleware.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { applyCors, checkRateLimit, resetRateLimitForTesting } from "../_lib/middleware.js";
+import {
+  applyCors,
+  checkRateLimit,
+  resetRateLimitForTesting,
+} from "../_lib/middleware.js";
 
 // Minimal fake request / response ------------------------------------------------
 
@@ -19,12 +23,28 @@ interface FakeRes {
 }
 
 function fakeRes(): FakeRes & VercelResponse {
-  const r: FakeRes = { statusCode: 200, body: undefined, headers: {}, ended: false };
+  const r: FakeRes = {
+    statusCode: 200,
+    body: undefined,
+    headers: {},
+    ended: false,
+  };
   return Object.assign(r, {
-    status(code: number) { r.statusCode = code; return this; },
-    json(payload: unknown) { r.body = payload; return this; },
-    end() { r.ended = true; return this; },
-    setHeader(k: string, v: string) { r.headers[k] = v; },
+    status(code: number) {
+      r.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      r.body = payload;
+      return this;
+    },
+    end() {
+      r.ended = true;
+      return this;
+    },
+    setHeader(k: string, v: string) {
+      r.headers[k] = v;
+    },
   }) as unknown as FakeRes & VercelResponse;
 }
 
@@ -66,7 +86,9 @@ describe("checkRateLimit", () => {
     const ip = "1.2.3.4";
     for (let i = 0; i < 100; i++) {
       const res = fakeRes();
-      expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)).toBe(true);
+      expect(
+        checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
+      ).toBe(true);
       expect(res.statusCode).toBe(200);
     }
   });
@@ -77,7 +99,9 @@ describe("checkRateLimit", () => {
       checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), fakeRes());
     }
     const res = fakeRes();
-    expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)).toBe(false);
+    expect(
+      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
+    ).toBe(false);
     expect(res.statusCode).toBe(429);
   });
 
@@ -90,7 +114,9 @@ describe("checkRateLimit", () => {
     // Advance past the 60 s window.
     vi.advanceTimersByTime(61_000);
     const res = fakeRes();
-    expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)).toBe(true);
+    expect(
+      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ip }), res)
+    ).toBe(true);
     expect(res.statusCode).toBe(200);
   });
 
@@ -102,9 +128,13 @@ describe("checkRateLimit", () => {
     }
     // ipA is blocked but ipB should still be allowed.
     const resA = fakeRes();
-    expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipA }), resA)).toBe(false);
+    expect(
+      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipA }), resA)
+    ).toBe(false);
     const resB = fakeRes();
-    expect(checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipB }), resB)).toBe(true);
+    expect(
+      checkRateLimit(fakeReq("POST", { "x-forwarded-for": ipB }), resB)
+    ).toBe(true);
   });
 
   it("uses x-vercel-forwarded-for over x-forwarded-for when both are present", () => {
@@ -112,7 +142,10 @@ describe("checkRateLimit", () => {
     const fwdIp = "9.9.9.9";
     for (let i = 0; i < 100; i++) {
       checkRateLimit(
-        fakeReq("POST", { "x-vercel-forwarded-for": vercelIp, "x-forwarded-for": fwdIp }),
+        fakeReq("POST", {
+          "x-vercel-forwarded-for": vercelIp,
+          "x-forwarded-for": fwdIp,
+        }),
         fakeRes()
       );
     }
@@ -120,7 +153,10 @@ describe("checkRateLimit", () => {
     const resBlocked = fakeRes();
     expect(
       checkRateLimit(
-        fakeReq("POST", { "x-vercel-forwarded-for": vercelIp, "x-forwarded-for": fwdIp }),
+        fakeReq("POST", {
+          "x-vercel-forwarded-for": vercelIp,
+          "x-forwarded-for": fwdIp,
+        }),
         resBlocked
       )
     ).toBe(false);

--- a/api/_lib/middleware.ts
+++ b/api/_lib/middleware.ts
@@ -40,9 +40,11 @@ function clientIp(req: VercelRequest): string {
 
   // Fallback for local dev (Fastify / pnpm dev) where Vercel headers are absent.
   const fwd = req.headers["x-forwarded-for"];
-  return (typeof fwd === "string" ? fwd.split(",")[0]?.trim() ?? fwd : null) ??
+  return (
+    (typeof fwd === "string" ? (fwd.split(",")[0]?.trim() ?? fwd) : null) ??
     req.socket?.remoteAddress ??
-    "unknown";
+    "unknown"
+  );
 }
 
 /**
@@ -50,7 +52,10 @@ function clientIp(req: VercelRequest): string {
  * Writes a 429 response and returns false when the limit is exceeded — the
  * caller should return immediately.
  */
-export function checkRateLimit(req: VercelRequest, res: VercelResponse): boolean {
+export function checkRateLimit(
+  req: VercelRequest,
+  res: VercelResponse
+): boolean {
   const ip = clientIp(req);
   const now = Date.now();
   const entry = counts.get(ip);
@@ -60,7 +65,9 @@ export function checkRateLimit(req: VercelRequest, res: VercelResponse): boolean
     return true;
   }
   if (entry.n >= LIMIT) {
-    res.status(429).json({ error: "Too many requests. Try again in a minute." });
+    res
+      .status(429)
+      .json({ error: "Too many requests. Try again in a minute." });
     return false;
   }
   entry.n++;

--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,6 +1,10 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { resolvePositions } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, buildTxAddresses, isValidStellarAddress } from "@meridian/shared";
+import {
+  APP_NETWORK,
+  buildTxAddresses,
+  isValidStellarAddress,
+} from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -13,7 +17,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const positions = await resolvePositions(publicKey, APP_NETWORK, buildTxAddresses(process.env.DEFINDEX_VAULT_ID));
+    const positions = await resolvePositions(
+      publicKey,
+      APP_NETWORK,
+      buildTxAddresses(process.env.DEFINDEX_VAULT_ID)
+    );
     res.json({ positions });
   } catch (err) {
     console.error("[positions] error:", err);

--- a/api/v1/tx/add-trustline.ts
+++ b/api/v1/tx/add-trustline.ts
@@ -1,21 +1,33 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildAddTrustlineTx } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, TrustlineRequestSchema, formatZodError, sanitizeTxError } from "@meridian/shared";
+import {
+  APP_NETWORK,
+  TrustlineRequestSchema,
+  formatZodError,
+  sanitizeTxError,
+} from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   if (!checkRateLimit(req, res)) return;
-  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  if (req.method !== "POST")
+    return res.status(405).json({ error: "Method not allowed" });
 
   const parsed = TrustlineRequestSchema.safeParse(req.body);
-  if (!parsed.success) return res.status(400).json({ error: formatZodError(parsed.error) });
+  if (!parsed.success)
+    return res.status(400).json({ error: formatZodError(parsed.error) });
 
   try {
-    const result = await buildAddTrustlineTx(parsed.data.walletAddress, APP_NETWORK);
+    const result = await buildAddTrustlineTx(
+      parsed.data.walletAddress,
+      APP_NETWORK
+    );
     res.json(result);
   } catch (err) {
     console.error("[tx/add-trustline] build failed:", err);
-    res.status(500).json({ error: sanitizeTxError(err, "Failed to build trustline transaction") });
+    res.status(500).json({
+      error: sanitizeTxError(err, "Failed to build trustline transaction"),
+    });
   }
 }

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -1,26 +1,38 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildDepositTx } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, buildTxAddresses, DepositRequestSchema, formatZodError, sanitizeTxError } from "@meridian/shared";
+import {
+  APP_NETWORK,
+  buildTxAddresses,
+  DepositRequestSchema,
+  formatZodError,
+  sanitizeTxError,
+} from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   if (!checkRateLimit(req, res)) return;
-  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  if (req.method !== "POST")
+    return res.status(405).json({ error: "Method not allowed" });
 
   const parsed = DepositRequestSchema.safeParse(req.body);
-  if (!parsed.success) return res.status(400).json({ error: formatZodError(parsed.error) });
+  if (!parsed.success)
+    return res.status(400).json({ error: formatZodError(parsed.error) });
 
   try {
     const { walletAddress, vaultId, amount } = parsed.data;
     const result = await buildDepositTx(
-      vaultId, walletAddress, amount,
+      vaultId,
+      walletAddress,
+      amount,
       buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
       APP_NETWORK
     );
     return res.json(result);
   } catch (err) {
     console.error("[tx/deposit] build failed:", err);
-    res.status(500).json({ error: sanitizeTxError(err, "Failed to build deposit transaction") });
+    res.status(500).json({
+      error: sanitizeTxError(err, "Failed to build deposit transaction"),
+    });
   }
 }

--- a/api/v1/tx/submit.ts
+++ b/api/v1/tx/submit.ts
@@ -1,21 +1,30 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { submitTx } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, SubmitRequestSchema, formatZodError, sanitizeTxError } from "@meridian/shared";
+import {
+  APP_NETWORK,
+  SubmitRequestSchema,
+  formatZodError,
+  sanitizeTxError,
+} from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   if (!checkRateLimit(req, res)) return;
-  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  if (req.method !== "POST")
+    return res.status(405).json({ error: "Method not allowed" });
 
   const parsed = SubmitRequestSchema.safeParse(req.body);
-  if (!parsed.success) return res.status(400).json({ error: formatZodError(parsed.error) });
+  if (!parsed.success)
+    return res.status(400).json({ error: formatZodError(parsed.error) });
 
   try {
     const result = await submitTx(parsed.data.xdr, APP_NETWORK);
     res.json(result);
   } catch (err) {
     console.error("[tx/submit] failed:", err);
-    res.status(500).json({ error: sanitizeTxError(err, "Failed to submit transaction") });
+    res
+      .status(500)
+      .json({ error: sanitizeTxError(err, "Failed to submit transaction") });
   }
 }

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -1,26 +1,38 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { buildWithdrawTx } from "@meridian/stellar-sdk-helpers";
-import { APP_NETWORK, buildTxAddresses, WithdrawRequestSchema, formatZodError, sanitizeTxError } from "@meridian/shared";
+import {
+  APP_NETWORK,
+  buildTxAddresses,
+  WithdrawRequestSchema,
+  formatZodError,
+  sanitizeTxError,
+} from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (applyCors(req, res)) return;
   if (!checkRateLimit(req, res)) return;
-  if (req.method !== "POST") return res.status(405).json({ error: "Method not allowed" });
+  if (req.method !== "POST")
+    return res.status(405).json({ error: "Method not allowed" });
 
   const parsed = WithdrawRequestSchema.safeParse(req.body);
-  if (!parsed.success) return res.status(400).json({ error: formatZodError(parsed.error) });
+  if (!parsed.success)
+    return res.status(400).json({ error: formatZodError(parsed.error) });
 
   try {
     const { walletAddress, vaultId, shares } = parsed.data;
     const result = await buildWithdrawTx(
-      vaultId, walletAddress, shares,
+      vaultId,
+      walletAddress,
+      shares,
       buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
       APP_NETWORK
     );
     return res.json(result);
   } catch (err) {
     console.error("[tx/withdraw] build failed:", err);
-    res.status(500).json({ error: sanitizeTxError(err, "Failed to build withdraw transaction") });
+    res.status(500).json({
+      error: sanitizeTxError(err, "Failed to build withdraw transaction"),
+    });
   }
 }

--- a/api/v1/vaults/[vaultId].ts
+++ b/api/v1/vaults/[vaultId].ts
@@ -5,7 +5,10 @@ import { APP_NETWORK } from "@meridian/shared";
 
 const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
 const KNOWN_VAULT_IDS = new Set(
-  [...Object.values(KNOWN_POOLS.mainnet), ...Object.values(KNOWN_POOLS.testnet)].map((p) => p.id)
+  [
+    ...Object.values(KNOWN_POOLS.mainnet),
+    ...Object.values(KNOWN_POOLS.testnet),
+  ].map((p) => p.id)
 );
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -13,12 +16,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const raw = req.query["vaultId"];
   const vaultId = typeof raw === "string" ? raw : undefined;
   if (!vaultId) return res.status(400).json({ error: "vaultId is required" });
-  if (!KNOWN_VAULT_IDS.has(vaultId)) return res.status(404).json({ error: "vault not found", vaultId });
+  if (!KNOWN_VAULT_IDS.has(vaultId))
+    return res.status(404).json({ error: "vault not found", vaultId });
 
   try {
     const vaults = await fetchAllVaults(APP_NETWORK.network);
     const vault = vaults.find((v) => v.id === vaultId);
-    if (!vault) return res.status(404).json({ error: "vault not found", vaultId });
+    if (!vault)
+      return res.status(404).json({ error: "vault not found", vaultId });
     res.setHeader("Cache-Control", CACHE_CONTROL);
     res.json(vault);
   } catch (err) {

--- a/api/v1/vaults/index.ts
+++ b/api/v1/vaults/index.ts
@@ -1,5 +1,9 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
-import { fetchAllVaults, selectBestVault, isVaultCacheWarm } from "@meridian/stellar-sdk-helpers";
+import {
+  fetchAllVaults,
+  selectBestVault,
+  isVaultCacheWarm,
+} from "@meridian/stellar-sdk-helpers";
 import { isDefindexConfigured, APP_NETWORK } from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
@@ -15,7 +19,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     const cached = isVaultCacheWarm();
     const vaults = await fetchAllVaults(APP_NETWORK.network);
-    const best = selectBestVault(vaults, { defindexConfigured: isDefindexConfigured() });
+    const best = selectBestVault(vaults, {
+      defindexConfigured: isDefindexConfigured(),
+    });
     res.setHeader("Cache-Control", CACHE_CONTROL);
     res.json({
       vaults,

--- a/apps/api/src/__tests__/routes.test.ts
+++ b/apps/api/src/__tests__/routes.test.ts
@@ -51,17 +51,31 @@ describe("GET /health", () => {
 describe("GET /api/v1/positions/:publicKey", () => {
   it("returns 200 with positions from the SDK", async () => {
     const app = buildApp();
-    const pos = [{ vaultId: "blend-usdc-fixed", shares: 10, deposited: 10, earned: 0, entryTime: 0 }];
+    const pos = [
+      {
+        vaultId: "blend-usdc-fixed",
+        shares: 10,
+        deposited: 10,
+        earned: 0,
+        entryTime: 0,
+      },
+    ];
     vi.mocked(resolvePositions).mockResolvedValue(pos);
 
-    const res = await app.inject({ method: "GET", url: `/api/v1/positions/${WALLET}` });
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/positions/${WALLET}`,
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ positions: pos });
   });
 
   it("returns 400 for an invalid public key", async () => {
     const app = buildApp();
-    const res = await app.inject({ method: "GET", url: "/api/v1/positions/not-a-key" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/positions/not-a-key",
+    });
     expect(res.statusCode).toBe(400);
     expect(res.json()).toHaveProperty("error");
   });
@@ -69,14 +83,21 @@ describe("GET /api/v1/positions/:publicKey", () => {
   it("returns 503 when the SDK throws", async () => {
     const app = buildApp();
     vi.mocked(resolvePositions).mockRejectedValue(new Error("RPC down"));
-    const res = await app.inject({ method: "GET", url: `/api/v1/positions/${WALLET}` });
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/v1/positions/${WALLET}`,
+    });
     expect(res.statusCode).toBe(503);
     expect(res.json()).toHaveProperty("error");
   });
 });
 
 describe("POST /api/v1/tx/deposit", () => {
-  const validBody = { walletAddress: WALLET, vaultId: "blend-usdc-fixed", amount: "10" };
+  const validBody = {
+    walletAddress: WALLET,
+    vaultId: "blend-usdc-fixed",
+    amount: "10",
+  };
 
   it("returns 200 with xdr and fee from the SDK", async () => {
     const app = buildApp();
@@ -117,7 +138,9 @@ describe("POST /api/v1/tx/deposit", () => {
 
   it("returns 500 when the SDK throws a simulation error", async () => {
     const app = buildApp();
-    vi.mocked(buildDepositTx).mockRejectedValue(new Error("Simulation failed: HostError"));
+    vi.mocked(buildDepositTx).mockRejectedValue(
+      new Error("Simulation failed: HostError")
+    );
 
     const res = await app.inject({
       method: "POST",
@@ -131,11 +154,18 @@ describe("POST /api/v1/tx/deposit", () => {
 });
 
 describe("POST /api/v1/tx/withdraw", () => {
-  const validBody = { walletAddress: WALLET, vaultId: "blend-usdc-fixed", shares: "5" };
+  const validBody = {
+    walletAddress: WALLET,
+    vaultId: "blend-usdc-fixed",
+    shares: "5",
+  };
 
   it("returns 200 with xdr and fee from the SDK", async () => {
     const app = buildApp();
-    vi.mocked(buildWithdrawTx).mockResolvedValue({ xdr: "WITHDRAWXDR", fee: "100" });
+    vi.mocked(buildWithdrawTx).mockResolvedValue({
+      xdr: "WITHDRAWXDR",
+      fee: "100",
+    });
 
     const res = await app.inject({
       method: "POST",
@@ -153,7 +183,10 @@ describe("POST /api/v1/tx/withdraw", () => {
       method: "POST",
       url: "/api/v1/tx/withdraw",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ walletAddress: WALLET, vaultId: "blend-usdc-fixed" }),
+      body: JSON.stringify({
+        walletAddress: WALLET,
+        vaultId: "blend-usdc-fixed",
+      }),
     });
     expect(res.statusCode).toBe(400);
   });
@@ -202,7 +235,11 @@ describe("POST /api/v1/tx/add-trustline", () => {
 describe("POST /api/v1/tx/submit", () => {
   it("returns 200 with the submit result from the SDK", async () => {
     const app = buildApp();
-    vi.mocked(submitTx).mockResolvedValue({ hash: "abc123", status: "SUCCESS", ledger: 42 });
+    vi.mocked(submitTx).mockResolvedValue({
+      hash: "abc123",
+      status: "SUCCESS",
+      ledger: 42,
+    });
 
     const res = await app.inject({
       method: "POST",
@@ -211,7 +248,11 @@ describe("POST /api/v1/tx/submit", () => {
       body: JSON.stringify({ xdr: "SIGNEDXDR" }),
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({ hash: "abc123", status: "SUCCESS", ledger: 42 });
+    expect(res.json()).toMatchObject({
+      hash: "abc123",
+      status: "SUCCESS",
+      ledger: 42,
+    });
   });
 
   it("returns 400 for an empty xdr string", async () => {
@@ -273,7 +314,11 @@ describe("rate limiting on /api/v1/tx/deposit", () => {
       method: "POST" as const,
       url: "/api/v1/tx/deposit",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ walletAddress: WALLET, vaultId: "blend-usdc-fixed", amount: "10" }),
+      body: JSON.stringify({
+        walletAddress: WALLET,
+        vaultId: "blend-usdc-fixed",
+        amount: "10",
+      }),
     };
 
     for (let i = 0; i < 10; i++) {
@@ -292,7 +337,10 @@ describe("GET /api/v1/vaults/:vaultId", () => {
     const vault = { id: "blend-usdc-fixed", apy: 0.05 };
     vi.mocked(fetchAllVaults).mockResolvedValue([vault] as never);
 
-    const res = await app.inject({ method: "GET", url: "/api/v1/vaults/blend-usdc-fixed" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/vaults/blend-usdc-fixed",
+    });
     expect(res.statusCode).toBe(200);
     expect(res.json()).toMatchObject({ id: "blend-usdc-fixed" });
   });
@@ -301,7 +349,10 @@ describe("GET /api/v1/vaults/:vaultId", () => {
     const app = buildApp();
     vi.mocked(fetchAllVaults).mockResolvedValue([] as never);
 
-    const res = await app.inject({ method: "GET", url: "/api/v1/vaults/unknown" });
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/v1/vaults/unknown",
+    });
     expect(res.statusCode).toBe(404);
     expect(res.json()).toHaveProperty("error");
   });

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -18,7 +18,9 @@ import { txRoute } from "./routes/tx";
 // Security headers: X-Content-Type-Options and X-Frame-Options on every response.
 const app = Fastify({ logger: true, bodyLimit: 10 * 1024 });
 
-await app.register(cors, { origin: process.env.ALLOWED_ORIGIN ?? DEFAULT_ALLOWED_ORIGIN });
+await app.register(cors, {
+  origin: process.env.ALLOWED_ORIGIN ?? DEFAULT_ALLOWED_ORIGIN,
+});
 await app.register(rateLimit, { max: 100, timeWindow: "1 minute" });
 
 app.addHook("onSend", (_req, reply, _payload, done) => {

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -1,5 +1,9 @@
 import type { FastifyPluginAsync } from "fastify";
-import { APP_NETWORK, buildTxAddresses, isValidStellarAddress } from "@meridian/shared";
+import {
+  APP_NETWORK,
+  buildTxAddresses,
+  isValidStellarAddress,
+} from "@meridian/shared";
 import { resolvePositions } from "@meridian/stellar-sdk-helpers";
 
 export const positionsRoute: FastifyPluginAsync = async (app) => {
@@ -11,7 +15,11 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
     }
 
     try {
-      const positions = await resolvePositions(publicKey, APP_NETWORK, buildTxAddresses(process.env.DEFINDEX_VAULT_ID));
+      const positions = await resolvePositions(
+        publicKey,
+        APP_NETWORK,
+        buildTxAddresses(process.env.DEFINDEX_VAULT_ID)
+      );
       reply.send({ positions });
     } catch (err) {
       app.log.error(err, "[positions] read failed");

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -17,65 +17,92 @@ import {
 } from "@meridian/stellar-sdk-helpers";
 
 export const txRoute: FastifyPluginAsync = async (app) => {
-  app.post("/deposit", { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } }, async (req, reply) => {
-    const parsed = DepositRequestSchema.safeParse(req.body);
-    if (!parsed.success) return reply.code(400).send({ error: formatZodError(parsed.error) });
+  app.post(
+    "/deposit",
+    { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } },
+    async (req, reply) => {
+      const parsed = DepositRequestSchema.safeParse(req.body);
+      if (!parsed.success)
+        return reply.code(400).send({ error: formatZodError(parsed.error) });
 
-    try {
-      const { walletAddress, vaultId, amount } = parsed.data;
-      const result = await buildDepositTx(
-        vaultId, walletAddress, amount,
-        buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
-        APP_NETWORK
-      );
-      reply.send(result);
-    } catch (err) {
-      app.log.error({ err }, "[tx/deposit] build failed");
-      reply.code(500).send({ error: sanitizeTxError(err, "Failed to build deposit transaction") });
+      try {
+        const { walletAddress, vaultId, amount } = parsed.data;
+        const result = await buildDepositTx(
+          vaultId,
+          walletAddress,
+          amount,
+          buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
+          APP_NETWORK
+        );
+        reply.send(result);
+      } catch (err) {
+        app.log.error({ err }, "[tx/deposit] build failed");
+        reply.code(500).send({
+          error: sanitizeTxError(err, "Failed to build deposit transaction"),
+        });
+      }
     }
-  });
+  );
 
-  app.post("/withdraw", { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } }, async (req, reply) => {
-    const parsed = WithdrawRequestSchema.safeParse(req.body);
-    if (!parsed.success) return reply.code(400).send({ error: formatZodError(parsed.error) });
+  app.post(
+    "/withdraw",
+    { config: { rateLimit: { max: 10, timeWindow: "1 minute" } } },
+    async (req, reply) => {
+      const parsed = WithdrawRequestSchema.safeParse(req.body);
+      if (!parsed.success)
+        return reply.code(400).send({ error: formatZodError(parsed.error) });
 
-    try {
-      const { walletAddress, vaultId, shares } = parsed.data;
-      const result = await buildWithdrawTx(
-        vaultId, walletAddress, shares,
-        buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
-        APP_NETWORK
-      );
-      reply.send(result);
-    } catch (err) {
-      app.log.error({ err }, "[tx/withdraw] build failed");
-      reply.code(500).send({ error: sanitizeTxError(err, "Failed to build withdraw transaction") });
+      try {
+        const { walletAddress, vaultId, shares } = parsed.data;
+        const result = await buildWithdrawTx(
+          vaultId,
+          walletAddress,
+          shares,
+          buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
+          APP_NETWORK
+        );
+        reply.send(result);
+      } catch (err) {
+        app.log.error({ err }, "[tx/withdraw] build failed");
+        reply.code(500).send({
+          error: sanitizeTxError(err, "Failed to build withdraw transaction"),
+        });
+      }
     }
-  });
+  );
 
   app.post("/add-trustline", async (req, reply) => {
     const parsed = TrustlineRequestSchema.safeParse(req.body);
-    if (!parsed.success) return reply.code(400).send({ error: formatZodError(parsed.error) });
+    if (!parsed.success)
+      return reply.code(400).send({ error: formatZodError(parsed.error) });
 
     try {
-      const result = await buildAddTrustlineTx(parsed.data.walletAddress, APP_NETWORK);
+      const result = await buildAddTrustlineTx(
+        parsed.data.walletAddress,
+        APP_NETWORK
+      );
       reply.send(result);
     } catch (err) {
       app.log.error({ err }, "[tx/add-trustline] build failed");
-      reply.code(500).send({ error: sanitizeTxError(err, "Failed to build trustline transaction") });
+      reply.code(500).send({
+        error: sanitizeTxError(err, "Failed to build trustline transaction"),
+      });
     }
   });
 
   app.post("/submit", async (req, reply) => {
     const parsed = SubmitRequestSchema.safeParse(req.body);
-    if (!parsed.success) return reply.code(400).send({ error: formatZodError(parsed.error) });
+    if (!parsed.success)
+      return reply.code(400).send({ error: formatZodError(parsed.error) });
 
     try {
       const result = await submitTx(parsed.data.xdr, APP_NETWORK);
       reply.send(result);
     } catch (err) {
       app.log.error({ err }, "[tx/submit] failed");
-      reply.code(500).send({ error: sanitizeTxError(err, "Failed to submit transaction") });
+      reply
+        .code(500)
+        .send({ error: sanitizeTxError(err, "Failed to submit transaction") });
     }
   });
 };

--- a/apps/api/src/routes/vaults.ts
+++ b/apps/api/src/routes/vaults.ts
@@ -1,5 +1,8 @@
 import type { FastifyPluginAsync } from "fastify";
-import { selectBestVault, isVaultCacheWarm } from "@meridian/stellar-sdk-helpers";
+import {
+  selectBestVault,
+  isVaultCacheWarm,
+} from "@meridian/stellar-sdk-helpers";
 import { isDefindexConfigured, APP_NETWORK } from "@meridian/shared";
 import { fetchAllVaults } from "../services/vaults.js";
 
@@ -8,7 +11,9 @@ export const vaultsRoute: FastifyPluginAsync = async (app) => {
     try {
       const cached = isVaultCacheWarm();
       const vaults = await fetchAllVaults(APP_NETWORK.network);
-      const best = selectBestVault(vaults, { defindexConfigured: isDefindexConfigured() });
+      const best = selectBestVault(vaults, {
+        defindexConfigured: isDefindexConfigured(),
+      });
       return reply.send({
         vaults,
         recommendedVaultId: best?.id ?? null,
@@ -26,7 +31,8 @@ export const vaultsRoute: FastifyPluginAsync = async (app) => {
       const { vaultId } = req.params as { vaultId: string };
       const vaults = await fetchAllVaults(APP_NETWORK.network);
       const vault = vaults.find((v) => v.id === vaultId);
-      if (!vault) return reply.code(404).send({ error: "vault not found", vaultId });
+      if (!vault)
+        return reply.code(404).send({ error: "vault not found", vaultId });
       return reply.send(vault);
     } catch (err) {
       app.log.error(err, "[vaults] failed to fetch vault by id");

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -8,7 +8,9 @@
     "outDir": "dist",
     "paths": {
       "@meridian/shared": ["../../packages/shared/src"],
-      "@meridian/stellar-sdk-helpers": ["../../packages/stellar-sdk-helpers/src"]
+      "@meridian/stellar-sdk-helpers": [
+        "../../packages/stellar-sdk-helpers/src"
+      ]
     }
   },
   "include": ["src"]

--- a/apps/docs/.vitepress/config.ts
+++ b/apps/docs/.vitepress/config.ts
@@ -2,11 +2,14 @@ import { defineConfig } from "vitepress";
 
 export default defineConfig({
   title: "Meridian",
-  description: "Stablecoin yield aggregator on Stellar, built for emerging market savers.",
+  description:
+    "Stablecoin yield aggregator on Stellar, built for emerging market savers.",
   base: "/docs/",
   vite: { server: { port: 3002 } },
   themeConfig: {
-    logo: { svg: '<svg viewBox="0 0 2000 2000" xmlns="http://www.w3.org/2000/svg"><path d="M1000 2000c554.17 0 1000-445.83 1000-1000S1554.17 0 1000 0 0 445.83 0 1000s445.83 1000 1000 1000z" fill="#2775ca"/><path d="M1275 1158.33c0-145.83-87.5-195.83-262.5-216.66-125-16.67-150-50-150-108.34s41.67-95.83 125-95.83c75 0 116.67 25 137.5 87.5 4.17 12.5 16.67 20.83 29.17 20.83h66.66c16.67 0 29.17-12.5 29.17-29.16v-4.17c-16.67-91.67-91.67-162.5-187.5-170.83v-100c0-16.67-12.5-29.17-33.33-33.34h-62.5c-16.67 0-29.17 12.5-33.34 33.34v95.83c-125 16.67-204.16 100-204.16 204.17 0 137.5 83.33 191.66 258.33 212.5 116.67 20.83 154.17 45.83 154.17 112.5s-58.34 112.5-137.5 112.5c-108.34 0-145.84-45.84-158.34-108.34-4.16-16.66-16.66-25-29.16-25h-70.84c-16.66 0-29.16 12.5-29.16 29.17v4.17c16.66 104.16 83.33 179.16 220.83 200v100c0 16.66 12.5 29.16 33.33 33.33h62.5c16.67 0 29.17-12.5 33.34-33.33v-100c125-20.84 208.33-108.34 208.33-220.84z" fill="#fff"/></svg>' },
+    logo: {
+      svg: '<svg viewBox="0 0 2000 2000" xmlns="http://www.w3.org/2000/svg"><path d="M1000 2000c554.17 0 1000-445.83 1000-1000S1554.17 0 1000 0 0 445.83 0 1000s445.83 1000 1000 1000z" fill="#2775ca"/><path d="M1275 1158.33c0-145.83-87.5-195.83-262.5-216.66-125-16.67-150-50-150-108.34s41.67-95.83 125-95.83c75 0 116.67 25 137.5 87.5 4.17 12.5 16.67 20.83 29.17 20.83h66.66c16.67 0 29.17-12.5 29.17-29.16v-4.17c-16.67-91.67-91.67-162.5-187.5-170.83v-100c0-16.67-12.5-29.17-33.33-33.34h-62.5c-16.67 0-29.17 12.5-33.34 33.34v95.83c-125 16.67-204.16 100-204.16 204.17 0 137.5 83.33 191.66 258.33 212.5 116.67 20.83 154.17 45.83 154.17 112.5s-58.34 112.5-137.5 112.5c-108.34 0-145.84-45.84-158.34-108.34-4.16-16.66-16.66-25-29.16-25h-70.84c-16.66 0-29.16 12.5-29.16 29.17v4.17c16.66 104.16 83.33 179.16 220.83 200v100c0 16.66 12.5 29.16 33.33 33.33h62.5c16.67 0 29.17-12.5 33.34-33.33v-100c125-20.84 208.33-108.34 208.33-220.84z" fill="#fff"/></svg>',
+    },
     nav: [
       { text: "Overview", link: "/overview/introduction" },
       { text: "Architecture", link: "/architecture/monorepo" },
@@ -37,8 +40,14 @@ export default defineConfig({
         text: "Operations",
         items: [
           { text: "Local Development", link: "/operations/local-development" },
-          { text: "Testnet Deployment", link: "/operations/testnet-deployment" },
-          { text: "Environment Variables", link: "/operations/environment-variables" },
+          {
+            text: "Testnet Deployment",
+            link: "/operations/testnet-deployment",
+          },
+          {
+            text: "Environment Variables",
+            link: "/operations/environment-variables",
+          },
         ],
       },
     ],

--- a/apps/docs/architecture/api.md
+++ b/apps/docs/architecture/api.md
@@ -2,10 +2,10 @@
 
 Meridian has two API implementations that share the same interface:
 
-| Implementation | Used in | Location |
-|---|---|---|
-| Vercel serverless functions | Production | `api/v1/` |
-| Fastify server | Local development | `apps/api/` |
+| Implementation              | Used in           | Location    |
+| --------------------------- | ----------------- | ----------- |
+| Vercel serverless functions | Production        | `api/v1/`   |
+| Fastify server              | Local development | `apps/api/` |
 
 ## Endpoints
 
@@ -14,6 +14,7 @@ Meridian has two API implementations that share the same interface:
 Returns all available vaults with live APY and TVL.
 
 **Response**
+
 ```json
 {
   "vaults": [
@@ -46,13 +47,14 @@ Returns a single vault or 404.
 Returns the user's on-chain position.
 
 **Response**
+
 ```json
 {
   "positions": [
     {
       "vaultId": "blend-usdc-variable",
       "shares": 100.0,
-      "deposited": 100.00,
+      "deposited": 100.0,
       "earned": 2.34,
       "entryTime": 1716729600
     }
@@ -67,6 +69,7 @@ Reads position data directly from the vault contract via `simulateTransaction`. 
 Builds an unsigned Soroban deposit transaction.
 
 **Request**
+
 ```json
 {
   "walletAddress": "G...",
@@ -76,6 +79,7 @@ Builds an unsigned Soroban deposit transaction.
 ```
 
 **Response**
+
 ```json
 {
   "xdr": "AAAAAgAAAAA...",
@@ -90,6 +94,7 @@ The `xdr` field is a base64-encoded unsigned `TransactionEnvelope`. The `fee` is
 Builds an unsigned Soroban withdraw transaction.
 
 **Request**
+
 ```json
 {
   "walletAddress": "G...",
@@ -105,11 +110,13 @@ Builds an unsigned Soroban withdraw transaction.
 Builds an unsigned transaction that adds the mUSDC trustline to the caller's account. Must be submitted before a first deposit.
 
 **Request**
+
 ```json
 { "walletAddress": "G..." }
 ```
 
 **Response**
+
 ```json
 { "xdr": "AAAAAgAAAAA..." }
 ```
@@ -119,11 +126,13 @@ Builds an unsigned transaction that adds the mUSDC trustline to the caller's acc
 Submits a Freighter-signed XDR to the Stellar network.
 
 **Request**
+
 ```json
 { "xdr": "AAAAAgAAAAA..." }
 ```
 
 **Response**
+
 ```json
 { "hash": "abc123..." }
 ```
@@ -142,9 +151,9 @@ The Fastify server (`apps/api/`) runs the same packages directly via `tsx`, whic
 
 When building a deposit transaction, the `vaultId` is mapped to the `Protocol` enum expected by the vault contract:
 
-| Vault ID prefix | Protocol |
-|---|---|
-| `blend-` | `Blend` |
-| `defindex-` | `DeFindex` |
+| Vault ID prefix | Protocol   |
+| --------------- | ---------- |
+| `blend-`        | `Blend`    |
+| `defindex-`     | `DeFindex` |
 
 Any other prefix returns a 500 with a clear mapping error.

--- a/apps/docs/architecture/frontend.md
+++ b/apps/docs/architecture/frontend.md
@@ -2,14 +2,14 @@
 
 ## Stack
 
-| Concern | Library |
-|---|---|
-| Bundler | Vite 8 |
-| UI | React 19 |
-| Styling | Tailwind CSS |
-| Server state | TanStack Query v5 |
-| Client state | Zustand |
-| Wallet | `@stellar/freighter-api` |
+| Concern      | Library                  |
+| ------------ | ------------------------ |
+| Bundler      | Vite 8                   |
+| UI           | React 19                 |
+| Styling      | Tailwind CSS             |
+| Server state | TanStack Query v5        |
+| Client state | Zustand                  |
+| Wallet       | `@stellar/freighter-api` |
 
 ## Component structure
 

--- a/apps/docs/architecture/monorepo.md
+++ b/apps/docs/architecture/monorepo.md
@@ -77,12 +77,12 @@ meridian/
 
 ## Key boundaries
 
-| Boundary | Rule |
-|---|---|
+| Boundary                    | Rule                                                                                                                                                                                                                                                    |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `api/` serverless functions | Imports from `@meridian/shared` and `@meridian/stellar-sdk-helpers` via pre-built `dist/` bundles. `scripts/build-vercel.sh` runs esbuild on each package before the Vercel build so the handlers can import compiled JS rather than TypeScript source. |
-| `apps/api` Fastify server | Imports the same workspace packages directly via `tsx` (TypeScript-native). Used for local development only. |
-| `apps/web` | No direct Soroban SDK usage. All blockchain interaction goes through the API. |
-| `packages/contracts` | Rust only. No TypeScript. |
+| `apps/api` Fastify server   | Imports the same workspace packages directly via `tsx` (TypeScript-native). Used for local development only.                                                                                                                                            |
+| `apps/web`                  | No direct Soroban SDK usage. All blockchain interaction goes through the API.                                                                                                                                                                           |
+| `packages/contracts`        | Rust only. No TypeScript.                                                                                                                                                                                                                               |
 
 ## Task pipeline
 

--- a/apps/docs/architecture/signing-flow.md
+++ b/apps/docs/architecture/signing-flow.md
@@ -54,7 +54,7 @@ Browser                    API (Vercel)              Stellar RPC
 
 Before returning XDR to the client, the API simulates the transaction against the Soroban RPC node. Simulation:
 
-1. Executes the transaction in a read-only context to determine what contract storage entries will be read and written (the *footprint*).
+1. Executes the transaction in a read-only context to determine what contract storage entries will be read and written (the _footprint_).
 2. Calculates the resource fee required to cover CPU and storage access.
 3. Returns a `readBytes`, `writeBytes`, and `minResourceFee` estimate.
 

--- a/apps/docs/architecture/vault-contract.md
+++ b/apps/docs/architecture/vault-contract.md
@@ -4,9 +4,9 @@ The `MeridianVault` contract is a Soroban smart contract written in Rust, locate
 
 ## Tokens
 
-| Token | Role |
-|---|---|
-| USDC | Deposit and withdrawal currency. Pulled from the user on deposit, returned on withdraw. |
+| Token | Role                                                                                                               |
+| ----- | ------------------------------------------------------------------------------------------------------------------ |
+| USDC  | Deposit and withdrawal currency. Pulled from the user on deposit, returned on withdraw.                            |
 | mUSDC | Share token. Minted to the user on deposit, burned on withdraw. Represents proportional ownership of vault assets. |
 
 Both are standard Stellar assets managed via the `TokenClient` interface. The vault must be set as the admin of the mUSDC asset to mint and burn autonomously.
@@ -98,14 +98,14 @@ USDC on Stellar uses 7 decimal places. 1 USDC = `10_000_000` stroops. All contra
 
 ## Contract storage
 
-| Key | Storage type | Value |
-|---|---|---|
-| `ADMIN` | Instance | Admin `Address` |
-| `USDC` | Instance | USDC contract `Address` |
-| `MUSDC` | Instance | mUSDC contract `Address` |
-| `PROTOCOL` | Instance | Last-used `Protocol` enum |
-| `TOTAL_SH` | Instance | Total mUSDC shares outstanding (`i128`) |
-| `PAUSED` | Instance | Deposit pause flag (`bool`) |
-| `Balance(address)` | Persistent | Per-address mUSDC share balance (`i128`) |
-| `Entry(address)` | Persistent | Per-address deposit entry timestamp (`u64`) |
-| `Principal(address)` | Persistent | Per-address net USDC deposited, not yet withdrawn (`i128`) |
+| Key                  | Storage type | Value                                                      |
+| -------------------- | ------------ | ---------------------------------------------------------- |
+| `ADMIN`              | Instance     | Admin `Address`                                            |
+| `USDC`               | Instance     | USDC contract `Address`                                    |
+| `MUSDC`              | Instance     | mUSDC contract `Address`                                   |
+| `PROTOCOL`           | Instance     | Last-used `Protocol` enum                                  |
+| `TOTAL_SH`           | Instance     | Total mUSDC shares outstanding (`i128`)                    |
+| `PAUSED`             | Instance     | Deposit pause flag (`bool`)                                |
+| `Balance(address)`   | Persistent   | Per-address mUSDC share balance (`i128`)                   |
+| `Entry(address)`     | Persistent   | Per-address deposit entry timestamp (`u64`)                |
+| `Principal(address)` | Persistent   | Per-address net USDC deposited, not yet withdrawn (`i128`) |

--- a/apps/docs/operations/environment-variables.md
+++ b/apps/docs/operations/environment-variables.md
@@ -2,17 +2,17 @@
 
 ## Web (`apps/web`)
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `VITE_API_URL` | No | `""` | Base URL of the API server. Empty means same origin. In local dev, Vite proxies `/api` to `localhost:3001` so this is not needed. |
+| Variable       | Required | Default | Description                                                                                                                       |
+| -------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `VITE_API_URL` | No       | `""`    | Base URL of the API server. Empty means same origin. In local dev, Vite proxies `/api` to `localhost:3001` so this is not needed. |
 
 ## API: serverless (`api/v1/`) and Fastify (`apps/api`)
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `DEFINDEX_VAULT_ID` | No | `""` | Overrides the DeFindex vault contract address at runtime. When empty, the address from `CONTRACT_ADDRESSES.testnet.defindex.vault` in `packages/shared/src/constants.ts` is used. Blend and vault contract addresses are always sourced from constants. |
-| `PORT` | No | `3001` | Fastify server port (local dev only). |
-| `ALLOWED_ORIGIN` | No | `"https://usemeridian.vercel.app"` | CORS allowed origin for the Fastify server. Set to your frontend domain in production if running Fastify as a standalone server. |
+| Variable            | Required | Default                            | Description                                                                                                                                                                                                                                             |
+| ------------------- | -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEFINDEX_VAULT_ID` | No       | `""`                               | Overrides the DeFindex vault contract address at runtime. When empty, the address from `CONTRACT_ADDRESSES.testnet.defindex.vault` in `packages/shared/src/constants.ts` is used. Blend and vault contract addresses are always sourced from constants. |
+| `PORT`              | No       | `3001`                             | Fastify server port (local dev only).                                                                                                                                                                                                                   |
+| `ALLOWED_ORIGIN`    | No       | `"https://usemeridian.vercel.app"` | CORS allowed origin for the Fastify server. Set to your frontend domain in production if running Fastify as a standalone server.                                                                                                                        |
 
 ## Vercel
 
@@ -38,7 +38,7 @@ The Fastify server loads `.env` via the `dotenv` package on startup.
 
 ## Future variables
 
-| Variable | Purpose |
-|---|---|
+| Variable          | Purpose                                                                 |
+| ----------------- | ----------------------------------------------------------------------- |
 | `STELLAR_NETWORK` | Switch between `testnet` and `mainnet`. Currently hardcoded to testnet. |
-| `REDIS_URL` | If Redis caching is added back to the API layer. Currently not used. |
+| `REDIS_URL`       | If Redis caching is added back to the API layer. Currently not used.    |

--- a/apps/docs/operations/local-development.md
+++ b/apps/docs/operations/local-development.md
@@ -2,12 +2,12 @@
 
 ## Prerequisites
 
-| Tool | Version | Install |
-| --- | --- | --- |
-| Node.js | ≥ 20 | [nodejs.org](https://nodejs.org) |
-| pnpm | ≥ 9 | `npm i -g pnpm` |
-| Rust | stable | [rustup.rs](https://rustup.rs) |
-| Stellar CLI | latest | `cargo install stellar-cli` |
+| Tool        | Version | Install                          |
+| ----------- | ------- | -------------------------------- |
+| Node.js     | ≥ 20    | [nodejs.org](https://nodejs.org) |
+| pnpm        | ≥ 9     | `npm i -g pnpm`                  |
+| Rust        | stable  | [rustup.rs](https://rustup.rs)   |
+| Stellar CLI | latest  | `cargo install stellar-cli`      |
 
 The Rust toolchain and Stellar CLI are only required if you are working on the Soroban contracts in `packages/contracts/`. Frontend and API work does not require them.
 

--- a/apps/docs/operations/testnet-deployment.md
+++ b/apps/docs/operations/testnet-deployment.md
@@ -101,10 +101,10 @@ export const CONTRACT_ADDRESSES = {
       factory: "C...",
       vault: "",
     },
-    usdc: "C...",   // USDC_CONTRACT_ID
+    usdc: "C...", // USDC_CONTRACT_ID
     eurc: "C...",
-    musdc: "C...",  // MUSDC_CONTRACT_ID
-    vault: "C...",  // VAULT_CONTRACT_ID
+    musdc: "C...", // MUSDC_CONTRACT_ID
+    vault: "C...", // VAULT_CONTRACT_ID
   },
 } as const;
 ```

--- a/apps/landing/index.html
+++ b/apps/landing/index.html
@@ -1,1077 +1,1562 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Meridian — Stablecoin Yield on Stellar</title>
-  <meta name="description" content="Earn the best USDC yields on Stellar. No bank account. No gas fees. Built for West Africa. Powered by Blend Capital and DeFindex.">
-  <meta property="og:title" content="Meridian — Stablecoin Yield on Stellar">
-  <meta property="og:description" content="Earn the best USDC yields on Stellar. Built for West Africa.">
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="./og_image.png">
-  <meta property="og:url" content="https://usemeridian.vercel.app">
-  <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Meridian — Stablecoin Yield on Stellar">
-  <meta name="twitter:description" content="Earn the best USDC yields on Stellar. Built for West Africa.">
-  <meta name="twitter:image" content="./og_image.png">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
-  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
-  <link rel="apple-touch-icon" href="./favicon-180x180.png" sizes="180x180" />
-  <style>
-    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
-    :root {
-      --bg:            #070d19;
-      --bg-2:          #0d1e35;
-      --surface:       rgba(255, 255, 255, 0.03);
-      --surface-2:     rgba(255, 255, 255, 0.06);
-      --border:        rgba(255, 255, 255, 0.08);
-      --border-strong: rgba(255, 255, 255, 0.16);
-      --text:          #f0f4ff;
-      --muted:         rgba(240, 244, 255, 0.52);
-      --dim:           rgba(240, 244, 255, 0.26);
-      --blue:          #3b82f6;
-      --green:         #10b981;
-      --green-glow:    rgba(16, 185, 129, 0.12);
-    }
-
-    html { scroll-behavior: smooth; }
-
-    body {
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-      background-color: var(--bg);
-      color: var(--text);
-      -webkit-font-smoothing: antialiased;
-      overflow-x: hidden;
-      line-height: 1.6;
-    }
-
-    /* ── Background ── */
-    .bg-canvas {
-      position: fixed;
-      inset: 0;
-      pointer-events: none;
-      z-index: 0;
-      background-image: radial-gradient(circle, rgba(255,255,255,0.13) 1px, transparent 1px);
-      background-size: 28px 28px;
-    }
-
-    body::after {
-      content: '';
-      position: fixed;
-      inset: 0;
-      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E");
-      opacity: 0.028;
-      pointer-events: none;
-      z-index: 1;
-    }
-
-    /* ── Layout ── */
-    .wrap {
-      max-width: 1120px;
-      margin: 0 auto;
-      padding: 0 28px;
-      position: relative;
-      z-index: 2;
-    }
-
-    section { padding: 128px 0; }
-
-    /* ── Nav ── */
-    nav {
-      position: fixed;
-      inset: 0 0 auto;
-      z-index: 100;
-      padding: 20px 0;
-      transition: background 0.3s;
-    }
-
-    nav.stuck {
-      background: rgba(7, 13, 25, 0.82);
-      backdrop-filter: blur(18px);
-      -webkit-backdrop-filter: blur(18px);
-    }
-
-    .nav-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-    }
-
-    .wordmark {
-      font-size: 17px;
-      font-weight: 800;
-      letter-spacing: -0.03em;
-      color: var(--text);
-    }
-
-    .nav-gh {
-      display: inline-flex;
-      align-items: center;
-      gap: 7px;
-      padding: 9px 16px;
-      border-radius: 9px;
-      border: 1px solid var(--border);
-      font-size: 13.5px;
-      font-weight: 500;
-      color: var(--muted);
-      text-decoration: none;
-      transition: color 0.2s, border-color 0.2s;
-    }
-
-    .nav-gh:hover { color: var(--text); border-color: var(--border-strong); }
-
-    .nav-actions {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-
-    .nav-launch {
-      display: inline-flex;
-      align-items: center;
-      gap: 5px;
-      padding: 8px 16px;
-      border-radius: 8px;
-      border: 1px solid rgba(16,185,129,0.45);
-      background: transparent;
-      font-size: 13px;
-      font-weight: 600;
-      color: var(--green);
-      text-decoration: none;
-      transition: border-color 0.2s, background 0.2s;
-    }
-
-    .nav-launch:hover { border-color: var(--green); background: rgba(16,185,129,0.06); }
-
-    /* ── Hero ── */
-    .hero { padding: 120px 0 120px; overflow: hidden; }
-
-    .hero-content {
-      position: relative;
-      min-height: 460px;
-    }
-
-    .hero-copy {
-      max-width: 600px;
-      position: relative;
-      z-index: 2;
-    }
-
-
-    h1 {
-      font-size: clamp(52px, 6.5vw, 84px);
-      font-weight: 900;
-      line-height: 1.03;
-      letter-spacing: -0.035em;
-      margin-bottom: 24px;
-    }
-
-    .grad { color: var(--green); }
-
-    .hero-sub {
-      font-size: 17px;
-      color: var(--muted);
-      max-width: 420px;
-      margin-bottom: 40px;
-      line-height: 1.65;
-    }
-
-    .waitlist-row {
-      display: flex;
-      gap: 10px;
-      max-width: 420px;
-      margin-bottom: 24px;
-    }
-
-    .waitlist-input {
-      flex: 1;
-      min-width: 0;
-      padding: 13px 16px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: rgba(255,255,255,0.04);
-      color: var(--text);
-      font-size: 14.5px;
-      font-family: inherit;
-      outline: none;
-      transition: border-color 0.2s, background 0.2s;
-    }
-
-    .waitlist-input::placeholder { color: var(--dim); }
-    .waitlist-input:focus { border-color: var(--blue); background: rgba(255,255,255,0.06); }
-
-    .btn {
-      padding: 13px 20px;
-      border-radius: 10px;
-      border: none;
-      background: var(--green);
-      color: #fff;
-      font-size: 14.5px;
-      font-weight: 600;
-      font-family: inherit;
-      cursor: pointer;
-      white-space: nowrap;
-      transition: background 0.2s, transform 0.1s, box-shadow 0.2s;
-    }
-
-    .btn:hover { background: #059669; box-shadow: 0 0 28px rgba(16,185,129,0.35); }
-    .btn:active { transform: scale(0.97); }
-
-    .waitlist-success {
-      display: none;
-      max-width: 420px;
-      margin-bottom: 24px;
-      padding: 14px 20px;
-      border-radius: 12px;
-      border: 1px solid rgba(16,185,129,0.28);
-      background: var(--green-glow);
-      color: var(--green);
-      font-size: 14.5px;
-      font-weight: 500;
-    }
-
-    .stellar-mark {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      font-size: 13px;
-      color: var(--dim);
-    }
-
-    /* ── Product Mockup ── */
-    .mock-wrap {
-      position: absolute;
-      right: 0;
-      top: 50%;
-      transform: translateY(-50%);
-      width: 52%;
-      z-index: 1;
-    }
-
-
-    .mock-wrap::after {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background:
-        linear-gradient(to bottom, var(--bg) 0%, transparent 18%),
-        linear-gradient(to right, var(--bg) 0%, rgba(7,13,25,0.5) 30%, transparent 60%);
-      pointer-events: none;
-      z-index: 3;
-      border-radius: 14px 0 0 14px;
-    }
-
-    .mock-window {
-      position: relative;
-      z-index: 1;
-      border-radius: 14px;
-      border: 1px solid var(--border-strong);
-      background: rgba(9, 16, 30, 0.95);
-      overflow: hidden;
-      box-shadow: 0 40px 100px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04);
-    }
-
-    .mock-chrome {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      padding: 11px 16px;
-      border-bottom: 1px solid var(--border);
-      background: rgba(255,255,255,0.02);
-    }
-
-    .mock-dots { display: flex; gap: 6px; }
-
-    .mock-dot {
-      width: 10px; height: 10px;
-      border-radius: 50%;
-    }
-
-    .mock-dot-r { background: #ff5f57; }
-    .mock-dot-y { background: #febc2e; }
-    .mock-dot-g { background: #28c840; }
-
-    .mock-url {
-      flex: 1;
-      text-align: center;
-      font-size: 11px;
-      color: var(--dim);
-      background: rgba(255,255,255,0.04);
-      border: 1px solid var(--border);
-      border-radius: 5px;
-      padding: 4px 10px;
-      font-family: 'SF Mono', 'Fira Code', monospace;
-    }
-
-    .mock-body { padding: 18px; }
-
-    .mock-section-label {
-      font-size: 10px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.09em;
-      color: var(--dim);
-      margin-bottom: 10px;
-    }
-
-    .mock-portfolio {
-      display: grid;
-      grid-template-columns: 1fr 1fr 1fr;
-      gap: 8px;
-      margin-bottom: 18px;
-    }
-
-    .mock-stat {
-      background: var(--surface);
-      border: 1px solid var(--border);
-      border-radius: 9px;
-      padding: 10px 12px;
-    }
-
-    .mock-stat-label { font-size: 9px; color: var(--dim); margin-bottom: 4px; }
-    .mock-stat-val   { font-size: 14px; font-weight: 800; letter-spacing: -0.02em; }
-    .mock-stat-val.pos { color: var(--green); }
-
-    .mock-vaults { display: flex; flex-direction: column; gap: 7px; }
-
-    .mock-vault {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: 11px 14px;
-      border-radius: 10px;
-      border: 1px solid var(--border);
-      background: var(--surface);
-    }
-
-    .mock-vault-name  { font-size: 12px; font-weight: 600; }
-    .mock-vault-proto { font-size: 10px; color: var(--dim); margin-top: 2px; }
-    .mock-vault-apy   { font-size: 16px; font-weight: 900; color: var(--green); letter-spacing: -0.02em; }
-
-    /* ── Section labels ── */
-    .label {
-      font-size: 11.5px;
-      font-weight: 700;
-      letter-spacing: 0.13em;
-      text-transform: uppercase;
-      color: var(--blue);
-      margin-bottom: 14px;
-    }
-
-    .section-title {
-      font-size: clamp(30px, 4vw, 46px);
-      font-weight: 800;
-      letter-spacing: -0.027em;
-      line-height: 1.08;
-      margin-bottom: 18px;
-    }
-
-    .section-sub {
-      font-size: 16.5px;
-      color: var(--muted);
-      line-height: 1.65;
-      max-width: 460px;
-    }
-
-    /* ── Problem ── */
-    .alt-section {
-      background: var(--bg-2);
-      border-top: 1px solid var(--border);
-      border-bottom: 1px solid var(--border);
-      --text:  #ddeeff;
-      --muted: rgba(200, 225, 255, 0.56);
-      --dim:   rgba(200, 225, 255, 0.28);
-      color: var(--text);
-    }
-
-    .light-section {
-      background-color: #dce6f7;
-      background-image: radial-gradient(circle, rgba(59,130,246,0.39) 1px, transparent 1px);
-      background-size: 28px 28px;
-      border-top: 1px solid rgba(0, 0, 0, 0.07);
-      border-bottom: 1px solid rgba(0, 0, 0, 0.07);
-      --text:   #0d1929;
-      --muted:  rgba(13, 25, 41, 0.58);
-      --dim:    rgba(13, 25, 41, 0.36);
-      --border: rgba(0, 0, 0, 0.1);
-      --surface: rgba(0, 0, 0, 0.04);
-      color: var(--text);
-    }
-
-    .problem-header { margin-bottom: 60px; }
-
-    .stats {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 18px;
-    }
-
-    .stat {
-      padding: 36px 30px;
-      border-radius: 18px;
-      border: 1px solid var(--border);
-      background: var(--surface);
-      position: relative;
-      overflow: hidden;
-    }
-
-    .stat::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(140deg, rgba(255,255,255,0.024) 0%, transparent 55%);
-      pointer-events: none;
-    }
-
-    .stat-icon {
-      width: 40px; height: 40px;
-      border-radius: 10px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      margin-bottom: 20px;
-    }
-
-    .stat-icon-red    { background: rgba(248, 113, 113, 0.12); color: #f87171; }
-    .stat-icon-amber  { background: rgba(251, 191,  36, 0.12); color: #fbbf24; }
-    .stat-icon-green  { background: rgba( 16, 185, 129, 0.12); color: var(--green); }
-
-    .stat-num {
-      font-size: 52px;
-      font-weight: 900;
-      letter-spacing: -0.04em;
-      line-height: 1;
-      margin-bottom: 10px;
-    }
-
-    .num-red   { color: #f87171; }
-    .num-amber { color: #fbbf24; }
-    .num-green { color: var(--green); }
-
-    .stat-name {
-      font-size: 11px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: var(--muted);
-      margin-bottom: 12px;
-    }
-
-    .stat-body { font-size: 14px; color: var(--muted); line-height: 1.6; }
-
-    /* ── Steps ── */
-    .steps {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 48px;
-      margin-top: 72px;
-      position: relative;
-    }
-
-    .steps::before {
-      content: '';
-      position: absolute;
-      top: 23px;
-      left: calc(16.67% + 10px);
-      right: calc(16.67% + 10px);
-      height: 1px;
-      background: linear-gradient(90deg, transparent 0%, var(--border) 20%, var(--border) 80%, transparent 100%);
-    }
-
-    .step-num {
-      width: 46px; height: 46px;
-      border-radius: 12px;
-      border: 1px solid var(--border);
-      background: var(--surface);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 14px;
-      font-weight: 700;
-      color: var(--blue);
-      margin-bottom: 24px;
-      position: relative;
-      z-index: 1;
-    }
-
-    .step-icon {
-      width: 44px; height: 44px;
-      border-radius: 12px;
-      background: rgba(59,130,246,0.08);
-      border: 1px solid rgba(59,130,246,0.18);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: var(--blue);
-      margin-bottom: 20px;
-    }
-
-    .step h3 {
-      font-size: 17px;
-      font-weight: 700;
-      letter-spacing: -0.015em;
-      margin-bottom: 10px;
-    }
-
-    .step p { font-size: 14.5px; color: var(--muted); line-height: 1.65; }
-
-    /* ── Protocols ── */
-    /* .protocols shares .alt-section */
-
-    .proto-head {
-      margin-bottom: 52px;
-    }
-
-    .proto-head .section-sub {
-      max-width: 560px;
-      margin-top: 16px;
-    }
-
-    .proto-grid {
-      display: grid;
-      grid-template-columns: repeat(2, 1fr);
-      gap: 18px;
-    }
-
-    .proto-card {
-      --ca: 255, 255, 255;
-      display: block;
-      padding: 36px;
-      border-radius: 20px;
-      border: 1px solid rgba(var(--ca), 0.28);
-      background: rgba(var(--ca), 0.14);
-      text-decoration: none;
-      color: inherit;
-      position: relative;
-      overflow: hidden;
-      transition: border-color 0.22s, background 0.22s;
-    }
-
-    .proto-card--blend  { --ca: 36, 163, 56; }
-    .proto-card--defi   { --ca: 186, 155, 221; }
-
-    .proto-card::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(140deg, rgba(var(--ca), 0.14) 0%, transparent 55%);
-      pointer-events: none;
-      z-index: 1;
-    }
-
-    .proto-card:hover { border-color: rgba(var(--ca), 0.5); background: rgba(var(--ca), 0.2); }
-
-    .proto-arrow {
-      position: absolute;
-      top: 30px; right: 30px;
-      font-size: 18px;
-      color: var(--dim);
-      transition: color 0.2s;
-      z-index: 2;
-    }
-
-    .proto-card:hover .proto-arrow { color: var(--muted); }
-
-    .proto-logo-bg {
-      position: absolute;
-      right: -20px;
-      bottom: -20px;
-      opacity: 0.2;
-      pointer-events: none;
-      z-index: 0;
-    }
-
-    .proto-name,
-    .proto-desc { position: relative; z-index: 2; }
-
-    .proto-tag {
-      display: inline-block;
-      padding: 4px 10px;
-      border-radius: 6px;
-      font-size: 10.5px;
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-    }
-
-    .tag-blue   { background: rgba(59,130,246,0.14);  color: #93c5fd; }
-    .tag-violet { background: rgba(139,92,246,0.14);  color: #c4b5fd; }
-
-    .proto-name { font-size: 22px; font-weight: 800; letter-spacing: -0.022em; margin-bottom: 10px; }
-    .proto-desc { font-size: 14.5px; color: var(--muted); line-height: 1.65; margin-bottom: 28px; }
-
-
-    /* ── Built in public ── */
-    .public-grid {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 96px;
-      align-items: center;
-    }
-
-    .public-copy .section-sub { margin-bottom: 0; }
-
-    .public-links { display: flex; flex-direction: column; gap: 12px; }
-
-    .pub-link {
-      display: flex;
-      align-items: center;
-      gap: 16px;
-      padding: 18px 22px;
-      border-radius: 14px;
-      border: 1px solid var(--border);
-      background: var(--surface);
-      text-decoration: none;
-      color: inherit;
-      transition: border-color 0.2s, background 0.2s;
-    }
-
-    .pub-link:hover { border-color: var(--border-strong); background: var(--surface-2); }
-
-    .pub-icon {
-      width: 40px; height: 40px;
-      border-radius: 10px;
-      background: var(--surface-2);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-shrink: 0;
-      color: var(--muted);
-    }
-
-    .pub-text { flex: 1; }
-    .pub-title { font-size: 14.5px; font-weight: 600; margin-bottom: 2px; }
-    .pub-sub   { font-size: 12.5px; color: var(--dim); }
-    .pub-chevron { color: var(--dim); font-size: 16px; }
-
-
-    /* ── Footer ── */
-    footer {
-      padding: 36px 0;
-      background: rgba(7, 13, 25, 0.82);
-      backdrop-filter: blur(18px);
-      -webkit-backdrop-filter: blur(18px);
-    }
-
-    .foot-row {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      flex-wrap: wrap;
-      gap: 14px;
-    }
-
-    .foot-left {
-      display: flex;
-      align-items: center;
-      gap: 18px;
-      font-size: 13.5px;
-      color: var(--dim);
-    }
-
-    .foot-wordmark { font-weight: 700; color: var(--muted); font-size: 14px; }
-
-    .foot-right { display: flex; gap: 22px; }
-
-    .foot-right a {
-      font-size: 13.5px;
-      color: var(--dim);
-      text-decoration: none;
-      transition: color 0.2s;
-    }
-
-    .foot-right a:hover { color: var(--muted); }
-
-    /* ── Responsive ── */
-    @media (max-width: 900px) {
-      .hero-copy { max-width: 100%; text-align: center; }
-
-      .hero-sub { max-width: 100%; margin-left: auto; margin-right: auto; }
-      .waitlist-row { margin-left: auto; margin-right: auto; }
-      .waitlist-success { margin-left: auto; margin-right: auto; }
-      .stellar-mark { justify-content: center; }
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Meridian — Stablecoin Yield on Stellar</title>
+    <meta
+      name="description"
+      content="Earn the best USDC yields on Stellar. No bank account. No gas fees. Built for West Africa. Powered by Blend Capital and DeFindex."
+    />
+    <meta
+      property="og:title"
+      content="Meridian — Stablecoin Yield on Stellar"
+    />
+    <meta
+      property="og:description"
+      content="Earn the best USDC yields on Stellar. Built for West Africa."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="./og_image.png" />
+    <meta property="og:url" content="https://usemeridian.vercel.app" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Meridian — Stablecoin Yield on Stellar"
+    />
+    <meta
+      name="twitter:description"
+      content="Earn the best USDC yields on Stellar. Built for West Africa."
+    />
+    <meta name="twitter:image" content="./og_image.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      href="./favicon-32x32.png"
+      sizes="32x32"
+    />
+    <link rel="apple-touch-icon" href="./favicon-180x180.png" sizes="180x180" />
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      :root {
+        --bg: #070d19;
+        --bg-2: #0d1e35;
+        --surface: rgba(255, 255, 255, 0.03);
+        --surface-2: rgba(255, 255, 255, 0.06);
+        --border: rgba(255, 255, 255, 0.08);
+        --border-strong: rgba(255, 255, 255, 0.16);
+        --text: #f0f4ff;
+        --muted: rgba(240, 244, 255, 0.52);
+        --dim: rgba(240, 244, 255, 0.26);
+        --blue: #3b82f6;
+        --green: #10b981;
+        --green-glow: rgba(16, 185, 129, 0.12);
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        font-family:
+          "Inter",
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
+          sans-serif;
+        background-color: var(--bg);
+        color: var(--text);
+        -webkit-font-smoothing: antialiased;
+        overflow-x: hidden;
+        line-height: 1.6;
+      }
+
+      /* ── Background ── */
+      .bg-canvas {
+        position: fixed;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background-image: radial-gradient(
+          circle,
+          rgba(255, 255, 255, 0.13) 1px,
+          transparent 1px
+        );
+        background-size: 28px 28px;
+      }
+
+      body::after {
+        content: "";
+        position: fixed;
+        inset: 0;
+        background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23n)' opacity='1'/%3E%3C/svg%3E");
+        opacity: 0.028;
+        pointer-events: none;
+        z-index: 1;
+      }
+
+      /* ── Layout ── */
+      .wrap {
+        max-width: 1120px;
+        margin: 0 auto;
+        padding: 0 28px;
+        position: relative;
+        z-index: 2;
+      }
+
+      section {
+        padding: 128px 0;
+      }
+
+      /* ── Nav ── */
+      nav {
+        position: fixed;
+        inset: 0 0 auto;
+        z-index: 100;
+        padding: 20px 0;
+        transition: background 0.3s;
+      }
+
+      nav.stuck {
+        background: rgba(7, 13, 25, 0.82);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+      }
+
+      .nav-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .wordmark {
+        font-size: 17px;
+        font-weight: 800;
+        letter-spacing: -0.03em;
+        color: var(--text);
+      }
+
+      .nav-gh {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        padding: 9px 16px;
+        border-radius: 9px;
+        border: 1px solid var(--border);
+        font-size: 13.5px;
+        font-weight: 500;
+        color: var(--muted);
+        text-decoration: none;
+        transition:
+          color 0.2s,
+          border-color 0.2s;
+      }
+
+      .nav-gh:hover {
+        color: var(--text);
+        border-color: var(--border-strong);
+      }
+
+      .nav-actions {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .nav-launch {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        border: 1px solid rgba(16, 185, 129, 0.45);
+        background: transparent;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--green);
+        text-decoration: none;
+        transition:
+          border-color 0.2s,
+          background 0.2s;
+      }
+
+      .nav-launch:hover {
+        border-color: var(--green);
+        background: rgba(16, 185, 129, 0.06);
+      }
+
+      /* ── Hero ── */
+      .hero {
+        padding: 120px 0 120px;
+        overflow: hidden;
+      }
+
+      .hero-content {
+        position: relative;
+        min-height: 460px;
+      }
+
+      .hero-copy {
+        max-width: 600px;
+        position: relative;
+        z-index: 2;
+      }
+
+      h1 {
+        font-size: clamp(52px, 6.5vw, 84px);
+        font-weight: 900;
+        line-height: 1.03;
+        letter-spacing: -0.035em;
+        margin-bottom: 24px;
+      }
+
+      .grad {
+        color: var(--green);
+      }
+
+      .hero-sub {
+        font-size: 17px;
+        color: var(--muted);
+        max-width: 420px;
+        margin-bottom: 40px;
+        line-height: 1.65;
+      }
+
+      .waitlist-row {
+        display: flex;
+        gap: 10px;
+        max-width: 420px;
+        margin-bottom: 24px;
+      }
+
+      .waitlist-input {
+        flex: 1;
+        min-width: 0;
+        padding: 13px 16px;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: rgba(255, 255, 255, 0.04);
+        color: var(--text);
+        font-size: 14.5px;
+        font-family: inherit;
+        outline: none;
+        transition:
+          border-color 0.2s,
+          background 0.2s;
+      }
+
+      .waitlist-input::placeholder {
+        color: var(--dim);
+      }
+      .waitlist-input:focus {
+        border-color: var(--blue);
+        background: rgba(255, 255, 255, 0.06);
+      }
+
+      .btn {
+        padding: 13px 20px;
+        border-radius: 10px;
+        border: none;
+        background: var(--green);
+        color: #fff;
+        font-size: 14.5px;
+        font-weight: 600;
+        font-family: inherit;
+        cursor: pointer;
+        white-space: nowrap;
+        transition:
+          background 0.2s,
+          transform 0.1s,
+          box-shadow 0.2s;
+      }
+
+      .btn:hover {
+        background: #059669;
+        box-shadow: 0 0 28px rgba(16, 185, 129, 0.35);
+      }
+      .btn:active {
+        transform: scale(0.97);
+      }
+
+      .waitlist-success {
+        display: none;
+        max-width: 420px;
+        margin-bottom: 24px;
+        padding: 14px 20px;
+        border-radius: 12px;
+        border: 1px solid rgba(16, 185, 129, 0.28);
+        background: var(--green-glow);
+        color: var(--green);
+        font-size: 14.5px;
+        font-weight: 500;
+      }
+
+      .stellar-mark {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 13px;
+        color: var(--dim);
+      }
+
+      /* ── Product Mockup ── */
       .mock-wrap {
-        width: 100%;
+        position: absolute;
         right: 0;
         top: 50%;
-        transform: translateX(-50%) translateY(-50%);
-        left: 50%;
-        opacity: 0.28;
-        display: flex;
-        justify-content: center;
-        filter: blur(3px);
+        transform: translateY(-50%);
+        width: 52%;
+        z-index: 1;
       }
+
       .mock-wrap::after {
+        content: "";
+        position: absolute;
+        inset: 0;
         background:
-          linear-gradient(to bottom, var(--bg) 0%, transparent 20%, var(--bg) 85%),
-          linear-gradient(to right, var(--bg) 0%, transparent 25%, var(--bg) 75%);
+          linear-gradient(to bottom, var(--bg) 0%, transparent 18%),
+          linear-gradient(
+            to right,
+            var(--bg) 0%,
+            rgba(7, 13, 25, 0.5) 30%,
+            transparent 60%
+          );
+        pointer-events: none;
+        z-index: 3;
+        border-radius: 14px 0 0 14px;
       }
-    }
 
-    @media (max-width: 768px) {
-      section { padding: 88px 0; }
-      .hero   { padding: 128px 0 80px; }
-      h1 { font-size: clamp(44px, 13vw, 68px); }
-      .waitlist-row { flex-direction: column; }
-      .stats { grid-template-columns: 1fr; }
-      .steps { grid-template-columns: 1fr; gap: 36px; }
-      .steps::before { display: none; }
-
-      .proto-grid { grid-template-columns: 1fr; }
-      .public-grid { grid-template-columns: 1fr; gap: 52px; }
-      .foot-row { flex-direction: column; align-items: flex-start; }
-    }
-  </style>
-</head>
-<body>
-
-<div class="bg-canvas" aria-hidden="true"></div>
-
-<!-- ── Nav ── -->
-<nav id="nav">
-  <div class="wrap">
-    <div class="nav-row">
-      <span class="wordmark">Meridian</span>
-      <div class="nav-actions">
-        <a class="nav-gh" href="https://github.com/drydocs/meridian" target="_blank" rel="noopener">
-          <svg width="15" height="15" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
-          GitHub
-        </a>
-        <a class="nav-launch" href="/app">Launch App ↗</a>
-      </div>
-    </div>
-  </div>
-</nav>
-
-<!-- ── Hero ── -->
-<section class="hero">
-  <div class="wrap">
-
-
-    <div class="hero-content">
-      <!-- Copy -->
-      <div class="hero-copy">
-        <h1>
-          Earn dollar yields<br>
-          <span class="grad">from anywhere.</span>
-        </h1>
-        <p class="hero-sub">
-          Meridian routes your USDC into the highest-yielding vaults on Stellar.
-          No bank account. No gas fees. Built for West Africa.
-        </p>
-
-        <div class="waitlist-row" id="waitlist-form">
-          <input class="waitlist-input" id="email" type="email" placeholder="your@email.com" autocomplete="email" aria-label="Email address">
-          <button class="btn" id="cta-btn">Get early access</button>
-        </div>
-        <div class="waitlist-success" id="waitlist-success">
-          You're on the list — we'll reach out when early access opens.
-        </div>
-
-        <div class="stellar-mark">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M12.003 1.716c-1.37 0-2.7.27-3.948.78A10.18 10.18 0 0 0 2.66 7.901a10.136 10.136 0 0 0-.797 3.954c0 .258.01.516.027.775a1.942 1.942 0 0 1-1.055 1.88L0 14.934v1.902l2.463-1.26.072-.032v.005l.77-.39.758-.385.066-.039 14.807-7.56 1.666-.847 3.392-1.732V2.694L17.792 5.86 3.744 13.025l-.104.055-.017-.115a8.286 8.286 0 0 1-.071-1.105c0-2.255.88-4.377 2.474-5.977a8.462 8.462 0 0 1 2.71-1.82 8.513 8.513 0 0 1 3.2-.654h.067a8.41 8.41 0 0 1 4.09 1.055l1.628-.83.126-.066a10.11 10.11 0 0 0-5.845-1.853zM24 7.143 5.047 16.808l-1.666.847L0 19.382v1.902l3.282-1.671 2.91-1.485 14.058-7.153.105-.055.016.115c.05.369.072.743.072 1.11 0 2.255-.88 4.383-2.475 5.978a8.461 8.461 0 0 1-2.71 1.82 8.305 8.305 0 0 1-3.2.654h-.06c-1.441 0-2.86-.369-4.102-1.061l-.066.033-1.683.857c.594.418 1.232.776 1.903 1.062a10.11 10.11 0 0 0 3.947.797 10.09 10.09 0 0 0 7.17-2.975 10.136 10.136 0 0 0 2.969-7.18c0-.259-.005-.523-.027-.781a1.942 1.942 0 0 1 1.055-1.88L24 9.044z" opacity="0.6"/>
-          </svg>
-          Built on Stellar
-        </div>
-      </div>
-
-      <!-- Product mockup -->
-      <div class="mock-wrap" aria-hidden="true">
-        <div class="mock-window">
-          <div class="mock-chrome">
-            <div class="mock-dots">
-              <span class="mock-dot mock-dot-r"></span>
-              <span class="mock-dot mock-dot-y"></span>
-              <span class="mock-dot mock-dot-g"></span>
-            </div>
-            <div class="mock-url">meridian.app</div>
-          </div>
-          <div class="mock-body">
-
-            <div class="mock-section-label">Your Portfolio</div>
-            <div class="mock-portfolio">
-              <div class="mock-stat">
-                <div class="mock-stat-label">Deposited</div>
-                <div class="mock-stat-val">$2,400</div>
-              </div>
-              <div class="mock-stat">
-                <div class="mock-stat-label">Earned</div>
-                <div class="mock-stat-val pos">+$312.50</div>
-              </div>
-              <div class="mock-stat">
-                <div class="mock-stat-label">Positions</div>
-                <div class="mock-stat-val">3</div>
-              </div>
-            </div>
-
-            <div class="mock-section-label">Available Vaults</div>
-            <div class="mock-vaults">
-              <div class="mock-vault">
-                <div>
-                  <div class="mock-vault-name">Blend · USDC</div>
-                  <div class="mock-vault-proto">Lending Protocol</div>
-                </div>
-                <div class="mock-vault-apy">15.8%</div>
-              </div>
-              <div class="mock-vault">
-                <div>
-                  <div class="mock-vault-name">DeFindex · USDC</div>
-                  <div class="mock-vault-proto">Yield Strategy</div>
-                </div>
-                <div class="mock-vault-apy">13.2%</div>
-              </div>
-              <div class="mock-vault">
-                <div>
-                  <div class="mock-vault-name">Blend · EURC</div>
-                  <div class="mock-vault-proto">Lending Protocol</div>
-                </div>
-                <div class="mock-vault-apy">8.9%</div>
-              </div>
-            </div>
-
-          </div>
-        </div>
-      </div>
-    </div>
-
-  </div>
-</section>
-
-<!-- ── Problem ── -->
-<section class="problem alt-section">
-  <div class="wrap">
-    <div class="problem-header">
-      <h2 class="section-title">Inflation is winning.<br>Your savings are losing.</h2>
-      <p class="section-sub">
-        Across West Africa, inflation runs double-digit while savings accounts pay a fraction of that.
-        Most DeFi makes it worse — not better.
-      </p>
-    </div>
-    <div class="stats">
-      <div class="stat">
-        <div class="stat-icon stat-icon-red">
-          <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941"/></svg>
-        </div>
-        <div class="stat-num num-red" data-counter="33.7" data-suffix="%">33.7%</div>
-        <div class="stat-name">Nigeria inflation rate</div>
-        <p class="stat-body">Nigeria's average inflation in 2024, per the National Bureau of Statistics. Every naira saved in a bank loses a third of its purchasing power in a year.</p>
-      </div>
-      <div class="stat">
-        <div class="stat-icon stat-icon-amber">
-          <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0 0 12 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75Z"/></svg>
-        </div>
-        <div class="stat-num num-amber" data-counter="6.2" data-suffix="%">6.2%</div>
-        <div class="stat-name">Cost to receive $200</div>
-        <p class="stat-body">The average fee to receive a remittance in West Africa, per the World Bank 2023 report. Banks extract hundreds of millions in transfer fees every year.</p>
-      </div>
-      <div class="stat">
-        <div class="stat-icon stat-icon-green">
-          <svg width="20" height="20" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"/></svg>
-        </div>
-        <div class="stat-num num-green">&lt;$0.001</div>
-        <div class="stat-name">Stellar transaction fee</div>
-        <p class="stat-body">The cost to move any amount of USDC on Stellar, settling in 5 seconds. Not $50 in Ethereum gas. A fraction of a cent — designed for real people.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ── How it works ── -->
-<section class="light-section">
-  <div class="wrap">
-    <p class="label">How it works</p>
-    <h2 class="section-title">Three clicks to earning yield.</h2>
-    <div class="steps">
-      <div class="step">
-        <div class="step-num">01</div>
-        <h3>Connect your Freighter wallet</h3>
-        <p>Freighter is a free Stellar browser extension. No seed phrase sharing, no custodial risk. You hold your keys — always.</p>
-      </div>
-      <div class="step">
-        <div class="step-num">02</div>
-        <h3>See live APY across all vaults</h3>
-        <p>Meridian pulls real-time rates from Blend Capital and DeFindex. Every vault ranked by yield. No spreadsheets, no guesswork.</p>
-      </div>
-      <div class="step">
-        <div class="step-num">03</div>
-        <h3>Deposit in one click</h3>
-        <p>Approve a single transaction in Freighter. Meridian builds the unsigned XDR — your private key never leaves your device.</p>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ── Protocols ── -->
-<section class="protocols alt-section">
-  <div class="wrap">
-    <div class="proto-head">
-      <h2 class="section-title">Battle-tested protocols.</h2>
-      <p class="section-sub">
-        Meridian doesn't reinvent the wheel. It aggregates the best yield from two of
-        the most credible protocols already running in production on Stellar.
-      </p>
-    </div>
-    <div class="proto-grid">
-      <a class="proto-card proto-card--blend" href="https://blend.capital" target="_blank" rel="noopener">
-        <span class="proto-arrow">↗</span>
-        <div class="proto-logo-bg" aria-hidden="true">
-          <svg width="200" height="200" viewBox="0 0 300 300" fill="none">
-            <path fill="#24a338" d="M48.16,127.19A51.41,51.41,0,0,1,35,103.59c-2.92-11.64.2-22,7.78-31.06A57.05,57.05,0,0,1,57.17,60.62l1.37-.85c-1.31-2.71-2.57-5.37-3.88-8A22.54,22.54,0,0,1,52,40.38c.34-5.82,3.12-10.36,7.55-14a29.05,29.05,0,0,1,9.67-5q26.27-8.49,52.55-17A63,63,0,0,1,131.93,1.6a19.49,19.49,0,0,1,22.27,17c.46,3.39,1.07,6.76,1.6,10,2.83,0,5.56-.12,8.27,0a60,60,0,0,1,17.56,3.14c10.12,3.68,16.68,10.71,19.77,21a64.21,64.21,0,0,1,2.83,19c0,1.93-.3,3.86-.46,5.75,2.59,1.26,5.19,2.45,7.73,3.78a46.13,46.13,0,0,1,23,27c2.91,8.54,5.62,17.14,8.36,25.73q11.22,35.17,22.37,70.36a41.35,41.35,0,0,1,.42,22.5c-3,12.22-8.91,22.71-18.7,30.78-6,4.95-13,8.19-20.32,10.63-12.77,4.25-25.6,8.3-38.42,12.41q-23.38,7.5-46.79,14.94a77.28,77.28,0,0,1-17.5,3.64,48.33,48.33,0,0,1-13-1,56.3,56.3,0,0,1-16.12-5.79c-12.53-6.77-20.77-16.93-25-30.65C62,236.65,53.8,211.54,45.7,186.4a177.41,177.41,0,0,1-5.61-19.6c-2.79-14.05-.39-27.05,7.67-39Zm27-5.8c-.84,1.15-1.55,2.23-2.38,3.22-2.81,3.32-5.79,6.52-8.47,9.94-7.94,10.1-10.38,21.29-6.31,33.67,2.86,8.7,5.76,17.39,8.55,26.11,7,21.9,13.95,43.82,21,65.7a24.57,24.57,0,0,0,3.16,6.59A35,35,0,0,0,101,276c10.38,6.44,21.44,7.42,33,3.8,11.17-3.5,22.29-7.14,33.44-10.71q26.1-8.36,52.21-16.69c4.85-1.56,9.64-3.3,13.89-6.22,8-5.46,12.52-13.19,15-22.34,1.31-4.88,1.68-9.67.1-14.62q-15.25-47.64-30.38-95.34a27.58,27.58,0,0,0-8.1-12.58c-5.61-5-12.25-7.89-19.45-9.66-3.46-.85-6.93-1.64-10.4-2.44-1-.23-1.89-.88-1.82-1.81.09-1.28-.26-2.88,1.27-3.71,5.46-3,7.59-7.77,7.06-13.68a95.31,95.31,0,0,0-2.19-12.27c-1.19-5.33-4.67-8.57-9.85-10.08a48.47,48.47,0,0,0-20.78-1.19c-1.46.22-2.92.48-4.37.8s-1.89,1-1.43,2.43l.48,1.45c.84,2.57.84,2.56,3.59,2.26a8.81,8.81,0,0,1,5.17.58c1.15.58,1.39,1.59.46,2.43a13.67,13.67,0,0,1-3.22,2.39c-8.87,4.06-17.69,8.27-26.72,12A192.14,192.14,0,0,1,87.72,82c-4.2.73-8.41,1.34-12.64,1.88a7.47,7.47,0,0,1-3-.51c-1-.3-1.33-1.09-.59-1.9a22.07,22.07,0,0,1,3-2.79c1-.76,2.25-1.27,3.33-2,.3-.2.64-.79.55-1-.62-1.73-1.34-3.42-2.06-5.18-.37.12-.63.2-.88.3a67.92,67.92,0,0,0-12,6.41,38,38,0,0,0-8.78,8C51.54,89.43,50,94.1,51.6,99.31a37.31,37.31,0,0,0,8.22,15,12.13,12.13,0,0,0,9.87,4.24A4.62,4.62,0,0,1,74,120.31,13.27,13.27,0,0,0,75.15,121.39ZM134.62,18.84c-.72.17-1.45.3-2.14.52L72.07,38.91a7.53,7.53,0,0,0-1.64.73c-1.35.84-1.51,1.48-.82,2.87Q73.8,51,78,59.43q3.39,6.84,6.78,13.68a3,3,0,0,0,3.5,1.81c2.35-.47,4.69-1,7-1.64,14.38-3.86,28.46-8.68,42.47-13.68,1.59-.57,3.58-.88,3.73-3.21,0-.07.12-.14.19-.2.86-.68.79-1.53.62-2.51-1-5.82-1.95-11.66-2.93-17.48-.86-5.15-1.71-10.3-2.6-15.44C136.49,19.28,136.06,19,134.62,18.84Z"/>
-            <path fill="#24a338" d="M210.69,133c.93,2.85,1.79,5.43,2.62,8,4.49,14,9,28,13.42,42,2,6.34,4,12.71,5.6,19.16a35.69,35.69,0,0,1,.34,18.27c-2.27,8.41-7.66,14.19-15.34,18-8.07,4-16.61,6.77-25.16,9.49q-23.67,7.51-47.35,15a77.75,77.75,0,0,1-20.61,3.45c-7.84.26-14.41-2.84-19.74-8.59a42.74,42.74,0,0,1-8.56-15c-3-8.48-5.92-17-8.79-25.57C83.33,206,79.7,194.64,75.8,183.37a11.21,11.21,0,0,1,.7-9c2-4.18,5.21-7.28,8.82-10,1.4-1.06,2.87-2,4.3-3,3.1-2.22,4.83-7.65,3.6-11.23a6.24,6.24,0,0,0-3.51-3.54,11.14,11.14,0,0,1-6.57-10.87A11.46,11.46,0,1,1,104.53,142a5.78,5.78,0,0,0,.33,6.88c1.75,2.4,4.18,3.66,7.11,3.09,3.08-.6,6.07-1.64,9.11-2.41a53.34,53.34,0,0,1,19.17-1.05c6.06.69,12.08,1.74,18.14,2.46,14.19,1.69,27.47-.84,39.46-8.92,3.8-2.57,7.52-5.25,11.28-7.88C209.58,133.85,210,133.52,210.69,133Zm-63.61,86.39a30.93,30.93,0,0,0-5.74-16.75,17.63,17.63,0,0,0-7.64-6.47,8.12,8.12,0,0,0-10.24,3.12,14.93,14.93,0,0,0-2.43,7,30.21,30.21,0,0,0,5.82,21.19,17.13,17.13,0,0,0,6.78,5.82c4.59,2.09,8.91.67,11.36-3.75C146.57,226.73,147.07,223.6,147.08,219.43Zm50.34-15.8a31.12,31.12,0,0,0-5.69-17,17.86,17.86,0,0,0-7.24-6.32c-4.49-2-8.84-.55-11.23,3.78a18.39,18.39,0,0,0-2.11,9.37,30.82,30.82,0,0,0,4,14.73c2.1,3.78,4.75,7.08,8.78,9a8.28,8.28,0,0,0,11.45-3.76C196.88,210.62,197.4,207.55,197.42,203.63Z"/>
-            <path fill="#24a338" d="M189.8,132.28a11.49,11.49,0,0,1-23-.05,11.61,11.61,0,0,1,11.53-11.48A11.47,11.47,0,0,1,189.8,132.28Z"/>
-            <path fill="#24a338" d="M150.25,118.52a6.84,6.84,0,1,1,.05,13.67,6.84,6.84,0,0,1-.05-13.67Z"/>
-            <path fill="#f0f1f1" d="M147.08,219.43c0,4.17-.51,7.3-2.09,10.17-2.45,4.42-6.77,5.84-11.36,3.75a17.13,17.13,0,0,1-6.78-5.82A30.21,30.21,0,0,1,121,206.34a14.93,14.93,0,0,1,2.43-7,8.12,8.12,0,0,1,10.24-3.12,17.63,17.63,0,0,1,7.64,6.47A30.93,30.93,0,0,1,147.08,219.43Z"/>
-            <path fill="#f0f1f1" d="M197.42,203.63c0,3.92-.54,7-2.07,9.83a8.28,8.28,0,0,1-11.45,3.76c-4-1.92-6.68-5.22-8.78-9a30.82,30.82,0,0,1-4-14.73,18.39,18.39,0,0,1,2.11-9.37c2.39-4.33,6.74-5.8,11.23-3.78a17.86,17.86,0,0,1,7.24,6.32A31.12,31.12,0,0,1,197.42,203.63Z"/>
-          </svg>
-        </div>
-        <h3 class="proto-name">Blend Capital</h3>
-        <p class="proto-desc">The leading decentralized lending and borrowing protocol on Stellar. Open-source, audited, and actively maintained. Deep USDC liquidity with a proven track record in production.</p>
-      </a>
-      <a class="proto-card proto-card--defi" href="https://defindex.io" target="_blank" rel="noopener">
-        <span class="proto-arrow">↗</span>
-        <div class="proto-logo-bg" aria-hidden="true">
-          <svg width="200" height="210" viewBox="0 0 40 42" fill="none">
-            <path fill="#DEC9F4" d="M36.4588 17.5903H25.1996C18.0292 17.5903 11.1486 14.7412 6.07964 9.66847L4.83625 8.42508C4.62266 8.21149 4.2527 8.36405 4.2527 8.66536V12.9982C4.2527 13.185 4.10013 13.3376 3.91324 13.3376H0.339453C0.152563 13.3376 0 13.185 0 12.9982V0.926596C0 0.739706 0.152563 0.587143 0.339453 0.587143H12.411C12.5979 0.587143 12.7505 0.739706 12.7505 0.926596V4.49657C12.7505 4.68346 12.5979 4.83603 12.411 4.83603H8.07822C7.77309 4.83603 7.62434 5.20218 7.83793 5.41958C12.9107 10.4923 19.7874 13.3414 26.9579 13.3414H34.0559C34.3153 13.3414 34.4869 13.0592 34.3534 12.8342C31.5424 8.05511 26.3438 4.83984 20.4129 4.83984H17.3464C17.1595 4.83984 17.007 4.68728 17.007 4.50039V0.926596C17.007 0.739706 17.1595 0.587143 17.3464 0.587143H20.4129C28.9641 0.587143 36.2986 5.86964 39.3346 13.3414C39.3384 13.3567 39.346 13.3681 39.3498 13.3834C40.1622 15.401 38.6328 17.5941 36.4588 17.5941V17.5903Z"/>
-            <path fill="#DEC9F4" d="M36.4588 24.4097H25.1996C18.0292 24.4097 11.1486 27.2588 6.07964 32.3316L4.83625 33.5749C4.62266 33.7885 4.2527 33.636 4.2527 33.3347V29.0019C4.2527 28.815 4.10013 28.6624 3.91324 28.6624H0.339453C0.152563 28.6624 0 28.815 0 29.0019V41.0734C0 41.2603 0.152563 41.4129 0.339453 41.4129H12.411C12.5979 41.4129 12.7505 41.2603 12.7505 41.0734V37.5034C12.7505 37.3166 12.5979 37.164 12.411 37.164H8.07822C7.77309 37.164 7.62434 36.7978 7.83793 36.5804C12.9107 31.5077 19.7874 28.6586 26.9579 28.6586H34.0559C34.3153 28.6586 34.4869 28.9408 34.3534 29.1659C31.5424 33.9449 26.3438 37.1602 20.4129 37.1602H17.3464C17.1595 37.1602 17.007 37.3127 17.007 37.4996V41.0696C17.007 41.2565 17.1595 41.4091 17.3464 41.4091H20.4129C28.9641 41.4091 36.2986 36.1266 39.3346 28.6548C39.3384 28.6395 39.346 28.6281 39.3498 28.6128C40.1622 26.5952 38.6328 24.4021 36.4588 24.4021V24.4097Z"/>
-          </svg>
-        </div>
-        <h3 class="proto-name">DeFindex</h3>
-        <p class="proto-desc">Automated yield vaults built on Stellar smart contracts. Composable, capital-efficient strategies designed to optimize return over time — without manual intervention.</p>
-      </a>
-    </div>
-  </div>
-</section>
-
-<!-- ── Built in public ── -->
-<section>
-  <div class="wrap">
-    <div class="public-grid">
-      <div class="public-copy">
-        <p class="label">Open source</p>
-        <h2 class="section-title">Built in public,<br>for the community.</h2>
-        <p class="section-sub">
-          Meridian is fully open-source. Every commit, every design decision, and every
-          issue is public. If you build on Stellar or care about financial access in emerging
-          markets, there is a place for you here.
-        </p>
-      </div>
-      <div class="public-links">
-        <a class="pub-link" href="https://github.com/drydocs/meridian" target="_blank" rel="noopener">
-          <div class="pub-icon">
-            <svg width="18" height="18" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true"><path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"/></svg>
-          </div>
-          <div class="pub-text">
-            <div class="pub-title">drydocs/meridian</div>
-            <div class="pub-sub">View the source on GitHub</div>
-          </div>
-          <span class="pub-chevron">→</span>
-        </a>
-        <a class="pub-link" href="https://github.com/drydocs/meridian/issues" target="_blank" rel="noopener">
-          <div class="pub-icon">
-            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.7"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-          </div>
-          <div class="pub-text">
-            <div class="pub-title">Open Issues</div>
-            <div class="pub-sub">Pick one up and contribute</div>
-          </div>
-          <span class="pub-chevron">→</span>
-        </a>
-        <a class="pub-link" href="https://github.com/drydocs/meridian/discussions" target="_blank" rel="noopener">
-          <div class="pub-icon">
-            <svg width="18" height="18" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.7"><path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"/></svg>
-          </div>
-          <div class="pub-text">
-            <div class="pub-title">Discussions</div>
-            <div class="pub-sub">Roadmap, ideas, and feedback</div>
-          </div>
-          <span class="pub-chevron">→</span>
-        </a>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- ── Footer ── -->
-<footer>
-  <div class="wrap">
-    <div class="foot-row">
-      <div class="foot-left">
-        <span class="foot-wordmark">Meridian</span>
-        <span>MIT License</span>
-        <span>&copy; 2026</span>
-      </div>
-      <div class="foot-right">
-        <a href="/docs/">Docs</a>
-        <a href="https://github.com/drydocs/meridian" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://github.com/drydocs/meridian/issues" target="_blank" rel="noopener">Issues</a>
-        <a href="https://stellar.org" target="_blank" rel="noopener">Built on Stellar</a>
-      </div>
-    </div>
-  </div>
-</footer>
-
-<script>
-  /* Nav blur on scroll */
-  const nav = document.getElementById('nav');
-  window.addEventListener('scroll', () => {
-    nav.classList.toggle('stuck', window.scrollY > 24);
-  }, { passive: true });
-
-  /* Waitlist form */
-  const form    = document.getElementById('waitlist-form');
-  const success = document.getElementById('waitlist-success');
-  const emailEl = document.getElementById('email');
-
-  function submit() {
-    const val = emailEl.value.trim();
-    if (!val || !val.includes('@') || !val.includes('.')) {
-      emailEl.focus();
-      emailEl.style.borderColor = '#f87171';
-      setTimeout(() => { emailEl.style.borderColor = ''; }, 1800);
-      return;
-    }
-    form.style.display = 'none';
-    success.style.display = 'block';
-  }
-
-  document.getElementById('cta-btn').addEventListener('click', submit);
-  emailEl.addEventListener('keydown', e => { if (e.key === 'Enter') submit(); });
-
-  /* Scroll-triggered number counters (33.7% and 6.2% only) */
-  function animateCounter(el) {
-    const target   = parseFloat(el.dataset.counter);
-    const suffix   = el.dataset.suffix || '';
-    const duration = 1800;
-    const start    = performance.now();
-    const decimals = target % 1 !== 0 ? 1 : 0;
-
-    function tick(now) {
-      const elapsed  = now - start;
-      const progress = Math.min(elapsed / duration, 1);
-      const ease     = 1 - Math.pow(1 - progress, 3);
-      el.textContent = (target * ease).toFixed(decimals) + suffix;
-      if (progress < 1) requestAnimationFrame(tick);
-    }
-
-    requestAnimationFrame(tick);
-  }
-
-  const counters = document.querySelectorAll('[data-counter]');
-  const seen     = new Set();
-
-  const observer = new IntersectionObserver(entries => {
-    entries.forEach(entry => {
-      if (entry.isIntersecting && !seen.has(entry.target)) {
-        seen.add(entry.target);
-        animateCounter(entry.target);
+      .mock-window {
+        position: relative;
+        z-index: 1;
+        border-radius: 14px;
+        border: 1px solid var(--border-strong);
+        background: rgba(9, 16, 30, 0.95);
+        overflow: hidden;
+        box-shadow:
+          0 40px 100px rgba(0, 0, 0, 0.6),
+          0 0 0 1px rgba(255, 255, 255, 0.04);
       }
-    });
-  }, { threshold: 0.3 });
 
-  counters.forEach(el => observer.observe(el));
-</script>
-</body>
+      .mock-chrome {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 11px 16px;
+        border-bottom: 1px solid var(--border);
+        background: rgba(255, 255, 255, 0.02);
+      }
+
+      .mock-dots {
+        display: flex;
+        gap: 6px;
+      }
+
+      .mock-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+      }
+
+      .mock-dot-r {
+        background: #ff5f57;
+      }
+      .mock-dot-y {
+        background: #febc2e;
+      }
+      .mock-dot-g {
+        background: #28c840;
+      }
+
+      .mock-url {
+        flex: 1;
+        text-align: center;
+        font-size: 11px;
+        color: var(--dim);
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid var(--border);
+        border-radius: 5px;
+        padding: 4px 10px;
+        font-family: "SF Mono", "Fira Code", monospace;
+      }
+
+      .mock-body {
+        padding: 18px;
+      }
+
+      .mock-section-label {
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.09em;
+        color: var(--dim);
+        margin-bottom: 10px;
+      }
+
+      .mock-portfolio {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 8px;
+        margin-bottom: 18px;
+      }
+
+      .mock-stat {
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 9px;
+        padding: 10px 12px;
+      }
+
+      .mock-stat-label {
+        font-size: 9px;
+        color: var(--dim);
+        margin-bottom: 4px;
+      }
+      .mock-stat-val {
+        font-size: 14px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+      }
+      .mock-stat-val.pos {
+        color: var(--green);
+      }
+
+      .mock-vaults {
+        display: flex;
+        flex-direction: column;
+        gap: 7px;
+      }
+
+      .mock-vault {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 11px 14px;
+        border-radius: 10px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+      }
+
+      .mock-vault-name {
+        font-size: 12px;
+        font-weight: 600;
+      }
+      .mock-vault-proto {
+        font-size: 10px;
+        color: var(--dim);
+        margin-top: 2px;
+      }
+      .mock-vault-apy {
+        font-size: 16px;
+        font-weight: 900;
+        color: var(--green);
+        letter-spacing: -0.02em;
+      }
+
+      /* ── Section labels ── */
+      .label {
+        font-size: 11.5px;
+        font-weight: 700;
+        letter-spacing: 0.13em;
+        text-transform: uppercase;
+        color: var(--blue);
+        margin-bottom: 14px;
+      }
+
+      .section-title {
+        font-size: clamp(30px, 4vw, 46px);
+        font-weight: 800;
+        letter-spacing: -0.027em;
+        line-height: 1.08;
+        margin-bottom: 18px;
+      }
+
+      .section-sub {
+        font-size: 16.5px;
+        color: var(--muted);
+        line-height: 1.65;
+        max-width: 460px;
+      }
+
+      /* ── Problem ── */
+      .alt-section {
+        background: var(--bg-2);
+        border-top: 1px solid var(--border);
+        border-bottom: 1px solid var(--border);
+        --text: #ddeeff;
+        --muted: rgba(200, 225, 255, 0.56);
+        --dim: rgba(200, 225, 255, 0.28);
+        color: var(--text);
+      }
+
+      .light-section {
+        background-color: #dce6f7;
+        background-image: radial-gradient(
+          circle,
+          rgba(59, 130, 246, 0.39) 1px,
+          transparent 1px
+        );
+        background-size: 28px 28px;
+        border-top: 1px solid rgba(0, 0, 0, 0.07);
+        border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+        --text: #0d1929;
+        --muted: rgba(13, 25, 41, 0.58);
+        --dim: rgba(13, 25, 41, 0.36);
+        --border: rgba(0, 0, 0, 0.1);
+        --surface: rgba(0, 0, 0, 0.04);
+        color: var(--text);
+      }
+
+      .problem-header {
+        margin-bottom: 60px;
+      }
+
+      .stats {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 18px;
+      }
+
+      .stat {
+        padding: 36px 30px;
+        border-radius: 18px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        position: relative;
+        overflow: hidden;
+      }
+
+      .stat::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          140deg,
+          rgba(255, 255, 255, 0.024) 0%,
+          transparent 55%
+        );
+        pointer-events: none;
+      }
+
+      .stat-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-bottom: 20px;
+      }
+
+      .stat-icon-red {
+        background: rgba(248, 113, 113, 0.12);
+        color: #f87171;
+      }
+      .stat-icon-amber {
+        background: rgba(251, 191, 36, 0.12);
+        color: #fbbf24;
+      }
+      .stat-icon-green {
+        background: rgba(16, 185, 129, 0.12);
+        color: var(--green);
+      }
+
+      .stat-num {
+        font-size: 52px;
+        font-weight: 900;
+        letter-spacing: -0.04em;
+        line-height: 1;
+        margin-bottom: 10px;
+      }
+
+      .num-red {
+        color: #f87171;
+      }
+      .num-amber {
+        color: #fbbf24;
+      }
+      .num-green {
+        color: var(--green);
+      }
+
+      .stat-name {
+        font-size: 11px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.1em;
+        color: var(--muted);
+        margin-bottom: 12px;
+      }
+
+      .stat-body {
+        font-size: 14px;
+        color: var(--muted);
+        line-height: 1.6;
+      }
+
+      /* ── Steps ── */
+      .steps {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 48px;
+        margin-top: 72px;
+        position: relative;
+      }
+
+      .steps::before {
+        content: "";
+        position: absolute;
+        top: 23px;
+        left: calc(16.67% + 10px);
+        right: calc(16.67% + 10px);
+        height: 1px;
+        background: linear-gradient(
+          90deg,
+          transparent 0%,
+          var(--border) 20%,
+          var(--border) 80%,
+          transparent 100%
+        );
+      }
+
+      .step-num {
+        width: 46px;
+        height: 46px;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 14px;
+        font-weight: 700;
+        color: var(--blue);
+        margin-bottom: 24px;
+        position: relative;
+        z-index: 1;
+      }
+
+      .step-icon {
+        width: 44px;
+        height: 44px;
+        border-radius: 12px;
+        background: rgba(59, 130, 246, 0.08);
+        border: 1px solid rgba(59, 130, 246, 0.18);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--blue);
+        margin-bottom: 20px;
+      }
+
+      .step h3 {
+        font-size: 17px;
+        font-weight: 700;
+        letter-spacing: -0.015em;
+        margin-bottom: 10px;
+      }
+
+      .step p {
+        font-size: 14.5px;
+        color: var(--muted);
+        line-height: 1.65;
+      }
+
+      /* ── Protocols ── */
+      /* .protocols shares .alt-section */
+
+      .proto-head {
+        margin-bottom: 52px;
+      }
+
+      .proto-head .section-sub {
+        max-width: 560px;
+        margin-top: 16px;
+      }
+
+      .proto-grid {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 18px;
+      }
+
+      .proto-card {
+        --ca: 255, 255, 255;
+        display: block;
+        padding: 36px;
+        border-radius: 20px;
+        border: 1px solid rgba(var(--ca), 0.28);
+        background: rgba(var(--ca), 0.14);
+        text-decoration: none;
+        color: inherit;
+        position: relative;
+        overflow: hidden;
+        transition:
+          border-color 0.22s,
+          background 0.22s;
+      }
+
+      .proto-card--blend {
+        --ca: 36, 163, 56;
+      }
+      .proto-card--defi {
+        --ca: 186, 155, 221;
+      }
+
+      .proto-card::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          140deg,
+          rgba(var(--ca), 0.14) 0%,
+          transparent 55%
+        );
+        pointer-events: none;
+        z-index: 1;
+      }
+
+      .proto-card:hover {
+        border-color: rgba(var(--ca), 0.5);
+        background: rgba(var(--ca), 0.2);
+      }
+
+      .proto-arrow {
+        position: absolute;
+        top: 30px;
+        right: 30px;
+        font-size: 18px;
+        color: var(--dim);
+        transition: color 0.2s;
+        z-index: 2;
+      }
+
+      .proto-card:hover .proto-arrow {
+        color: var(--muted);
+      }
+
+      .proto-logo-bg {
+        position: absolute;
+        right: -20px;
+        bottom: -20px;
+        opacity: 0.2;
+        pointer-events: none;
+        z-index: 0;
+      }
+
+      .proto-name,
+      .proto-desc {
+        position: relative;
+        z-index: 2;
+      }
+
+      .proto-tag {
+        display: inline-block;
+        padding: 4px 10px;
+        border-radius: 6px;
+        font-size: 10.5px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+      }
+
+      .tag-blue {
+        background: rgba(59, 130, 246, 0.14);
+        color: #93c5fd;
+      }
+      .tag-violet {
+        background: rgba(139, 92, 246, 0.14);
+        color: #c4b5fd;
+      }
+
+      .proto-name {
+        font-size: 22px;
+        font-weight: 800;
+        letter-spacing: -0.022em;
+        margin-bottom: 10px;
+      }
+      .proto-desc {
+        font-size: 14.5px;
+        color: var(--muted);
+        line-height: 1.65;
+        margin-bottom: 28px;
+      }
+
+      /* ── Built in public ── */
+      .public-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 96px;
+        align-items: center;
+      }
+
+      .public-copy .section-sub {
+        margin-bottom: 0;
+      }
+
+      .public-links {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .pub-link {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 18px 22px;
+        border-radius: 14px;
+        border: 1px solid var(--border);
+        background: var(--surface);
+        text-decoration: none;
+        color: inherit;
+        transition:
+          border-color 0.2s,
+          background 0.2s;
+      }
+
+      .pub-link:hover {
+        border-color: var(--border-strong);
+        background: var(--surface-2);
+      }
+
+      .pub-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        background: var(--surface-2);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        color: var(--muted);
+      }
+
+      .pub-text {
+        flex: 1;
+      }
+      .pub-title {
+        font-size: 14.5px;
+        font-weight: 600;
+        margin-bottom: 2px;
+      }
+      .pub-sub {
+        font-size: 12.5px;
+        color: var(--dim);
+      }
+      .pub-chevron {
+        color: var(--dim);
+        font-size: 16px;
+      }
+
+      /* ── Footer ── */
+      footer {
+        padding: 36px 0;
+        background: rgba(7, 13, 25, 0.82);
+        backdrop-filter: blur(18px);
+        -webkit-backdrop-filter: blur(18px);
+      }
+
+      .foot-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 14px;
+      }
+
+      .foot-left {
+        display: flex;
+        align-items: center;
+        gap: 18px;
+        font-size: 13.5px;
+        color: var(--dim);
+      }
+
+      .foot-wordmark {
+        font-weight: 700;
+        color: var(--muted);
+        font-size: 14px;
+      }
+
+      .foot-right {
+        display: flex;
+        gap: 22px;
+      }
+
+      .foot-right a {
+        font-size: 13.5px;
+        color: var(--dim);
+        text-decoration: none;
+        transition: color 0.2s;
+      }
+
+      .foot-right a:hover {
+        color: var(--muted);
+      }
+
+      /* ── Responsive ── */
+      @media (max-width: 900px) {
+        .hero-copy {
+          max-width: 100%;
+          text-align: center;
+        }
+
+        .hero-sub {
+          max-width: 100%;
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .waitlist-row {
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .waitlist-success {
+          margin-left: auto;
+          margin-right: auto;
+        }
+        .stellar-mark {
+          justify-content: center;
+        }
+        .mock-wrap {
+          width: 100%;
+          right: 0;
+          top: 50%;
+          transform: translateX(-50%) translateY(-50%);
+          left: 50%;
+          opacity: 0.28;
+          display: flex;
+          justify-content: center;
+          filter: blur(3px);
+        }
+        .mock-wrap::after {
+          background:
+            linear-gradient(
+              to bottom,
+              var(--bg) 0%,
+              transparent 20%,
+              var(--bg) 85%
+            ),
+            linear-gradient(
+              to right,
+              var(--bg) 0%,
+              transparent 25%,
+              var(--bg) 75%
+            );
+        }
+      }
+
+      @media (max-width: 768px) {
+        section {
+          padding: 88px 0;
+        }
+        .hero {
+          padding: 128px 0 80px;
+        }
+        h1 {
+          font-size: clamp(44px, 13vw, 68px);
+        }
+        .waitlist-row {
+          flex-direction: column;
+        }
+        .stats {
+          grid-template-columns: 1fr;
+        }
+        .steps {
+          grid-template-columns: 1fr;
+          gap: 36px;
+        }
+        .steps::before {
+          display: none;
+        }
+
+        .proto-grid {
+          grid-template-columns: 1fr;
+        }
+        .public-grid {
+          grid-template-columns: 1fr;
+          gap: 52px;
+        }
+        .foot-row {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="bg-canvas" aria-hidden="true"></div>
+
+    <!-- ── Nav ── -->
+    <nav id="nav">
+      <div class="wrap">
+        <div class="nav-row">
+          <span class="wordmark">Meridian</span>
+          <div class="nav-actions">
+            <a
+              class="nav-gh"
+              href="https://github.com/drydocs/meridian"
+              target="_blank"
+              rel="noopener"
+            >
+              <svg
+                width="15"
+                height="15"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                  clip-rule="evenodd"
+                />
+              </svg>
+              GitHub
+            </a>
+            <a class="nav-launch" href="/app">Launch App ↗</a>
+          </div>
+        </div>
+      </div>
+    </nav>
+
+    <!-- ── Hero ── -->
+    <section class="hero">
+      <div class="wrap">
+        <div class="hero-content">
+          <!-- Copy -->
+          <div class="hero-copy">
+            <h1>
+              Earn dollar yields<br />
+              <span class="grad">from anywhere.</span>
+            </h1>
+            <p class="hero-sub">
+              Meridian routes your USDC into the highest-yielding vaults on
+              Stellar. No bank account. No gas fees. Built for West Africa.
+            </p>
+
+            <div class="waitlist-row" id="waitlist-form">
+              <input
+                class="waitlist-input"
+                id="email"
+                type="email"
+                placeholder="your@email.com"
+                autocomplete="email"
+                aria-label="Email address"
+              />
+              <button class="btn" id="cta-btn">Get early access</button>
+            </div>
+            <div class="waitlist-success" id="waitlist-success">
+              You're on the list — we'll reach out when early access opens.
+            </div>
+
+            <div class="stellar-mark">
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12.003 1.716c-1.37 0-2.7.27-3.948.78A10.18 10.18 0 0 0 2.66 7.901a10.136 10.136 0 0 0-.797 3.954c0 .258.01.516.027.775a1.942 1.942 0 0 1-1.055 1.88L0 14.934v1.902l2.463-1.26.072-.032v.005l.77-.39.758-.385.066-.039 14.807-7.56 1.666-.847 3.392-1.732V2.694L17.792 5.86 3.744 13.025l-.104.055-.017-.115a8.286 8.286 0 0 1-.071-1.105c0-2.255.88-4.377 2.474-5.977a8.462 8.462 0 0 1 2.71-1.82 8.513 8.513 0 0 1 3.2-.654h.067a8.41 8.41 0 0 1 4.09 1.055l1.628-.83.126-.066a10.11 10.11 0 0 0-5.845-1.853zM24 7.143 5.047 16.808l-1.666.847L0 19.382v1.902l3.282-1.671 2.91-1.485 14.058-7.153.105-.055.016.115c.05.369.072.743.072 1.11 0 2.255-.88 4.383-2.475 5.978a8.461 8.461 0 0 1-2.71 1.82 8.305 8.305 0 0 1-3.2.654h-.06c-1.441 0-2.86-.369-4.102-1.061l-.066.033-1.683.857c.594.418 1.232.776 1.903 1.062a10.11 10.11 0 0 0 3.947.797 10.09 10.09 0 0 0 7.17-2.975 10.136 10.136 0 0 0 2.969-7.18c0-.259-.005-.523-.027-.781a1.942 1.942 0 0 1 1.055-1.88L24 9.044z"
+                  opacity="0.6"
+                />
+              </svg>
+              Built on Stellar
+            </div>
+          </div>
+
+          <!-- Product mockup -->
+          <div class="mock-wrap" aria-hidden="true">
+            <div class="mock-window">
+              <div class="mock-chrome">
+                <div class="mock-dots">
+                  <span class="mock-dot mock-dot-r"></span>
+                  <span class="mock-dot mock-dot-y"></span>
+                  <span class="mock-dot mock-dot-g"></span>
+                </div>
+                <div class="mock-url">meridian.app</div>
+              </div>
+              <div class="mock-body">
+                <div class="mock-section-label">Your Portfolio</div>
+                <div class="mock-portfolio">
+                  <div class="mock-stat">
+                    <div class="mock-stat-label">Deposited</div>
+                    <div class="mock-stat-val">$2,400</div>
+                  </div>
+                  <div class="mock-stat">
+                    <div class="mock-stat-label">Earned</div>
+                    <div class="mock-stat-val pos">+$312.50</div>
+                  </div>
+                  <div class="mock-stat">
+                    <div class="mock-stat-label">Positions</div>
+                    <div class="mock-stat-val">3</div>
+                  </div>
+                </div>
+
+                <div class="mock-section-label">Available Vaults</div>
+                <div class="mock-vaults">
+                  <div class="mock-vault">
+                    <div>
+                      <div class="mock-vault-name">Blend · USDC</div>
+                      <div class="mock-vault-proto">Lending Protocol</div>
+                    </div>
+                    <div class="mock-vault-apy">15.8%</div>
+                  </div>
+                  <div class="mock-vault">
+                    <div>
+                      <div class="mock-vault-name">DeFindex · USDC</div>
+                      <div class="mock-vault-proto">Yield Strategy</div>
+                    </div>
+                    <div class="mock-vault-apy">13.2%</div>
+                  </div>
+                  <div class="mock-vault">
+                    <div>
+                      <div class="mock-vault-name">Blend · EURC</div>
+                      <div class="mock-vault-proto">Lending Protocol</div>
+                    </div>
+                    <div class="mock-vault-apy">8.9%</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Problem ── -->
+    <section class="problem alt-section">
+      <div class="wrap">
+        <div class="problem-header">
+          <h2 class="section-title">
+            Inflation is winning.<br />Your savings are losing.
+          </h2>
+          <p class="section-sub">
+            Across West Africa, inflation runs double-digit while savings
+            accounts pay a fraction of that. Most DeFi makes it worse — not
+            better.
+          </p>
+        </div>
+        <div class="stats">
+          <div class="stat">
+            <div class="stat-icon stat-icon-red">
+              <svg
+                width="20"
+                height="20"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.8"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M2.25 18 9 11.25l4.306 4.306a11.95 11.95 0 0 1 5.814-5.518l2.74-1.22m0 0-5.94-2.281m5.94 2.28-2.28 5.941"
+                />
+              </svg>
+            </div>
+            <div class="stat-num num-red" data-counter="33.7" data-suffix="%">
+              33.7%
+            </div>
+            <div class="stat-name">Nigeria inflation rate</div>
+            <p class="stat-body">
+              Nigeria's average inflation in 2024, per the National Bureau of
+              Statistics. Every naira saved in a bank loses a third of its
+              purchasing power in a year.
+            </p>
+          </div>
+          <div class="stat">
+            <div class="stat-icon stat-icon-amber">
+              <svg
+                width="20"
+                height="20"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.8"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M12 21v-8.25M15.75 21v-8.25M8.25 21v-8.25M3 9l9-6 9 6m-1.5 12V10.332A48.36 48.36 0 0 0 12 9.75c-2.551 0-5.056.2-7.5.582V21M3 21h18M12 6.75h.008v.008H12V6.75Z"
+                />
+              </svg>
+            </div>
+            <div class="stat-num num-amber" data-counter="6.2" data-suffix="%">
+              6.2%
+            </div>
+            <div class="stat-name">Cost to receive $200</div>
+            <p class="stat-body">
+              The average fee to receive a remittance in West Africa, per the
+              World Bank 2023 report. Banks extract hundreds of millions in
+              transfer fees every year.
+            </p>
+          </div>
+          <div class="stat">
+            <div class="stat-icon stat-icon-green">
+              <svg
+                width="20"
+                height="20"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.8"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="m3.75 13.5 10.5-11.25L12 10.5h8.25L9.75 21.75 12 13.5H3.75Z"
+                />
+              </svg>
+            </div>
+            <div class="stat-num num-green">&lt;$0.001</div>
+            <div class="stat-name">Stellar transaction fee</div>
+            <p class="stat-body">
+              The cost to move any amount of USDC on Stellar, settling in 5
+              seconds. Not $50 in Ethereum gas. A fraction of a cent — designed
+              for real people.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── How it works ── -->
+    <section class="light-section">
+      <div class="wrap">
+        <p class="label">How it works</p>
+        <h2 class="section-title">Three clicks to earning yield.</h2>
+        <div class="steps">
+          <div class="step">
+            <div class="step-num">01</div>
+            <h3>Connect your Freighter wallet</h3>
+            <p>
+              Freighter is a free Stellar browser extension. No seed phrase
+              sharing, no custodial risk. You hold your keys — always.
+            </p>
+          </div>
+          <div class="step">
+            <div class="step-num">02</div>
+            <h3>See live APY across all vaults</h3>
+            <p>
+              Meridian pulls real-time rates from Blend Capital and DeFindex.
+              Every vault ranked by yield. No spreadsheets, no guesswork.
+            </p>
+          </div>
+          <div class="step">
+            <div class="step-num">03</div>
+            <h3>Deposit in one click</h3>
+            <p>
+              Approve a single transaction in Freighter. Meridian builds the
+              unsigned XDR — your private key never leaves your device.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Protocols ── -->
+    <section class="protocols alt-section">
+      <div class="wrap">
+        <div class="proto-head">
+          <h2 class="section-title">Battle-tested protocols.</h2>
+          <p class="section-sub">
+            Meridian doesn't reinvent the wheel. It aggregates the best yield
+            from two of the most credible protocols already running in
+            production on Stellar.
+          </p>
+        </div>
+        <div class="proto-grid">
+          <a
+            class="proto-card proto-card--blend"
+            href="https://blend.capital"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="proto-arrow">↗</span>
+            <div class="proto-logo-bg" aria-hidden="true">
+              <svg width="200" height="200" viewBox="0 0 300 300" fill="none">
+                <path
+                  fill="#24a338"
+                  d="M48.16,127.19A51.41,51.41,0,0,1,35,103.59c-2.92-11.64.2-22,7.78-31.06A57.05,57.05,0,0,1,57.17,60.62l1.37-.85c-1.31-2.71-2.57-5.37-3.88-8A22.54,22.54,0,0,1,52,40.38c.34-5.82,3.12-10.36,7.55-14a29.05,29.05,0,0,1,9.67-5q26.27-8.49,52.55-17A63,63,0,0,1,131.93,1.6a19.49,19.49,0,0,1,22.27,17c.46,3.39,1.07,6.76,1.6,10,2.83,0,5.56-.12,8.27,0a60,60,0,0,1,17.56,3.14c10.12,3.68,16.68,10.71,19.77,21a64.21,64.21,0,0,1,2.83,19c0,1.93-.3,3.86-.46,5.75,2.59,1.26,5.19,2.45,7.73,3.78a46.13,46.13,0,0,1,23,27c2.91,8.54,5.62,17.14,8.36,25.73q11.22,35.17,22.37,70.36a41.35,41.35,0,0,1,.42,22.5c-3,12.22-8.91,22.71-18.7,30.78-6,4.95-13,8.19-20.32,10.63-12.77,4.25-25.6,8.3-38.42,12.41q-23.38,7.5-46.79,14.94a77.28,77.28,0,0,1-17.5,3.64,48.33,48.33,0,0,1-13-1,56.3,56.3,0,0,1-16.12-5.79c-12.53-6.77-20.77-16.93-25-30.65C62,236.65,53.8,211.54,45.7,186.4a177.41,177.41,0,0,1-5.61-19.6c-2.79-14.05-.39-27.05,7.67-39Zm27-5.8c-.84,1.15-1.55,2.23-2.38,3.22-2.81,3.32-5.79,6.52-8.47,9.94-7.94,10.1-10.38,21.29-6.31,33.67,2.86,8.7,5.76,17.39,8.55,26.11,7,21.9,13.95,43.82,21,65.7a24.57,24.57,0,0,0,3.16,6.59A35,35,0,0,0,101,276c10.38,6.44,21.44,7.42,33,3.8,11.17-3.5,22.29-7.14,33.44-10.71q26.1-8.36,52.21-16.69c4.85-1.56,9.64-3.3,13.89-6.22,8-5.46,12.52-13.19,15-22.34,1.31-4.88,1.68-9.67.1-14.62q-15.25-47.64-30.38-95.34a27.58,27.58,0,0,0-8.1-12.58c-5.61-5-12.25-7.89-19.45-9.66-3.46-.85-6.93-1.64-10.4-2.44-1-.23-1.89-.88-1.82-1.81.09-1.28-.26-2.88,1.27-3.71,5.46-3,7.59-7.77,7.06-13.68a95.31,95.31,0,0,0-2.19-12.27c-1.19-5.33-4.67-8.57-9.85-10.08a48.47,48.47,0,0,0-20.78-1.19c-1.46.22-2.92.48-4.37.8s-1.89,1-1.43,2.43l.48,1.45c.84,2.57.84,2.56,3.59,2.26a8.81,8.81,0,0,1,5.17.58c1.15.58,1.39,1.59.46,2.43a13.67,13.67,0,0,1-3.22,2.39c-8.87,4.06-17.69,8.27-26.72,12A192.14,192.14,0,0,1,87.72,82c-4.2.73-8.41,1.34-12.64,1.88a7.47,7.47,0,0,1-3-.51c-1-.3-1.33-1.09-.59-1.9a22.07,22.07,0,0,1,3-2.79c1-.76,2.25-1.27,3.33-2,.3-.2.64-.79.55-1-.62-1.73-1.34-3.42-2.06-5.18-.37.12-.63.2-.88.3a67.92,67.92,0,0,0-12,6.41,38,38,0,0,0-8.78,8C51.54,89.43,50,94.1,51.6,99.31a37.31,37.31,0,0,0,8.22,15,12.13,12.13,0,0,0,9.87,4.24A4.62,4.62,0,0,1,74,120.31,13.27,13.27,0,0,0,75.15,121.39ZM134.62,18.84c-.72.17-1.45.3-2.14.52L72.07,38.91a7.53,7.53,0,0,0-1.64.73c-1.35.84-1.51,1.48-.82,2.87Q73.8,51,78,59.43q3.39,6.84,6.78,13.68a3,3,0,0,0,3.5,1.81c2.35-.47,4.69-1,7-1.64,14.38-3.86,28.46-8.68,42.47-13.68,1.59-.57,3.58-.88,3.73-3.21,0-.07.12-.14.19-.2.86-.68.79-1.53.62-2.51-1-5.82-1.95-11.66-2.93-17.48-.86-5.15-1.71-10.3-2.6-15.44C136.49,19.28,136.06,19,134.62,18.84Z"
+                />
+                <path
+                  fill="#24a338"
+                  d="M210.69,133c.93,2.85,1.79,5.43,2.62,8,4.49,14,9,28,13.42,42,2,6.34,4,12.71,5.6,19.16a35.69,35.69,0,0,1,.34,18.27c-2.27,8.41-7.66,14.19-15.34,18-8.07,4-16.61,6.77-25.16,9.49q-23.67,7.51-47.35,15a77.75,77.75,0,0,1-20.61,3.45c-7.84.26-14.41-2.84-19.74-8.59a42.74,42.74,0,0,1-8.56-15c-3-8.48-5.92-17-8.79-25.57C83.33,206,79.7,194.64,75.8,183.37a11.21,11.21,0,0,1,.7-9c2-4.18,5.21-7.28,8.82-10,1.4-1.06,2.87-2,4.3-3,3.1-2.22,4.83-7.65,3.6-11.23a6.24,6.24,0,0,0-3.51-3.54,11.14,11.14,0,0,1-6.57-10.87A11.46,11.46,0,1,1,104.53,142a5.78,5.78,0,0,0,.33,6.88c1.75,2.4,4.18,3.66,7.11,3.09,3.08-.6,6.07-1.64,9.11-2.41a53.34,53.34,0,0,1,19.17-1.05c6.06.69,12.08,1.74,18.14,2.46,14.19,1.69,27.47-.84,39.46-8.92,3.8-2.57,7.52-5.25,11.28-7.88C209.58,133.85,210,133.52,210.69,133Zm-63.61,86.39a30.93,30.93,0,0,0-5.74-16.75,17.63,17.63,0,0,0-7.64-6.47,8.12,8.12,0,0,0-10.24,3.12,14.93,14.93,0,0,0-2.43,7,30.21,30.21,0,0,0,5.82,21.19,17.13,17.13,0,0,0,6.78,5.82c4.59,2.09,8.91.67,11.36-3.75C146.57,226.73,147.07,223.6,147.08,219.43Zm50.34-15.8a31.12,31.12,0,0,0-5.69-17,17.86,17.86,0,0,0-7.24-6.32c-4.49-2-8.84-.55-11.23,3.78a18.39,18.39,0,0,0-2.11,9.37,30.82,30.82,0,0,0,4,14.73c2.1,3.78,4.75,7.08,8.78,9a8.28,8.28,0,0,0,11.45-3.76C196.88,210.62,197.4,207.55,197.42,203.63Z"
+                />
+                <path
+                  fill="#24a338"
+                  d="M189.8,132.28a11.49,11.49,0,0,1-23-.05,11.61,11.61,0,0,1,11.53-11.48A11.47,11.47,0,0,1,189.8,132.28Z"
+                />
+                <path
+                  fill="#24a338"
+                  d="M150.25,118.52a6.84,6.84,0,1,1,.05,13.67,6.84,6.84,0,0,1-.05-13.67Z"
+                />
+                <path
+                  fill="#f0f1f1"
+                  d="M147.08,219.43c0,4.17-.51,7.3-2.09,10.17-2.45,4.42-6.77,5.84-11.36,3.75a17.13,17.13,0,0,1-6.78-5.82A30.21,30.21,0,0,1,121,206.34a14.93,14.93,0,0,1,2.43-7,8.12,8.12,0,0,1,10.24-3.12,17.63,17.63,0,0,1,7.64,6.47A30.93,30.93,0,0,1,147.08,219.43Z"
+                />
+                <path
+                  fill="#f0f1f1"
+                  d="M197.42,203.63c0,3.92-.54,7-2.07,9.83a8.28,8.28,0,0,1-11.45,3.76c-4-1.92-6.68-5.22-8.78-9a30.82,30.82,0,0,1-4-14.73,18.39,18.39,0,0,1,2.11-9.37c2.39-4.33,6.74-5.8,11.23-3.78a17.86,17.86,0,0,1,7.24,6.32A31.12,31.12,0,0,1,197.42,203.63Z"
+                />
+              </svg>
+            </div>
+            <h3 class="proto-name">Blend Capital</h3>
+            <p class="proto-desc">
+              The leading decentralized lending and borrowing protocol on
+              Stellar. Open-source, audited, and actively maintained. Deep USDC
+              liquidity with a proven track record in production.
+            </p>
+          </a>
+          <a
+            class="proto-card proto-card--defi"
+            href="https://defindex.io"
+            target="_blank"
+            rel="noopener"
+          >
+            <span class="proto-arrow">↗</span>
+            <div class="proto-logo-bg" aria-hidden="true">
+              <svg width="200" height="210" viewBox="0 0 40 42" fill="none">
+                <path
+                  fill="#DEC9F4"
+                  d="M36.4588 17.5903H25.1996C18.0292 17.5903 11.1486 14.7412 6.07964 9.66847L4.83625 8.42508C4.62266 8.21149 4.2527 8.36405 4.2527 8.66536V12.9982C4.2527 13.185 4.10013 13.3376 3.91324 13.3376H0.339453C0.152563 13.3376 0 13.185 0 12.9982V0.926596C0 0.739706 0.152563 0.587143 0.339453 0.587143H12.411C12.5979 0.587143 12.7505 0.739706 12.7505 0.926596V4.49657C12.7505 4.68346 12.5979 4.83603 12.411 4.83603H8.07822C7.77309 4.83603 7.62434 5.20218 7.83793 5.41958C12.9107 10.4923 19.7874 13.3414 26.9579 13.3414H34.0559C34.3153 13.3414 34.4869 13.0592 34.3534 12.8342C31.5424 8.05511 26.3438 4.83984 20.4129 4.83984H17.3464C17.1595 4.83984 17.007 4.68728 17.007 4.50039V0.926596C17.007 0.739706 17.1595 0.587143 17.3464 0.587143H20.4129C28.9641 0.587143 36.2986 5.86964 39.3346 13.3414C39.3384 13.3567 39.346 13.3681 39.3498 13.3834C40.1622 15.401 38.6328 17.5941 36.4588 17.5941V17.5903Z"
+                />
+                <path
+                  fill="#DEC9F4"
+                  d="M36.4588 24.4097H25.1996C18.0292 24.4097 11.1486 27.2588 6.07964 32.3316L4.83625 33.5749C4.62266 33.7885 4.2527 33.636 4.2527 33.3347V29.0019C4.2527 28.815 4.10013 28.6624 3.91324 28.6624H0.339453C0.152563 28.6624 0 28.815 0 29.0019V41.0734C0 41.2603 0.152563 41.4129 0.339453 41.4129H12.411C12.5979 41.4129 12.7505 41.2603 12.7505 41.0734V37.5034C12.7505 37.3166 12.5979 37.164 12.411 37.164H8.07822C7.77309 37.164 7.62434 36.7978 7.83793 36.5804C12.9107 31.5077 19.7874 28.6586 26.9579 28.6586H34.0559C34.3153 28.6586 34.4869 28.9408 34.3534 29.1659C31.5424 33.9449 26.3438 37.1602 20.4129 37.1602H17.3464C17.1595 37.1602 17.007 37.3127 17.007 37.4996V41.0696C17.007 41.2565 17.1595 41.4091 17.3464 41.4091H20.4129C28.9641 41.4091 36.2986 36.1266 39.3346 28.6548C39.3384 28.6395 39.346 28.6281 39.3498 28.6128C40.1622 26.5952 38.6328 24.4021 36.4588 24.4021V24.4097Z"
+                />
+              </svg>
+            </div>
+            <h3 class="proto-name">DeFindex</h3>
+            <p class="proto-desc">
+              Automated yield vaults built on Stellar smart contracts.
+              Composable, capital-efficient strategies designed to optimize
+              return over time — without manual intervention.
+            </p>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Built in public ── -->
+    <section>
+      <div class="wrap">
+        <div class="public-grid">
+          <div class="public-copy">
+            <p class="label">Open source</p>
+            <h2 class="section-title">
+              Built in public,<br />for the community.
+            </h2>
+            <p class="section-sub">
+              Meridian is fully open-source. Every commit, every design
+              decision, and every issue is public. If you build on Stellar or
+              care about financial access in emerging markets, there is a place
+              for you here.
+            </p>
+          </div>
+          <div class="public-links">
+            <a
+              class="pub-link"
+              href="https://github.com/drydocs/meridian"
+              target="_blank"
+              rel="noopener"
+            >
+              <div class="pub-icon">
+                <svg
+                  width="18"
+                  height="18"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+                    clip-rule="evenodd"
+                  />
+                </svg>
+              </div>
+              <div class="pub-text">
+                <div class="pub-title">drydocs/meridian</div>
+                <div class="pub-sub">View the source on GitHub</div>
+              </div>
+              <span class="pub-chevron">→</span>
+            </a>
+            <a
+              class="pub-link"
+              href="https://github.com/drydocs/meridian/issues"
+              target="_blank"
+              rel="noopener"
+            >
+              <div class="pub-icon">
+                <svg
+                  width="18"
+                  height="18"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <line x1="12" y1="8" x2="12" y2="12" />
+                  <line x1="12" y1="16" x2="12.01" y2="16" />
+                </svg>
+              </div>
+              <div class="pub-text">
+                <div class="pub-title">Open Issues</div>
+                <div class="pub-sub">Pick one up and contribute</div>
+              </div>
+              <span class="pub-chevron">→</span>
+            </a>
+            <a
+              class="pub-link"
+              href="https://github.com/drydocs/meridian/discussions"
+              target="_blank"
+              rel="noopener"
+            >
+              <div class="pub-icon">
+                <svg
+                  width="18"
+                  height="18"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z"
+                  />
+                </svg>
+              </div>
+              <div class="pub-text">
+                <div class="pub-title">Discussions</div>
+                <div class="pub-sub">Roadmap, ideas, and feedback</div>
+              </div>
+              <span class="pub-chevron">→</span>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Footer ── -->
+    <footer>
+      <div class="wrap">
+        <div class="foot-row">
+          <div class="foot-left">
+            <span class="foot-wordmark">Meridian</span>
+            <span>MIT License</span>
+            <span>&copy; 2026</span>
+          </div>
+          <div class="foot-right">
+            <a href="/docs/">Docs</a>
+            <a
+              href="https://github.com/drydocs/meridian"
+              target="_blank"
+              rel="noopener"
+              >GitHub</a
+            >
+            <a
+              href="https://github.com/drydocs/meridian/issues"
+              target="_blank"
+              rel="noopener"
+              >Issues</a
+            >
+            <a href="https://stellar.org" target="_blank" rel="noopener"
+              >Built on Stellar</a
+            >
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      /* Nav blur on scroll */
+      const nav = document.getElementById("nav");
+      window.addEventListener(
+        "scroll",
+        () => {
+          nav.classList.toggle("stuck", window.scrollY > 24);
+        },
+        { passive: true }
+      );
+
+      /* Waitlist form */
+      const form = document.getElementById("waitlist-form");
+      const success = document.getElementById("waitlist-success");
+      const emailEl = document.getElementById("email");
+
+      function submit() {
+        const val = emailEl.value.trim();
+        if (!val || !val.includes("@") || !val.includes(".")) {
+          emailEl.focus();
+          emailEl.style.borderColor = "#f87171";
+          setTimeout(() => {
+            emailEl.style.borderColor = "";
+          }, 1800);
+          return;
+        }
+        form.style.display = "none";
+        success.style.display = "block";
+      }
+
+      document.getElementById("cta-btn").addEventListener("click", submit);
+      emailEl.addEventListener("keydown", (e) => {
+        if (e.key === "Enter") submit();
+      });
+
+      /* Scroll-triggered number counters (33.7% and 6.2% only) */
+      function animateCounter(el) {
+        const target = parseFloat(el.dataset.counter);
+        const suffix = el.dataset.suffix || "";
+        const duration = 1800;
+        const start = performance.now();
+        const decimals = target % 1 !== 0 ? 1 : 0;
+
+        function tick(now) {
+          const elapsed = now - start;
+          const progress = Math.min(elapsed / duration, 1);
+          const ease = 1 - Math.pow(1 - progress, 3);
+          el.textContent = (target * ease).toFixed(decimals) + suffix;
+          if (progress < 1) requestAnimationFrame(tick);
+        }
+
+        requestAnimationFrame(tick);
+      }
+
+      const counters = document.querySelectorAll("[data-counter]");
+      const seen = new Set();
+
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting && !seen.has(entry.target)) {
+              seen.add(entry.target);
+              animateCounter(entry.target);
+            }
+          });
+        },
+        { threshold: 0.3 }
+      );
+
+      counters.forEach((el) => observer.observe(el));
+    </script>
+  </body>
 </html>

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -20,7 +20,10 @@ export default [
       "no-undef": "off",
       ...tsPlugin.configs.recommended.rules,
       ...reactHooks.configs["recommended-latest"].rules,
-      "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+      "react-refresh/only-export-components": [
+        "warn",
+        { allowConstantExport: true },
+      ],
     },
   },
 ];

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1,50 +1,48 @@
 {
-    "header": {
-        "title": "Meridian"
-    },
+  "header": {
+    "title": "Meridian"
+  },
 
-    "walletConnect": {
-        "disconnect": "Disconnect",
-        "copyAddress": "Copy Address",
-        "copied": "Copied",
-        "walletDisconnected": "Wallet Disconnected",
-        "walletConnected": "Wallet Connected"
-    },
+  "walletConnect": {
+    "disconnect": "Disconnect",
+    "copyAddress": "Copy Address",
+    "copied": "Copied",
+    "walletDisconnected": "Wallet Disconnected",
+    "walletConnected": "Wallet Connected"
+  },
 
-    
-    "vaultPanel": {
-        "deposit": "Deposit",
-        "withdraw": "Withdraw",
-        "network": "Network",
-        "apy": "APY",
-        "tvl": "TVL",
-        "route": "Route",
-        "protocol": "Protocol",
-        "noLiveRateData": "No live rate data.",
-        "yourPosition": "Your Position",
-        "earned": "Earned",
-        "connectUSDC": "Connect your Freighter wallet to deposit USDC and start earning yield automatically.",
-        "amount": "Amount",
-        "balance": "Balance",
-        "addAssets": "Add vault assets to wallet",
-        "position": "You have no active position to withdraw from.",
-        "shares": "Shares",
-        "waiting": "Waiting for signature..."
-    },
+  "vaultPanel": {
+    "deposit": "Deposit",
+    "withdraw": "Withdraw",
+    "network": "Network",
+    "apy": "APY",
+    "tvl": "TVL",
+    "route": "Route",
+    "protocol": "Protocol",
+    "noLiveRateData": "No live rate data.",
+    "yourPosition": "Your Position",
+    "earned": "Earned",
+    "connectUSDC": "Connect your Freighter wallet to deposit USDC and start earning yield automatically.",
+    "amount": "Amount",
+    "balance": "Balance",
+    "addAssets": "Add vault assets to wallet",
+    "position": "You have no active position to withdraw from.",
+    "shares": "Shares",
+    "waiting": "Waiting for signature..."
+  },
 
-    "vaultActions": {
-        "failedAssets": "Failed to add vault assets",
-        "depositFailed": "Deposit failed",
-        "assetsAdded": "Vault assets added to wallet",
-        "withdrawalFailed": "Withdrawal failed",
-        "withdrew": "Withdrew",
-        "deposited": "Deposited"
-    },
+  "vaultActions": {
+    "failedAssets": "Failed to add vault assets",
+    "depositFailed": "Deposit failed",
+    "assetsAdded": "Vault assets added to wallet",
+    "withdrawalFailed": "Withdrawal failed",
+    "withdrew": "Withdrew",
+    "deposited": "Deposited"
+  },
 
-    "common": {
-        "connectWallet":"Connect Wallet",
-        "connecting":"Connecting...",
-        "installFreighter": "Install Freighter"
-    }
-
+  "common": {
+    "connectWallet": "Connect Wallet",
+    "connecting": "Connecting...",
+    "installFreighter": "Install Freighter"
+  }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -42,8 +42,7 @@
 
   "common": {
     "connectWallet": "Connecter le portefeuille",
-    "connecting":"Connexion...",
+    "connecting": "Connexion...",
     "installFreighter": "Installer Freighter"
   }
-
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -43,6 +43,5 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "jsdom": "^26.0.0",
     "vitest": "^4.1.9"
-
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -10,7 +10,7 @@ const queryClient = new QueryClient();
 
 function Dashboard() {
   const { t, i18n } = useTranslation();
-  const toggleLanguage = useCallback(() => { 
+  const toggleLanguage = useCallback(() => {
     const newLang = i18n.language === "en" ? "fr" : "en";
     i18n.changeLanguage(newLang);
     localStorage.setItem("language", newLang);
@@ -20,10 +20,12 @@ function Dashboard() {
     <div className="min-h-screen bg-[#0d1117] text-white">
       <header className="sticky top-0 z-50 border-b border-gray-800 bg-[#0d1117]/95 backdrop-blur-sm pb-4">
         <div className="max-w-xl mx-auto px-6 h-20 flex items-end justify-between pb-4">
-          <span className="font-extrabold text-lg tracking-tight text-white">{t("header.title")}</span>
+          <span className="font-extrabold text-lg tracking-tight text-white">
+            {t("header.title")}
+          </span>
           <div className="flex items-center gap-2">
             <WalletConnect />
-            <button 
+            <button
               onClick={toggleLanguage}
               className="text-sm border border-gray-700 rounded-lg px-3 py-1.5 text-gray-300 hover:border-gray-600 hover:text-white transition-colors duration-150"
             >

--- a/apps/web/src/__tests__/hooks/useVaultActions.test.ts
+++ b/apps/web/src/__tests__/hooks/useVaultActions.test.ts
@@ -44,10 +44,15 @@ import { signTransaction } from "../../lib/wallet";
 
 const KEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 // Matches USDC_ISSUER.testnet in @meridian/shared (Blend TestnetV2 issuer).
-const BLEND_TESTNET_USDC_ISSUER = "GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56";
+const BLEND_TESTNET_USDC_ISSUER =
+  "GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56";
 
 beforeEach(() => {
-  useWalletStore.setState({ publicKey: KEY, connected: true, network: "testnet" });
+  useWalletStore.setState({
+    publicKey: KEY,
+    connected: true,
+    network: "testnet",
+  });
   useToastStore.setState({ toasts: [] });
   invalidateQueries.mockClear();
   vi.clearAllMocks();
@@ -55,20 +60,21 @@ beforeEach(() => {
   // testnet faucet path. Tests that need the faucet path override this per-test.
   vi.stubGlobal(
     "fetch",
-    vi.fn(async () =>
-      new Response(
-        JSON.stringify({
-          balances: [
-            {
-              asset_type: "credit_alphanum4",
-              asset_code: "USDC",
-              asset_issuer: BLEND_TESTNET_USDC_ISSUER,
-              balance: "100.0000000",
-            },
-          ],
-        }),
-        { status: 200 }
-      )
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            balances: [
+              {
+                asset_type: "credit_alphanum4",
+                asset_code: "USDC",
+                asset_issuer: BLEND_TESTNET_USDC_ISSUER,
+                balance: "100.0000000",
+              },
+            ],
+          }),
+          { status: 200 }
+        )
     )
   );
 });
@@ -82,31 +88,53 @@ describe("useVaultActions — deposit", () => {
     const { result } = renderHook(() => useVaultActions());
 
     let ok: boolean | undefined;
-    await act(async () => { ok = await result.current.deposit("10", "blend-usdc-fixed", "USDC"); });
+    await act(async () => {
+      ok = await result.current.deposit("10", "blend-usdc-fixed", "USDC");
+    });
 
     expect(ok).toBe(true);
-    expect(api.buildDeposit).toHaveBeenCalledWith({ walletAddress: KEY, vaultId: "blend-usdc-fixed", amount: "10" });
-    expect(signTransaction).toHaveBeenCalledWith("DEPOSIT_XDR", expect.stringContaining("Test SDF"));
+    expect(api.buildDeposit).toHaveBeenCalledWith({
+      walletAddress: KEY,
+      vaultId: "blend-usdc-fixed",
+      amount: "10",
+    });
+    expect(signTransaction).toHaveBeenCalledWith(
+      "DEPOSIT_XDR",
+      expect.stringContaining("Test SDF")
+    );
     expect(api.submitTx).toHaveBeenCalledWith({ xdr: "SIGNED_XDR" });
-    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "success", message: "Deposited 10 USDC" });
+    expect(useToastStore.getState().toasts[0]).toMatchObject({
+      kind: "success",
+      message: "Deposited 10 USDC",
+    });
   });
 
   it("sets needsTrustline when the API signals a missing trustline", async () => {
-    vi.mocked(api.buildDeposit).mockRejectedValueOnce(new Error("USDC trustline missing"));
+    vi.mocked(api.buildDeposit).mockRejectedValueOnce(
+      new Error("USDC trustline missing")
+    );
     const { result } = renderHook(() => useVaultActions());
 
-    await act(async () => { await result.current.deposit("10", "blend-usdc-fixed", "USDC"); });
+    await act(async () => {
+      await result.current.deposit("10", "blend-usdc-fixed", "USDC");
+    });
 
     expect(result.current.needsTrustline).toBe(true);
     expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "error" });
   });
 
   it("returns false without calling the API when no publicKey", async () => {
-    useWalletStore.setState({ publicKey: null, connected: false, network: "testnet" });
+    useWalletStore.setState({
+      publicKey: null,
+      connected: false,
+      network: "testnet",
+    });
     const { result } = renderHook(() => useVaultActions());
 
     let ok: boolean | undefined;
-    await act(async () => { ok = await result.current.deposit("10", "v", "USDC"); });
+    await act(async () => {
+      ok = await result.current.deposit("10", "v", "USDC");
+    });
 
     expect(ok).toBe(false);
     expect(api.buildDeposit).not.toHaveBeenCalled();
@@ -118,20 +146,33 @@ describe("useVaultActions — withdraw", () => {
     const { result } = renderHook(() => useVaultActions());
 
     let ok: boolean | undefined;
-    await act(async () => { ok = await result.current.withdraw("5", "blend-usdc-fixed", "USDC"); });
+    await act(async () => {
+      ok = await result.current.withdraw("5", "blend-usdc-fixed", "USDC");
+    });
 
     expect(ok).toBe(true);
-    expect(api.buildWithdraw).toHaveBeenCalledWith({ walletAddress: KEY, vaultId: "blend-usdc-fixed", shares: "5" });
+    expect(api.buildWithdraw).toHaveBeenCalledWith({
+      walletAddress: KEY,
+      vaultId: "blend-usdc-fixed",
+      shares: "5",
+    });
     expect(signTransaction).toHaveBeenCalled();
-    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "success", message: "Withdrew 5 USDC" });
+    expect(useToastStore.getState().toasts[0]).toMatchObject({
+      kind: "success",
+      message: "Withdrew 5 USDC",
+    });
   });
 
   it("pushes an error toast and returns false when withdraw fails", async () => {
-    vi.mocked(api.buildWithdraw).mockRejectedValueOnce(new Error("Insufficient shares"));
+    vi.mocked(api.buildWithdraw).mockRejectedValueOnce(
+      new Error("Insufficient shares")
+    );
     const { result } = renderHook(() => useVaultActions());
 
     let ok: boolean | undefined;
-    await act(async () => { ok = await result.current.withdraw("5", "blend-usdc-fixed", "USDC"); });
+    await act(async () => {
+      ok = await result.current.withdraw("5", "blend-usdc-fixed", "USDC");
+    });
 
     expect(ok).toBe(false);
     expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "error" });

--- a/apps/web/src/__tests__/hooks/useWalletConnect.test.ts
+++ b/apps/web/src/__tests__/hooks/useWalletConnect.test.ts
@@ -18,7 +18,7 @@ vi.mock("react-i18next", () => {
     "common.connectWallet": "Connect Wallet",
     "common.connecting": "Connecting...",
     "walletConnect.walletDisconnected": "Wallet Disconnected",
-    "walletConnect.walletConnected" : "Wallet Connected",
+    "walletConnect.walletConnected": "Wallet Connected",
   };
 
   return {
@@ -33,7 +33,11 @@ import { isFreighterInstalled, connectFreighter } from "../../lib/wallet";
 const KEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
 beforeEach(() => {
-  useWalletStore.setState({ publicKey: null, connected: false, network: "testnet" });
+  useWalletStore.setState({
+    publicKey: null,
+    connected: false,
+    network: "testnet",
+  });
   useToastStore.setState({ toasts: [] });
   vi.clearAllMocks();
 });
@@ -57,13 +61,20 @@ describe("useWalletConnect", () => {
     await act(() => result.current.handleConnect());
 
     expect(result.current.status).toBe("idle");
-    expect(useWalletStore.getState()).toMatchObject({ publicKey: KEY, connected: true });
-    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "success" });
+    expect(useWalletStore.getState()).toMatchObject({
+      publicKey: KEY,
+      connected: true,
+    });
+    expect(useToastStore.getState().toasts[0]).toMatchObject({
+      kind: "success",
+    });
   });
 
   it("swallows user-cancel errors without a toast", async () => {
     vi.mocked(isFreighterInstalled).mockResolvedValue(true);
-    vi.mocked(connectFreighter).mockRejectedValue(new Error("User declined request"));
+    vi.mocked(connectFreighter).mockRejectedValue(
+      new Error("User declined request")
+    );
     const { result } = renderHook(() => useWalletConnect());
 
     await act(() => result.current.handleConnect());
@@ -80,6 +91,9 @@ describe("useWalletConnect", () => {
     await act(() => result.current.handleConnect());
 
     expect(result.current.status).toBe("idle");
-    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "error", message: "Network error" });
+    expect(useToastStore.getState().toasts[0]).toMatchObject({
+      kind: "error",
+      message: "Network error",
+    });
   });
 });

--- a/apps/web/src/__tests__/i18n.test.ts
+++ b/apps/web/src/__tests__/i18n.test.ts
@@ -21,6 +21,6 @@ describe("i18n", () => {
   Object.entries(locales).forEach(([locale, translations]) => {
     it(`${locale} has the same keys as english`, () => {
       expect(flatten(translations).sort()).toEqual(englishKeys);
-    })
-  })
+    });
+  });
 });

--- a/apps/web/src/__tests__/store/toast.test.ts
+++ b/apps/web/src/__tests__/store/toast.test.ts
@@ -9,7 +9,10 @@ describe("useToastStore", () => {
     useToastStore.getState().push("success", "Wallet connected");
     const { toasts } = useToastStore.getState();
     expect(toasts).toHaveLength(1);
-    expect(toasts[0]).toMatchObject({ kind: "success", message: "Wallet connected" });
+    expect(toasts[0]).toMatchObject({
+      kind: "success",
+      message: "Wallet connected",
+    });
     expect(typeof toasts[0].id).toBe("string");
   });
 

--- a/apps/web/src/__tests__/store/wallet.test.ts
+++ b/apps/web/src/__tests__/store/wallet.test.ts
@@ -10,20 +10,30 @@ import { isFreighterInstalled } from "../../lib/wallet";
 const KEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
 beforeEach(() => {
-  useWalletStore.setState({ publicKey: null, connected: false, network: "testnet" });
+  useWalletStore.setState({
+    publicKey: null,
+    connected: false,
+    network: "testnet",
+  });
   vi.clearAllMocks();
 });
 
 describe("useWalletStore", () => {
   it("connect sets publicKey and marks connected", () => {
     useWalletStore.getState().connect(KEY);
-    expect(useWalletStore.getState()).toMatchObject({ publicKey: KEY, connected: true });
+    expect(useWalletStore.getState()).toMatchObject({
+      publicKey: KEY,
+      connected: true,
+    });
   });
 
   it("disconnect clears publicKey and marks disconnected", () => {
     useWalletStore.setState({ publicKey: KEY, connected: true });
     useWalletStore.getState().disconnect();
-    expect(useWalletStore.getState()).toMatchObject({ publicKey: null, connected: false });
+    expect(useWalletStore.getState()).toMatchObject({
+      publicKey: null,
+      connected: false,
+    });
   });
 
   it("setNetwork updates the active network", () => {
@@ -40,13 +50,19 @@ describe("useWalletStore", () => {
     useWalletStore.setState({ publicKey: KEY, connected: true });
     vi.mocked(isFreighterInstalled).mockResolvedValue(true);
     await useWalletStore.getState().revalidate();
-    expect(useWalletStore.getState()).toMatchObject({ publicKey: KEY, connected: true });
+    expect(useWalletStore.getState()).toMatchObject({
+      publicKey: KEY,
+      connected: true,
+    });
   });
 
   it("revalidate disconnects when Freighter extension is gone", async () => {
     useWalletStore.setState({ publicKey: KEY, connected: true });
     vi.mocked(isFreighterInstalled).mockResolvedValue(false);
     await useWalletStore.getState().revalidate();
-    expect(useWalletStore.getState()).toMatchObject({ publicKey: null, connected: false });
+    expect(useWalletStore.getState()).toMatchObject({
+      publicKey: null,
+      connected: false,
+    });
   });
 });

--- a/apps/web/src/components/dashboard/VaultPanel.tsx
+++ b/apps/web/src/components/dashboard/VaultPanel.tsx
@@ -11,7 +11,6 @@ const PROTOCOL_LABEL: Record<string, string> = {
   defindex: "DeFindex",
 };
 
-
 function formatUsd(value: number, locale: string) {
   return value.toLocaleString(locale === "fr" ? "fr-FR" : "en-US", {
     style: "currency",
@@ -36,13 +35,30 @@ export function VaultPanel() {
   const { connected, publicKey } = useWalletStore();
   const { handleConnect, status: connectStatus } = useWalletConnect();
   const { data: positions = [] } = usePositions(publicKey);
-  const { deposit, withdraw, addTrustline, needsTrustline, isDepositing, isWithdrawing, clearNeedsTrustline } = useVaultActions();
+  const {
+    deposit,
+    withdraw,
+    addTrustline,
+    needsTrustline,
+    isDepositing,
+    isWithdrawing,
+    clearNeedsTrustline,
+  } = useVaultActions();
 
   const [tab, setTab] = useState<Tab>("deposit");
   const [amount, setAmount] = useState("");
 
   function onAmountKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    const allowed = ["Backspace", "Delete", "Tab", "ArrowLeft", "ArrowRight", "Home", "End", "."];
+    const allowed = [
+      "Backspace",
+      "Delete",
+      "Tab",
+      "ArrowLeft",
+      "ArrowRight",
+      "Home",
+      "End",
+      ".",
+    ];
     if (allowed.includes(e.key) || (e.key >= "0" && e.key <= "9")) return;
     e.preventDefault();
   }
@@ -52,7 +68,8 @@ export function VaultPanel() {
   const bestVault = vaults?.find((v) => v.id === data?.recommendedVaultId);
   // Single-vault architecture: the user holds at most one position. Revisit if multi-vault is added.
   const position = positions[0];
-  const hasPosition = position && Number.isFinite(position.deposited) && position.deposited > 0;
+  const hasPosition =
+    position && Number.isFinite(position.deposited) && position.deposited > 0;
 
   async function handleDeposit() {
     if (!amount || !bestVault) return;
@@ -74,17 +91,29 @@ export function VaultPanel() {
 
   return (
     <div className="rounded-2xl border border-gray-800 bg-[#161b22] overflow-hidden shadow-xl shadow-black/40">
-
       {/* Hero — identity + stats */}
       <div className="px-7 pt-7 pb-6">
         {/* Identity row */}
         <div className="flex items-center justify-between mb-8">
           <div className="flex items-center gap-3">
             {/* USDC logo */}
-            <svg className="w-10 h-10 shrink-0" viewBox="0 0 2000 2000" xmlns="http://www.w3.org/2000/svg">
-              <path d="M1000 2000c554.17 0 1000-445.83 1000-1000S1554.17 0 1000 0 0 445.83 0 1000s445.83 1000 1000 1000z" fill="#2775ca"/>
-              <path d="M1275 1158.33c0-145.83-87.5-195.83-262.5-216.66-125-16.67-150-50-150-108.34s41.67-95.83 125-95.83c75 0 116.67 25 137.5 87.5 4.17 12.5 16.67 20.83 29.17 20.83h66.66c16.67 0 29.17-12.5 29.17-29.16v-4.17c-16.67-91.67-91.67-162.5-187.5-170.83v-100c0-16.67-12.5-29.17-33.33-33.34h-62.5c-16.67 0-29.17 12.5-33.34 33.34v95.83c-125 16.67-204.16 100-204.16 204.17 0 137.5 83.33 191.66 258.33 212.5 116.67 20.83 154.17 45.83 154.17 112.5s-58.34 112.5-137.5 112.5c-108.34 0-145.84-45.84-158.34-108.34-4.16-16.66-16.66-25-29.16-25h-70.84c-16.66 0-29.16 12.5-29.16 29.17v4.17c16.66 104.16 83.33 179.16 220.83 200v100c0 16.66 12.5 29.16 33.33 33.33h62.5c16.67 0 29.17-12.5 33.34-33.33v-100c125-20.84 208.33-108.34 208.33-220.84z" fill="#fff"/>
-              <path d="M787.5 1595.83c-325-116.66-491.67-479.16-370.83-800 62.5-175 200-308.33 370.83-370.83 16.67-8.33 25-20.83 25-41.67V325c0-16.67-8.33-29.17-25-33.33-4.17 0-12.5 0-16.67 4.16-395.83 125-612.5 545.84-487.5 941.67 75 233.33 254.17 412.5 487.5 487.5 16.67 8.33 33.34 0 37.5-16.67 4.17-4.16 4.17-8.33 4.17-16.66v-58.34c0-12.5-12.5-29.16-25-37.5zM1229.17 295.83c-16.67-8.33-33.34 0-37.5 16.67-4.17 4.17-4.17 8.33-4.17 16.67v58.33c0 16.67 12.5 33.33 25 41.67 325 116.66 491.67 479.16 370.83 800-62.5 175-200 308.33-370.83 370.83-16.67 8.33-25 20.83-25 41.67V1700c0 16.67 8.33 29.17 25 33.33 4.17 0 12.5 0 16.67-4.16 395.83-125 612.5-545.84 487.5-941.67-75-237.5-258.34-416.67-487.5-491.67z" fill="#fff"/>
+            <svg
+              className="w-10 h-10 shrink-0"
+              viewBox="0 0 2000 2000"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M1000 2000c554.17 0 1000-445.83 1000-1000S1554.17 0 1000 0 0 445.83 0 1000s445.83 1000 1000 1000z"
+                fill="#2775ca"
+              />
+              <path
+                d="M1275 1158.33c0-145.83-87.5-195.83-262.5-216.66-125-16.67-150-50-150-108.34s41.67-95.83 125-95.83c75 0 116.67 25 137.5 87.5 4.17 12.5 16.67 20.83 29.17 20.83h66.66c16.67 0 29.17-12.5 29.17-29.16v-4.17c-16.67-91.67-91.67-162.5-187.5-170.83v-100c0-16.67-12.5-29.17-33.33-33.34h-62.5c-16.67 0-29.17 12.5-33.34 33.34v95.83c-125 16.67-204.16 100-204.16 204.17 0 137.5 83.33 191.66 258.33 212.5 116.67 20.83 154.17 45.83 154.17 112.5s-58.34 112.5-137.5 112.5c-108.34 0-145.84-45.84-158.34-108.34-4.16-16.66-16.66-25-29.16-25h-70.84c-16.66 0-29.16 12.5-29.16 29.17v4.17c16.66 104.16 83.33 179.16 220.83 200v100c0 16.66 12.5 29.16 33.33 33.33h62.5c16.67 0 29.17-12.5 33.34-33.33v-100c125-20.84 208.33-108.34 208.33-220.84z"
+                fill="#fff"
+              />
+              <path
+                d="M787.5 1595.83c-325-116.66-491.67-479.16-370.83-800 62.5-175 200-308.33 370.83-370.83 16.67-8.33 25-20.83 25-41.67V325c0-16.67-8.33-29.17-25-33.33-4.17 0-12.5 0-16.67 4.16-395.83 125-612.5 545.84-487.5 941.67 75 233.33 254.17 412.5 487.5 487.5 16.67 8.33 33.34 0 37.5-16.67 4.17-4.16 4.17-8.33 4.17-16.66v-58.34c0-12.5-12.5-29.16-25-37.5zM1229.17 295.83c-16.67-8.33-33.34 0-37.5 16.67-4.17 4.17-4.17 8.33-4.17 16.67v58.33c0 16.67 12.5 33.33 25 41.67 325 116.66 491.67 479.16 370.83 800-62.5 175-200 308.33-370.83 370.83-16.67 8.33-25 20.83-25 41.67V1700c0 16.67 8.33 29.17 25 33.33 4.17 0 12.5 0 16.67-4.16 395.83-125 612.5-545.84 487.5-941.67-75-237.5-258.34-416.67-487.5-491.67z"
+                fill="#fff"
+              />
             </svg>
             <div>
               <p className="text-xs text-gray-500">Meridian</p>
@@ -92,7 +121,9 @@ export function VaultPanel() {
             </div>
           </div>
           <div className="text-right">
-            <p className="text-xs text-gray-500 mb-0.5">{t("vaultPanel.network")}</p>
+            <p className="text-xs text-gray-500 mb-0.5">
+              {t("vaultPanel.network")}
+            </p>
             <p className="text-xs font-semibold text-gray-300">Stellar</p>
           </div>
         </div>
@@ -110,7 +141,9 @@ export function VaultPanel() {
         ) : bestVault ? (
           <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <p className="text-xs text-gray-500 mb-1.5">{t("vaultPanel.apy")}</p>
+              <p className="text-xs text-gray-500 mb-1.5">
+                {t("vaultPanel.apy")}
+              </p>
               <div className="flex items-baseline gap-0.5">
                 <span className="text-5xl font-black text-emerald-400 tabular-nums tracking-tight">
                   {bestVault.apy.toFixed(2)}
@@ -119,18 +152,26 @@ export function VaultPanel() {
               </div>
             </div>
             <div className="pb-1 sm:text-center">
-              <p className="text-xs text-gray-500 mb-1.5">{t("vaultPanel.tvl")}</p>
-              <p className="text-lg font-bold text-white">{formatTvl(bestVault.tvl)}</p>
+              <p className="text-xs text-gray-500 mb-1.5">
+                {t("vaultPanel.tvl")}
+              </p>
+              <p className="text-lg font-bold text-white">
+                {formatTvl(bestVault.tvl)}
+              </p>
             </div>
             <div className="pb-1 sm:text-right">
-              <p className="text-xs text-gray-500 mb-1.5">{t("vaultPanel.route")}</p>
+              <p className="text-xs text-gray-500 mb-1.5">
+                {t("vaultPanel.route")}
+              </p>
               <p className="text-lg font-bold text-white">
                 {PROTOCOL_LABEL[bestVault.protocol] ?? bestVault.protocol}
               </p>
             </div>
           </div>
         ) : (
-          <p className="text-sm text-gray-500">{t("vaultPanel.noLiveRateData")}</p>
+          <p className="text-sm text-gray-500">
+            {t("vaultPanel.noLiveRateData")}
+          </p>
         )}
       </div>
 
@@ -138,12 +179,20 @@ export function VaultPanel() {
       {connected && hasPosition && (
         <div className="mx-7 my-5 rounded-xl border border-gray-800 bg-gray-900/50 px-4 py-3.5 flex items-center justify-between">
           <div>
-            <p className="text-xs text-gray-500 mb-1">{t("vaultPanel.yourPosition")}</p>
-            <p className="text-base font-bold text-white">{formatUsd(position.deposited, i18n.language)}</p>
+            <p className="text-xs text-gray-500 mb-1">
+              {t("vaultPanel.yourPosition")}
+            </p>
+            <p className="text-base font-bold text-white">
+              {formatUsd(position.deposited, i18n.language)}
+            </p>
           </div>
           <div className="text-right">
-            <p className="text-xs text-gray-500 mb-1">{t("vaultPanel.earned")}</p>
-            <p className="text-base font-bold text-emerald-400">+{formatUsd(position.earned, i18n.language)}</p>
+            <p className="text-xs text-gray-500 mb-1">
+              {t("vaultPanel.earned")}
+            </p>
+            <p className="text-base font-bold text-emerald-400">
+              +{formatUsd(position.earned, i18n.language)}
+            </p>
           </div>
         </div>
       )}
@@ -189,7 +238,9 @@ export function VaultPanel() {
                 disabled={connectStatus === "connecting"}
                 className="w-full rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:bg-gray-800 disabled:text-gray-600 text-white text-sm font-semibold py-3 transition-all duration-150 disabled:cursor-not-allowed"
               >
-                {connectStatus === "connecting" ? t("common.connecting") : t("common.connectWallet")}
+                {connectStatus === "connecting"
+                  ? t("common.connecting")
+                  : t("common.connectWallet")}
               </button>
             )}
           </div>
@@ -197,10 +248,13 @@ export function VaultPanel() {
           <div className="space-y-4">
             <div>
               <div className="flex items-center justify-between mb-2">
-                <span className="text-xs font-medium text-gray-500">{t("vaultPanel.amount")}</span>
+                <span className="text-xs font-medium text-gray-500">
+                  {t("vaultPanel.amount")}
+                </span>
                 {hasPosition && (
                   <span className="text-xs text-gray-600">
-                    {t("vaultPanel.balance")}: {formatUsd(position.deposited, i18n.language)}
+                    {t("vaultPanel.balance")}:{" "}
+                    {formatUsd(position.deposited, i18n.language)}
                   </span>
                 )}
               </div>
@@ -211,7 +265,9 @@ export function VaultPanel() {
                   step="any"
                   placeholder="0.00"
                   value={amount}
-                  onChange={(e) => setAmount((e.target as HTMLInputElement).value)}
+                  onChange={(e) =>
+                    setAmount((e.target as HTMLInputElement).value)
+                  }
                   onKeyDown={onAmountKeyDown}
                   className="flex-1 min-w-0 bg-transparent text-white text-xl font-semibold outline-none placeholder:text-gray-700 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
@@ -239,12 +295,16 @@ export function VaultPanel() {
         ) : (
           <div className="space-y-4">
             {!hasPosition ? (
-              <p className="text-sm text-gray-500 py-2">{t("vaultPanel.position")}</p>
+              <p className="text-sm text-gray-500 py-2">
+                {t("vaultPanel.position")}
+              </p>
             ) : (
               <>
                 <div>
                   <div className="flex items-center justify-between mb-2">
-                    <span className="text-xs font-medium text-gray-500">{t("vaultPanel.amount")}</span>
+                    <span className="text-xs font-medium text-gray-500">
+                      {t("vaultPanel.amount")}
+                    </span>
                     <button
                       onClick={() => setAmount(position.shares.toFixed(7))}
                       className="text-xs text-emerald-500 hover:text-emerald-400 transition-colors duration-150"
@@ -259,7 +319,9 @@ export function VaultPanel() {
                       step="any"
                       placeholder="0.00"
                       value={amount}
-                      onChange={(e) => setAmount((e.target as HTMLInputElement).value)}
+                      onChange={(e) =>
+                        setAmount((e.target as HTMLInputElement).value)
+                      }
                       onKeyDown={onAmountKeyDown}
                       className="flex-1 min-w-0 bg-transparent text-white text-xl font-semibold outline-none placeholder:text-gray-700 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                     />
@@ -273,7 +335,9 @@ export function VaultPanel() {
                   disabled={!amount || !bestVault || isWithdrawing}
                   className="w-full rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:bg-gray-800 disabled:text-gray-600 text-white text-sm font-semibold py-3.5 transition-all duration-150 disabled:cursor-not-allowed"
                 >
-                  {isWithdrawing ? t("vaultPanel.waiting") : t("vaultPanel.withdraw")}
+                  {isWithdrawing
+                    ? t("vaultPanel.waiting")
+                    : t("vaultPanel.withdraw")}
                 </button>
               </>
             )}

--- a/apps/web/src/components/onboarding/WalletConnect.tsx
+++ b/apps/web/src/components/onboarding/WalletConnect.tsx
@@ -23,7 +23,7 @@ export function WalletConnect() {
       push("error", "Failed to copy address");
     }
   };
-  
+
   function handleDisconnect() {
     disconnect();
     push("info", t("walletConnect.walletDisconnected"));
@@ -36,8 +36,12 @@ export function WalletConnect() {
         <span>{shortenAddress(publicKey)}</span>
         <button
           onClick={handleCopy}
-          title={copied ? t("walletConnect.copied") : t("walletConnect.copyAddress")}
-          aria-label={copied ? t("walletConnect.copied") : t("walletConnect.copyAddress")}
+          title={
+            copied ? t("walletConnect.copied") : t("walletConnect.copyAddress")
+          }
+          aria-label={
+            copied ? t("walletConnect.copied") : t("walletConnect.copyAddress")
+          }
           className="text-gray-400 hover:text-white transition-colors duration-150"
         >
           {copied ? <Check size={14} /> : <Copy size={14} />}
@@ -73,7 +77,9 @@ export function WalletConnect() {
       disabled={status === "connecting"}
       className="text-sm border border-gray-700 rounded-lg px-4 py-2 font-medium text-gray-300 hover:border-gray-600 hover:text-white transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed"
     >
-      {status === "connecting" ? t("common.connecting") : t("common.connectWallet")}
+      {status === "connecting"
+        ? t("common.connecting")
+        : t("common.connectWallet")}
     </button>
   );
 }

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -7,26 +7,39 @@ import { api } from "../lib/api";
 import { useToastStore } from "../store/toast";
 import { useTranslation } from "react-i18next";
 
-const BLEND_FAUCET_URL = "https://ewqw4hx7oa.execute-api.us-east-1.amazonaws.com/getAssets";
+const BLEND_FAUCET_URL =
+  "https://ewqw4hx7oa.execute-api.us-east-1.amazonaws.com/getAssets";
 
 function isMissingTrustline(msg: string) {
   return msg.toLowerCase().includes("trustline");
 }
 
-async function hasBlendUsdcBalance(publicKey: string, network: string): Promise<boolean> {
-  const horizonUrl = network === "mainnet"
-    ? "https://horizon.stellar.org"
-    : "https://horizon-testnet.stellar.org";
+async function hasBlendUsdcBalance(
+  publicKey: string,
+  network: string
+): Promise<boolean> {
+  const horizonUrl =
+    network === "mainnet"
+      ? "https://horizon.stellar.org"
+      : "https://horizon-testnet.stellar.org";
   const issuer = USDC_ISSUER[network];
   if (!issuer) return true;
   try {
     const res = await fetch(`${horizonUrl}/accounts/${publicKey}`);
     if (!res.ok) return true;
-    const account = await res.json() as {
-      balances: { asset_type: string; asset_code?: string; asset_issuer?: string; balance: string }[];
+    const account = (await res.json()) as {
+      balances: {
+        asset_type: string;
+        asset_code?: string;
+        asset_issuer?: string;
+        balance: string;
+      }[];
     };
     return account.balances.some(
-      (b) => b.asset_code === "USDC" && b.asset_issuer === issuer && parseFloat(b.balance) > 0
+      (b) =>
+        b.asset_code === "USDC" &&
+        b.asset_issuer === issuer &&
+        parseFloat(b.balance) > 0
     );
   } catch {
     return true;
@@ -42,7 +55,8 @@ export function useVaultActions() {
   const [isWithdrawing, setIsWithdrawing] = useState(false);
   const [needsTrustline, setNeedsTrustline] = useState(false);
 
-  const passphrase = STELLAR_NETWORKS[network as keyof typeof STELLAR_NETWORKS]?.passphrase;
+  const passphrase =
+    STELLAR_NETWORKS[network as keyof typeof STELLAR_NETWORKS]?.passphrase;
 
   async function signAndSubmit(xdr: string) {
     const signedXdr = await signTransaction(xdr, passphrase);
@@ -58,7 +72,10 @@ export function useVaultActions() {
       push("success", t("vaultActions.assetsAdded"));
       return true;
     } catch (err) {
-      push("error", err instanceof Error ? err.message : t("vaultActions.failedAssets"));
+      push(
+        "error",
+        err instanceof Error ? err.message : t("vaultActions.failedAssets")
+      );
       return false;
     }
   }
@@ -76,12 +93,19 @@ export function useVaultActions() {
       push("success", "Testnet wallet funded");
       return true;
     } catch (err) {
-      push("error", err instanceof Error ? err.message : "Failed to fund testnet wallet");
+      push(
+        "error",
+        err instanceof Error ? err.message : "Failed to fund testnet wallet"
+      );
       return false;
     }
   }
 
-  async function deposit(amount: string, vaultId: string, asset: string): Promise<boolean> {
+  async function deposit(
+    amount: string,
+    vaultId: string,
+    asset: string
+  ): Promise<boolean> {
     if (!publicKey || !passphrase) return false;
     setIsDepositing(true);
     try {
@@ -95,14 +119,19 @@ export function useVaultActions() {
         }
       }
 
-      const { xdr } = await api.buildDeposit({ walletAddress: publicKey, vaultId, amount });
+      const { xdr } = await api.buildDeposit({
+        walletAddress: publicKey,
+        vaultId,
+        amount,
+      });
       await signAndSubmit(xdr);
       setNeedsTrustline(false);
       queryClient.invalidateQueries({ queryKey: ["positions", publicKey] });
       push("success", `${t("vaultActions.deposited")} ${amount} ${asset}`);
       return true;
     } catch (err) {
-      const msg = err instanceof Error ? err.message : t("vaultActions.depositFailed");
+      const msg =
+        err instanceof Error ? err.message : t("vaultActions.depositFailed");
       if (isMissingTrustline(msg)) {
         setNeedsTrustline(true);
       }
@@ -113,17 +142,28 @@ export function useVaultActions() {
     }
   }
 
-  async function withdraw(shares: string, vaultId: string, asset: string): Promise<boolean> {
+  async function withdraw(
+    shares: string,
+    vaultId: string,
+    asset: string
+  ): Promise<boolean> {
     if (!publicKey || !passphrase) return false;
     setIsWithdrawing(true);
     try {
-      const { xdr } = await api.buildWithdraw({ walletAddress: publicKey, vaultId, shares });
+      const { xdr } = await api.buildWithdraw({
+        walletAddress: publicKey,
+        vaultId,
+        shares,
+      });
       await signAndSubmit(xdr);
       queryClient.invalidateQueries({ queryKey: ["positions", publicKey] });
       push("success", `${t("vaultActions.withdrew")} ${shares} ${asset}`);
       return true;
     } catch (err) {
-      push("error", err instanceof Error ? err.message : t("vaultActions.withdrawalFailed"));
+      push(
+        "error",
+        err instanceof Error ? err.message : t("vaultActions.withdrawalFailed")
+      );
       return false;
     } finally {
       setIsWithdrawing(false);

--- a/apps/web/src/hooks/useVaults.ts
+++ b/apps/web/src/hooks/useVaults.ts
@@ -13,7 +13,10 @@ export function useVaults() {
     queryKey: ["vaults"],
     queryFn: async () => {
       const data = await api.getVaults();
-      return { vaults: data.vaults, recommendedVaultId: data.recommendedVaultId };
+      return {
+        vaults: data.vaults,
+        recommendedVaultId: data.recommendedVaultId,
+      };
     },
     staleTime: 5 * 60_000,
     retry: 1,

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -4,24 +4,25 @@ import { initReactI18next } from "react-i18next";
 import en from "../messages/en.json";
 import fr from "../messages/fr.json";
 
-function getBrowserLanguage(){
-    return(
-        localStorage.getItem("language")?? (navigator.language.startsWith("fr") ? "fr" : "en")
-    );
+function getBrowserLanguage() {
+  return (
+    localStorage.getItem("language") ??
+    (navigator.language.startsWith("fr") ? "fr" : "en")
+  );
 }
 
 export function initialiseI18n() {
-    return i18n.use(initReactI18next).init({
-        resources: {
-            en: { translation: en },
-            fr: { translation: fr },
-        },
-        fallbackLng: "en",
-        lng: getBrowserLanguage(),
-        interpolation: {
-            escapeValue: false,
-        },
-    });
+  return i18n.use(initReactI18next).init({
+    resources: {
+      en: { translation: en },
+      fr: { translation: fr },
+    },
+    fallbackLng: "en",
+    lng: getBrowserLanguage(),
+    interpolation: {
+      escapeValue: false,
+    },
+  });
 }
 
 export default i18n;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -33,7 +33,6 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-
 export const api = {
   getVaults: () =>
     apiFetch<{
@@ -43,20 +42,26 @@ export const api = {
       cached: boolean;
     }>("/api/v1/vaults"),
   getPositions: (publicKey: string) =>
-    apiFetch<{ positions: ApiPosition[] }>(
-      `/api/v1/positions/${publicKey}`
-    ),
+    apiFetch<{ positions: ApiPosition[] }>(`/api/v1/positions/${publicKey}`),
   addTrustline: (walletAddress: string) =>
     apiFetch<{ xdr: string }>("/api/v1/tx/add-trustline", {
       method: "POST",
       body: JSON.stringify({ walletAddress }),
     }),
-  buildDeposit: (body: { walletAddress: string; vaultId: string; amount: string }) =>
+  buildDeposit: (body: {
+    walletAddress: string;
+    vaultId: string;
+    amount: string;
+  }) =>
     apiFetch<{ xdr: string; fee: string }>("/api/v1/tx/deposit", {
       method: "POST",
       body: JSON.stringify(body),
     }),
-  buildWithdraw: (body: { walletAddress: string; vaultId: string; shares: string }) =>
+  buildWithdraw: (body: {
+    walletAddress: string;
+    vaultId: string;
+    shares: string;
+  }) =>
     apiFetch<{ xdr: string; fee: string }>("/api/v1/tx/withdraw", {
       method: "POST",
       body: JSON.stringify(body),

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -5,13 +5,13 @@ import "./styles/globals.css";
 import { initialiseI18n } from "./i18n";
 
 void initialiseI18n()
-.catch(() => {
-  console.error("Failed to initialise i18n");
-})
-.then(() => {
-  ReactDOM.createRoot(document.getElementById("root")!).render(
-    <React.StrictMode>
-      <App />
-    </React.StrictMode>
-  );
-});
+  .catch(() => {
+    console.error("Failed to initialise i18n");
+  })
+  .then(() => {
+    ReactDOM.createRoot(document.getElementById("root")!).render(
+      <React.StrictMode>
+        <App />
+      </React.StrictMode>
+    );
+  });

--- a/apps/web/src/store/toast.ts
+++ b/apps/web/src/store/toast.ts
@@ -19,7 +19,11 @@ export const useToastStore = create<ToastStore>((set) => ({
   push: (kind, message) => {
     const id = `${Date.now()}-${Math.random()}`;
     set((s) => ({ toasts: [...s.toasts, { id, kind, message }] }));
-    setTimeout(() => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })), 4000);
+    setTimeout(
+      () => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+      4000
+    );
   },
-  dismiss: (id) => set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
+  dismiss: (id) =>
+    set((s) => ({ toasts: s.toasts.filter((t) => t.id !== id) })),
 }));

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -15,7 +15,9 @@
     "noEmit": true,
     "paths": {
       "@meridian/shared": ["../../packages/shared/src"],
-      "@meridian/stellar-sdk-helpers": ["../../packages/stellar-sdk-helpers/src"]
+      "@meridian/stellar-sdk-helpers": [
+        "../../packages/stellar-sdk-helpers/src"
+      ]
     }
   },
   "include": ["src", "vite.config.ts"]

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,26 @@
+/** @type {import('@commitlint/types').UserConfig} */
+export default {
+  rules: {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "feat",
+        "fix",
+        "docs",
+        "chore",
+        "refactor",
+        "test",
+        "style",
+        "ci",
+        "perf",
+      ],
+    ],
+    "type-case": [2, "always", "lower-case"],
+    "type-empty": [2, "never"],
+    "scope-case": [2, "always", "lower-case"],
+    "subject-empty": [2, "never"],
+    "subject-full-stop": [2, "never", "."],
+    "header-max-length": [2, "always", 72],
+  },
+};

--- a/docs/signing-flow.md
+++ b/docs/signing-flow.md
@@ -1,7 +1,7 @@
 # Transaction signing flow
 
 Meridian's core security property is simple: **the API never holds or sees a private key.**
-It builds an *unsigned* Soroban transaction, returns it as a base64 XDR string, and the
+It builds an _unsigned_ Soroban transaction, returns it as a base64 XDR string, and the
 browser hands that XDR to the user's wallet (Freighter) for signing. The signed XDR is then
 relayed back through the API only to be forwarded to the Stellar network — the API still
 never signs anything itself.
@@ -45,7 +45,7 @@ sequenceDiagram
 - **The wallet is the trust boundary.** Freighter shows the user the operations and asset
   amounts before they approve. Signing happens inside the extension; the decrypted key never
   enters the page or the network.
-- **The `/submit` endpoint only relays.** It accepts an *already-signed* XDR and forwards it to
+- **The `/submit` endpoint only relays.** It accepts an _already-signed_ XDR and forwards it to
   Soroban RPC via `sendTransaction`. It does not (and cannot) add signatures. Submitting could
   also be done straight from the browser to RPC; routing it through the API just centralises
   endpoint configuration and error handling.

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "meridian",
   "version": "0.1.0",
   "private": true,
-"scripts": {
+  "scripts": {
     "dev": "turbo run dev",
     "build": "turbo run build",
     "test": "turbo run test",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
-    "typecheck:api": "tsc --noEmit -p api/tsconfig.json"
+    "typecheck:api": "tsc --noEmit -p api/tsconfig.json",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.0.0"

--- a/packages/shared/src/schemas.ts
+++ b/packages/shared/src/schemas.ts
@@ -33,6 +33,14 @@ export type TrustlineRequest = z.infer<typeof TrustlineRequestSchema>;
 export type SubmitRequest = z.infer<typeof SubmitRequestSchema>;
 
 export function formatZodError(err: z.ZodError): string {
-  const fields = err.flatten().fieldErrors as Record<string, string[] | undefined>;
-  return Object.entries(fields).filter(([, v]) => v && v.length > 0).map(([k, v]) => `${k}: ${v!.join(", ")}`).join("; ") || "Invalid request";
+  const fields = err.flatten().fieldErrors as Record<
+    string,
+    string[] | undefined
+  >;
+  return (
+    Object.entries(fields)
+      .filter(([, v]) => v && v.length > 0)
+      .map(([k, v]) => `${k}: ${v!.join(", ")}`)
+      .join("; ") || "Invalid request"
+  );
 }

--- a/packages/shared/src/utils.test.ts
+++ b/packages/shared/src/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { withRetry, withRaceTimeout, sanitizeTxError, fromStroops, formatUsdAmount, parseUsdAmount } from "./utils";
+import {
+  withRetry,
+  withRaceTimeout,
+  sanitizeTxError,
+  fromStroops,
+  formatUsdAmount,
+  parseUsdAmount,
+} from "./utils";
 
 describe("sanitizeTxError", () => {
   it("returns the fallback for non-Error values", () => {
@@ -10,17 +17,25 @@ describe("sanitizeTxError", () => {
   });
 
   it("returns the first line of a clean multi-line error message", () => {
-    const err = new Error("Transaction simulation failed\n  at contract: ...\n  context: ...");
-    expect(sanitizeTxError(err, "fallback")).toBe("Transaction simulation failed");
+    const err = new Error(
+      "Transaction simulation failed\n  at contract: ...\n  context: ..."
+    );
+    expect(sanitizeTxError(err, "fallback")).toBe(
+      "Transaction simulation failed"
+    );
   });
 
   it("returns the fallback when the first line contains an RPC URL", () => {
-    const err = new Error("fetch failed: https://soroban-testnet.stellar.org\nmore detail");
+    const err = new Error(
+      "fetch failed: https://soroban-testnet.stellar.org\nmore detail"
+    );
     expect(sanitizeTxError(err, "fallback")).toBe("fallback");
   });
 
   it("returns the fallback when the first line contains a contract C-address", () => {
-    const err = new Error("CCQNJ4SJM5NKRBJK3G4YATDUZPTLWVKWKJTPBFHIFVQMQJDQVLSEHWA: not found");
+    const err = new Error(
+      "CCQNJ4SJM5NKRBJK3G4YATDUZPTLWVKWKJTPBFHIFVQMQJDQVLSEHWA: not found"
+    );
     expect(sanitizeTxError(err, "fallback")).toBe("fallback");
   });
 
@@ -31,7 +46,9 @@ describe("sanitizeTxError", () => {
 
   it("passes through safe user-facing error messages unchanged", () => {
     const err = new Error("All required trustlines already exist");
-    expect(sanitizeTxError(err, "fallback")).toBe("All required trustlines already exist");
+    expect(sanitizeTxError(err, "fallback")).toBe(
+      "All required trustlines already exist"
+    );
   });
 });
 
@@ -96,7 +113,12 @@ describe("withRetry", () => {
       .mockRejectedValueOnce(new Error("transient"))
       .mockRejectedValueOnce(new TimeoutError("deadline"))
       .mockResolvedValue("ok");
-    const promise = withRetry(fn, 3, 0, (err) => !(err instanceof TimeoutError));
+    const promise = withRetry(
+      fn,
+      3,
+      0,
+      (err) => !(err instanceof TimeoutError)
+    );
     const assertion = expect(promise).rejects.toBeInstanceOf(TimeoutError);
     await vi.runAllTimersAsync();
     await assertion;
@@ -117,7 +139,9 @@ describe("withRaceTimeout", () => {
   it("rejects with a timeout error when fn does not complete in time", async () => {
     const fn = vi.fn().mockImplementation(() => new Promise(() => {}));
     const promise = withRaceTimeout(fn, 500, "test op");
-    const assertion = expect(promise).rejects.toThrow("test op timed out after 500ms");
+    const assertion = expect(promise).rejects.toThrow(
+      "test op timed out after 500ms"
+    );
     await vi.runAllTimersAsync();
     await assertion;
   });

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -27,12 +27,25 @@ export function isValidStellarAddress(key: string): boolean {
  * Races `fn` against a timeout. Clears the timer if `fn` resolves first so no
  * handle lingers in the event loop after a successful call.
  */
-export function withRaceTimeout<T>(fn: () => Promise<T>, ms: number, label: string): Promise<T> {
+export function withRaceTimeout<T>(
+  fn: () => Promise<T>,
+  ms: number,
+  label: string
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
-    const handle = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    const handle = setTimeout(
+      () => reject(new Error(`${label} timed out after ${ms}ms`)),
+      ms
+    );
     fn().then(
-      (val) => { clearTimeout(handle); resolve(val); },
-      (err) => { clearTimeout(handle); reject(err); }
+      (val) => {
+        clearTimeout(handle);
+        resolve(val);
+      },
+      (err) => {
+        clearTimeout(handle);
+        reject(err);
+      }
     );
   });
 }
@@ -58,7 +71,9 @@ export async function withRetry<T>(
     } catch (err) {
       lastErr = err;
       if (attempt < maxAttempts - 1 && shouldRetry(err)) {
-        await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** attempt));
+        await new Promise((resolve) =>
+          setTimeout(resolve, baseDelayMs * 2 ** attempt)
+        );
       } else {
         break;
       }
@@ -93,7 +108,8 @@ const USD_FORMATTER = new Intl.NumberFormat("en-US", {
 });
 
 export function formatUsdAmount(amount: number): string {
-  if (!Number.isFinite(amount)) throw new RangeError(`formatUsdAmount: invalid amount: ${amount}`);
+  if (!Number.isFinite(amount))
+    throw new RangeError(`formatUsdAmount: invalid amount: ${amount}`);
   return USD_FORMATTER.format(amount);
 }
 

--- a/packages/stellar-sdk-helpers/src/blend.test.ts
+++ b/packages/stellar-sdk-helpers/src/blend.test.ts
@@ -4,7 +4,8 @@ import type { StellarNetwork } from "./types";
 
 // Mock the Blend SDK so fetchBlendPositions never touches the network.
 vi.mock("@blend-capital/blend-sdk", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@blend-capital/blend-sdk")>();
+  const actual =
+    await importOriginal<typeof import("@blend-capital/blend-sdk")>();
   return {
     ...actual,
     PoolV2: {
@@ -22,7 +23,7 @@ const network: StellarNetwork = {
 };
 
 const POOL_ID = "CPOOL0000000000000000000000000000000000000000000000000000";
-const PUBKEY  = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+const PUBKEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 const USDC_ID = "CUSDC0000000000000000000000000000000000000000000000000000";
 const EURC_ID = "CEURC0000000000000000000000000000000000000000000000000000";
 
@@ -39,11 +40,13 @@ function makePool(
     reserves: reserveMap,
     loadUser: vi.fn(async (_publicKey: string) => ({
       getCollateralFloat: (reserve: object) => {
-        const id = [...reserveMap.entries()].find(([, r]) => r === reserve)?.[0] ?? "";
+        const id =
+          [...reserveMap.entries()].find(([, r]) => r === reserve)?.[0] ?? "";
         return userBalances[id]?.collateral ?? 0;
       },
       getSupplyFloat: (reserve: object) => {
-        const id = [...reserveMap.entries()].find(([, r]) => r === reserve)?.[0] ?? "";
+        const id =
+          [...reserveMap.entries()].find(([, r]) => r === reserve)?.[0] ?? "";
         return userBalances[id]?.supply ?? 0;
       },
     })),
@@ -65,7 +68,9 @@ describe("blendAssetForVault", () => {
   });
 
   it("throws for a vault id with no mapped reserve asset", () => {
-    expect(() => blendAssetForVault("blend-xlm-fixed")).toThrow(/no blend reserve asset/i);
+    expect(() => blendAssetForVault("blend-xlm-fixed")).toThrow(
+      /no blend reserve asset/i
+    );
   });
 });
 
@@ -78,7 +83,12 @@ describe("fetchBlendPositions", () => {
     const pool = makePool(reserveMap, {});
     vi.mocked(PoolV2.load).mockResolvedValue(pool as never);
 
-    const result = await fetchBlendPositions(network, POOL_ID, PUBKEY, reserves);
+    const result = await fetchBlendPositions(
+      network,
+      POOL_ID,
+      PUBKEY,
+      reserves
+    );
     expect(result).toEqual([]);
     expect(pool.loadUser).toHaveBeenCalledWith(PUBKEY);
   });
@@ -94,10 +104,27 @@ describe("fetchBlendPositions", () => {
     });
     vi.mocked(PoolV2.load).mockResolvedValue(pool as never);
 
-    const result = await fetchBlendPositions(network, POOL_ID, PUBKEY, reserves);
+    const result = await fetchBlendPositions(
+      network,
+      POOL_ID,
+      PUBKEY,
+      reserves
+    );
     expect(result).toHaveLength(2);
-    expect(result[0]).toMatchObject({ vaultId: "blend-usdc-fixed", shares: 50, deposited: 50, earned: 0, entryTime: 0 });
-    expect(result[1]).toMatchObject({ vaultId: "blend-eurc-fixed", shares: 20, deposited: 20, earned: 0, entryTime: 0 });
+    expect(result[0]).toMatchObject({
+      vaultId: "blend-usdc-fixed",
+      shares: 50,
+      deposited: 50,
+      earned: 0,
+      entryTime: 0,
+    });
+    expect(result[1]).toMatchObject({
+      vaultId: "blend-eurc-fixed",
+      shares: 20,
+      deposited: 20,
+      earned: 0,
+      entryTime: 0,
+    });
   });
 
   it("sets shares to collateral-only and deposited to collateral + plain supply", async () => {
@@ -107,7 +134,9 @@ describe("fetchBlendPositions", () => {
     });
     vi.mocked(PoolV2.load).mockResolvedValue(pool as never);
 
-    const [pos] = await fetchBlendPositions(network, POOL_ID, PUBKEY, [reserves[0]]);
+    const [pos] = await fetchBlendPositions(network, POOL_ID, PUBKEY, [
+      reserves[0],
+    ]);
     expect(pos.shares).toBe(30);
     expect(pos.deposited).toBe(40);
   });
@@ -120,7 +149,12 @@ describe("fetchBlendPositions", () => {
     vi.mocked(PoolV2.load).mockResolvedValue(pool as never);
 
     // Both USDC and EURC passed, but only USDC is in the pool's reserve map.
-    const result = await fetchBlendPositions(network, POOL_ID, PUBKEY, reserves);
+    const result = await fetchBlendPositions(
+      network,
+      POOL_ID,
+      PUBKEY,
+      reserves
+    );
     expect(result).toHaveLength(1);
     expect(result[0].vaultId).toBe("blend-usdc-fixed");
   });
@@ -132,7 +166,9 @@ describe("fetchBlendPositions", () => {
     });
     vi.mocked(PoolV2.load).mockResolvedValue(pool as never);
 
-    const result = await fetchBlendPositions(network, POOL_ID, PUBKEY, [reserves[0]]);
+    const result = await fetchBlendPositions(network, POOL_ID, PUBKEY, [
+      reserves[0],
+    ]);
     expect(result).toEqual([]);
   });
 });

--- a/packages/stellar-sdk-helpers/src/blend.ts
+++ b/packages/stellar-sdk-helpers/src/blend.ts
@@ -67,7 +67,12 @@ export function buildBlendDepositTx(
   depositor: string,
   amount: bigint
 ): Promise<{ xdr: string; fee: string }> {
-  return buildPoolRequestTx(config, depositor, RequestType.SupplyCollateral, amount);
+  return buildPoolRequestTx(
+    config,
+    depositor,
+    RequestType.SupplyCollateral,
+    amount
+  );
 }
 
 /**
@@ -80,7 +85,12 @@ export function buildBlendWithdrawTx(
   withdrawer: string,
   amount: bigint
 ): Promise<{ xdr: string; fee: string }> {
-  return buildPoolRequestTx(config, withdrawer, RequestType.WithdrawCollateral, amount);
+  return buildPoolRequestTx(
+    config,
+    withdrawer,
+    RequestType.WithdrawCollateral,
+    amount
+  );
 }
 
 export interface BlendReserveRef {
@@ -108,9 +118,16 @@ export async function fetchBlendPositions(
   reserves: BlendReserveRef[]
 ): Promise<PositionInfo[]> {
   const pool = await withRetry(() =>
-    withBlendTimeout(() => PoolV2.load({ rpc: network.rpcUrl, passphrase: network.passphrase }, poolId))
+    withBlendTimeout(() =>
+      PoolV2.load(
+        { rpc: network.rpcUrl, passphrase: network.passphrase },
+        poolId
+      )
+    )
   );
-  const user = await withRetry(() => withBlendTimeout(() => pool.loadUser(publicKey)));
+  const user = await withRetry(() =>
+    withBlendTimeout(() => pool.loadUser(publicKey))
+  );
 
   const positions: PositionInfo[] = [];
   for (const { assetId, vaultId } of reserves) {
@@ -119,7 +136,13 @@ export async function fetchBlendPositions(
     const collateral = user.getCollateralFloat(reserve);
     const total = collateral + user.getSupplyFloat(reserve);
     if (total <= 0) continue;
-    positions.push({ vaultId, shares: collateral, deposited: total, earned: 0, entryTime: 0 });
+    positions.push({
+      vaultId,
+      shares: collateral,
+      deposited: total,
+      earned: 0,
+      entryTime: 0,
+    });
   }
   return positions;
 }

--- a/packages/stellar-sdk-helpers/src/defilamma.test.ts
+++ b/packages/stellar-sdk-helpers/src/defilamma.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { assessPoolRisk, getStellarStablecoinPools, type DefiLlamaPool } from "./defilamma";
+import {
+  assessPoolRisk,
+  getStellarStablecoinPools,
+  type DefiLlamaPool,
+} from "./defilamma";
 
 function pool(overrides: Partial<DefiLlamaPool> = {}): DefiLlamaPool {
   return {
@@ -20,15 +24,21 @@ function pool(overrides: Partial<DefiLlamaPool> = {}): DefiLlamaPool {
 
 describe("assessPoolRisk", () => {
   it("rates a deep, stable, modest-APY pool as safe", () => {
-    expect(assessPoolRisk(pool({ tvlUsd: 5_000_000, apyPct7D: 0.5, apy: 5 }))).toBe("safe");
+    expect(
+      assessPoolRisk(pool({ tvlUsd: 5_000_000, apyPct7D: 0.5, apy: 5 }))
+    ).toBe("safe");
   });
 
   it("rates thin liquidity as caution", () => {
-    expect(assessPoolRisk(pool({ tvlUsd: 50_000, apyPct7D: 0, apy: 5 }))).toBe("caution");
+    expect(assessPoolRisk(pool({ tvlUsd: 50_000, apyPct7D: 0, apy: 5 }))).toBe(
+      "caution"
+    );
   });
 
   it("rates tiny TVL with a high, volatile APY as risky", () => {
-    expect(assessPoolRisk(pool({ tvlUsd: 5_000, apyPct7D: 40, apy: 25 }))).toBe("risky");
+    expect(assessPoolRisk(pool({ tvlUsd: 5_000, apyPct7D: 40, apy: 25 }))).toBe(
+      "risky"
+    );
   });
 });
 
@@ -37,7 +47,13 @@ describe("getStellarStablecoinPools", () => {
 
   it("keeps only Stellar stablecoin pools above the TVL/APY floors", async () => {
     const data = [
-      pool({ pool: "keep", chain: "Stellar", stablecoin: true, apy: 5, tvlUsd: 1_000_000 }),
+      pool({
+        pool: "keep",
+        chain: "Stellar",
+        stablecoin: true,
+        apy: 5,
+        tvlUsd: 1_000_000,
+      }),
       pool({ pool: "wrong-chain", chain: "Ethereum" }),
       pool({ pool: "not-stable", stablecoin: false }),
       pool({ pool: "tiny-tvl", tvlUsd: 500 }),

--- a/packages/stellar-sdk-helpers/src/defilamma.ts
+++ b/packages/stellar-sdk-helpers/src/defilamma.ts
@@ -27,16 +27,16 @@ export type RiskLevel = "safe" | "caution" | "risky";
 export function assessPoolRisk(pool: DefiLlamaPool): RiskLevel {
   let score = 0;
 
-  if (pool.tvlUsd < 10_000)           score += 3;
-  else if (pool.tvlUsd < 100_000)     score += 2;
-  else if (pool.tvlUsd < 2_000_000)   score += 1;
+  if (pool.tvlUsd < 10_000) score += 3;
+  else if (pool.tvlUsd < 100_000) score += 2;
+  else if (pool.tvlUsd < 2_000_000) score += 1;
 
   const vol7d = Math.abs(pool.apyPct7D ?? 0);
-  if (vol7d > 30)     score += 3;
+  if (vol7d > 30) score += 3;
   else if (vol7d > 5) score += 2;
   else if (vol7d > 1) score += 1;
 
-  if (pool.apy > 20)      score += 2;
+  if (pool.apy > 20) score += 2;
   else if (pool.apy > 12) score += 1;
 
   if (score >= 4) return "risky";
@@ -58,7 +58,11 @@ export async function getStellarStablecoinPools(): Promise<DefiLlamaPool[]> {
     if (!res.ok) throw new Error(`DeFiLlama /pools HTTP ${res.status}`);
     const json = (await res.json()) as { data: DefiLlamaPool[] };
     return json.data.filter(
-      (p) => p.chain === "Stellar" && p.stablecoin && p.apy >= MIN_APY && p.tvlUsd >= MIN_TVL_USD
+      (p) =>
+        p.chain === "Stellar" &&
+        p.stablecoin &&
+        p.apy >= MIN_APY &&
+        p.tvlUsd >= MIN_TVL_USD
     );
   });
 }

--- a/packages/stellar-sdk-helpers/src/defindex.test.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { buildDefindexDepositTx, buildDefindexWithdrawTx, stroopsToUnits, fetchDefindexPosition } from "./defindex";
+import {
+  buildDefindexDepositTx,
+  buildDefindexWithdrawTx,
+  stroopsToUnits,
+  fetchDefindexPosition,
+} from "./defindex";
 import type { StellarNetwork } from "./types";
 
 // Track rpc.Server constructor calls so we can assert on the timeout option.
@@ -39,14 +44,20 @@ const ADDR = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 // unit-testable without an RPC server.
 describe("buildDefindexDepositTx", () => {
   it("rejects a non-positive amount", async () => {
-    await expect(buildDefindexDepositTx(config, ADDR, 0n)).rejects.toThrow(/positive/);
-    await expect(buildDefindexDepositTx(config, ADDR, -1n)).rejects.toThrow(/positive/);
+    await expect(buildDefindexDepositTx(config, ADDR, 0n)).rejects.toThrow(
+      /positive/
+    );
+    await expect(buildDefindexDepositTx(config, ADDR, -1n)).rejects.toThrow(
+      /positive/
+    );
   });
 });
 
 describe("buildDefindexWithdrawTx", () => {
   it("rejects non-positive shares", async () => {
-    await expect(buildDefindexWithdrawTx(config, ADDR, 0n)).rejects.toThrow(/positive/);
+    await expect(buildDefindexWithdrawTx(config, ADDR, 0n)).rejects.toThrow(
+      /positive/
+    );
   });
 });
 
@@ -89,17 +100,27 @@ describe("fetchDefindexPosition", () => {
 
   it("returns [] when the user holds zero shares", async () => {
     vi.mocked(simulateView).mockResolvedValue(0n);
-    const result = await fetchDefindexPosition(network, VAULT_ID, "defindex-usdc", PUBKEY);
+    const result = await fetchDefindexPosition(
+      network,
+      VAULT_ID,
+      "defindex-usdc",
+      PUBKEY
+    );
     expect(result).toEqual([]);
     expect(simulateView).toHaveBeenCalledOnce();
   });
 
   it("maps shares and underlying amount into a PositionInfo", async () => {
     vi.mocked(simulateView)
-      .mockResolvedValueOnce(5_000_000n)          // balance: 0.5 dfTokens
-      .mockResolvedValueOnce([10_000_000n]);       // get_asset_amounts_per_shares: 1 USDC
+      .mockResolvedValueOnce(5_000_000n) // balance: 0.5 dfTokens
+      .mockResolvedValueOnce([10_000_000n]); // get_asset_amounts_per_shares: 1 USDC
 
-    const result = await fetchDefindexPosition(network, VAULT_ID, "defindex-usdc", PUBKEY);
+    const result = await fetchDefindexPosition(
+      network,
+      VAULT_ID,
+      "defindex-usdc",
+      PUBKEY
+    );
     expect(result).toHaveLength(1);
     expect(result[0].vaultId).toBe("defindex-usdc");
     expect(result[0].shares).toBeCloseTo(0.5, 7);
@@ -113,7 +134,12 @@ describe("fetchDefindexPosition", () => {
       .mockResolvedValueOnce(5_000_000n)
       .mockResolvedValueOnce(null);
 
-    const [pos] = await fetchDefindexPosition(network, VAULT_ID, "defindex-usdc", PUBKEY);
+    const [pos] = await fetchDefindexPosition(
+      network,
+      VAULT_ID,
+      "defindex-usdc",
+      PUBKEY
+    );
     expect(pos.deposited).toBe(0);
   });
 
@@ -122,7 +148,12 @@ describe("fetchDefindexPosition", () => {
       .mockResolvedValueOnce(5_000_000n)
       .mockResolvedValueOnce([]);
 
-    const [pos] = await fetchDefindexPosition(network, VAULT_ID, "defindex-usdc", PUBKEY);
+    const [pos] = await fetchDefindexPosition(
+      network,
+      VAULT_ID,
+      "defindex-usdc",
+      PUBKEY
+    );
     expect(pos.deposited).toBe(0);
   });
 });

--- a/packages/stellar-sdk-helpers/src/defindex.ts
+++ b/packages/stellar-sdk-helpers/src/defindex.ts
@@ -1,9 +1,4 @@
-import {
-  Address,
-  Contract,
-  nativeToScVal,
-  xdr,
-} from "@stellar/stellar-sdk";
+import { Address, Contract, nativeToScVal, xdr } from "@stellar/stellar-sdk";
 import { simulateView, prepareSorobanTx } from "./tx";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
@@ -49,12 +44,17 @@ export async function buildDefindexDepositTx(
   if (amount <= 0n) throw new Error("amount must be positive");
   const minAmount = amount - (amount * slippageBps) / 10_000n;
   const contract = new Contract(config.vaultId);
-  return prepareSorobanTx(config.network, depositor, contract.call("deposit",
-    xdr.ScVal.scvVec([i128(amount)]),
-    xdr.ScVal.scvVec([i128(minAmount)]),
-    Address.fromString(depositor).toScVal(),
-    xdr.ScVal.scvBool(true),
-  ));
+  return prepareSorobanTx(
+    config.network,
+    depositor,
+    contract.call(
+      "deposit",
+      xdr.ScVal.scvVec([i128(amount)]),
+      xdr.ScVal.scvVec([i128(minAmount)]),
+      Address.fromString(depositor).toScVal(),
+      xdr.ScVal.scvBool(true)
+    )
+  );
 }
 
 /**
@@ -72,11 +72,16 @@ export async function buildDefindexWithdrawTx(
 ): Promise<{ xdr: string; fee: string }> {
   if (shares <= 0n) throw new Error("shares must be positive");
   const contract = new Contract(config.vaultId);
-  return prepareSorobanTx(config.network, withdrawer, contract.call("withdraw",
-    i128(shares),
-    xdr.ScVal.scvVec([i128(0n)]),
-    Address.fromString(withdrawer).toScVal(),
-  ));
+  return prepareSorobanTx(
+    config.network,
+    withdrawer,
+    contract.call(
+      "withdraw",
+      i128(shares),
+      xdr.ScVal.scvVec([i128(0n)]),
+      Address.fromString(withdrawer).toScVal()
+    )
+  );
 }
 
 /**
@@ -110,7 +115,8 @@ export async function fetchDefindexPosition(
     "get_asset_amounts_per_shares",
     i128(shares)
   )) as Array<bigint | number> | null;
-  const underlying = Array.isArray(amounts) && amounts.length > 0 ? toBigInt(amounts[0]) : 0n;
+  const underlying =
+    Array.isArray(amounts) && amounts.length > 0 ? toBigInt(amounts[0]) : 0n;
 
   return [
     {

--- a/packages/stellar-sdk-helpers/src/horizon.test.ts
+++ b/packages/stellar-sdk-helpers/src/horizon.test.ts
@@ -9,9 +9,15 @@ function network(name: StellarNetwork["network"]): StellarNetwork {
 
 describe("buildHorizonServer", () => {
   it("returns a Horizon.Server instance for every supported network", () => {
-    expect(buildHorizonServer(network("testnet"))).toBeInstanceOf(Horizon.Server);
-    expect(buildHorizonServer(network("mainnet"))).toBeInstanceOf(Horizon.Server);
-    expect(buildHorizonServer(network("futurenet"))).toBeInstanceOf(Horizon.Server);
+    expect(buildHorizonServer(network("testnet"))).toBeInstanceOf(
+      Horizon.Server
+    );
+    expect(buildHorizonServer(network("mainnet"))).toBeInstanceOf(
+      Horizon.Server
+    );
+    expect(buildHorizonServer(network("futurenet"))).toBeInstanceOf(
+      Horizon.Server
+    );
   });
 
   it("maps each network to its canonical Horizon endpoint", () => {
@@ -27,4 +33,3 @@ describe("buildHorizonServer", () => {
     );
   });
 });
-

--- a/packages/stellar-sdk-helpers/src/horizon.ts
+++ b/packages/stellar-sdk-helpers/src/horizon.ts
@@ -10,4 +10,3 @@ export function buildHorizonServer(config: StellarNetwork): Horizon.Server {
   };
   return new Horizon.Server(urls[config.network]);
 }
-

--- a/packages/stellar-sdk-helpers/src/internal.ts
+++ b/packages/stellar-sdk-helpers/src/internal.ts
@@ -9,14 +9,19 @@ export function toBigInt(value: unknown): bigint {
   if (typeof value === "bigint") return value;
   if (typeof value === "number") return BigInt(Math.trunc(value));
   if (value === null || value === undefined) return 0n;
-  throw new TypeError(`toBigInt: unexpected type ${typeof value}: ${String(value)}`);
+  throw new TypeError(
+    `toBigInt: unexpected type ${typeof value}: ${String(value)}`
+  );
 }
 
 export function passphraseFor(network: StellarNetwork): string {
   switch (network.network) {
-    case "mainnet": return Networks.PUBLIC;
-    case "testnet": return Networks.TESTNET;
-    case "futurenet": return Networks.FUTURENET;
+    case "mainnet":
+      return Networks.PUBLIC;
+    case "testnet":
+      return Networks.TESTNET;
+    case "futurenet":
+      return Networks.FUTURENET;
   }
 }
 

--- a/packages/stellar-sdk-helpers/src/known-pools.ts
+++ b/packages/stellar-sdk-helpers/src/known-pools.ts
@@ -19,10 +19,30 @@ export const KNOWN_POOLS: {
   testnet: Record<string, TestnetPoolMeta>;
 } = {
   mainnet: {
-    "ecf788e3-d2ef-4fdd-9ece-8a2d96226ddf": { id: "blend-usdc-fixed",    name: "Blend Capital", protocol: "blend", label: "Fixed Pool"    },
-    "3a61420f-6f6e-45f9-accc-8d23f5a32d33": { id: "blend-eurc-fixed",    name: "Blend Capital", protocol: "blend", label: "Fixed Pool"    },
-    "48c597dc-9367-4b4a-aa10-49b9755c4c2e": { id: "blend-usdc-variable", name: "Blend Capital", protocol: "blend", label: "Variable Pool" },
-    "9a2f1f81-0a6e-441d-8219-c13b3520bd57": { id: "blend-eurc-variable", name: "Blend Capital", protocol: "blend", label: "Variable Pool" },
+    "ecf788e3-d2ef-4fdd-9ece-8a2d96226ddf": {
+      id: "blend-usdc-fixed",
+      name: "Blend Capital",
+      protocol: "blend",
+      label: "Fixed Pool",
+    },
+    "3a61420f-6f6e-45f9-accc-8d23f5a32d33": {
+      id: "blend-eurc-fixed",
+      name: "Blend Capital",
+      protocol: "blend",
+      label: "Fixed Pool",
+    },
+    "48c597dc-9367-4b4a-aa10-49b9755c4c2e": {
+      id: "blend-usdc-variable",
+      name: "Blend Capital",
+      protocol: "blend",
+      label: "Variable Pool",
+    },
+    "9a2f1f81-0a6e-441d-8219-c13b3520bd57": {
+      id: "blend-eurc-variable",
+      name: "Blend Capital",
+      protocol: "blend",
+      label: "Variable Pool",
+    },
   },
   testnet: {
     // Blend TestnetV2: only active lending pool on Stellar testnet. USDC reserve

--- a/packages/stellar-sdk-helpers/src/orchestration.test.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.test.ts
@@ -1,21 +1,52 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { buildDepositTx, buildWithdrawTx, resolvePositions, type ProtocolAddresses } from "./orchestration";
+import {
+  buildDepositTx,
+  buildWithdrawTx,
+  resolvePositions,
+  type ProtocolAddresses,
+} from "./orchestration";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
 
-const BLEND_USDC: PositionInfo = { vaultId: "blend-usdc-fixed", shares: 10, deposited: 10, earned: 0, entryTime: 0 };
-const DFX_USDC: PositionInfo = { vaultId: "defindex-usdc", shares: 5, deposited: 5, earned: 0, entryTime: 0 };
+const BLEND_USDC: PositionInfo = {
+  vaultId: "blend-usdc-fixed",
+  shares: 10,
+  deposited: 10,
+  earned: 0,
+  entryTime: 0,
+};
+const DFX_USDC: PositionInfo = {
+  vaultId: "defindex-usdc",
+  shares: 5,
+  deposited: 5,
+  earned: 0,
+  entryTime: 0,
+};
 
 vi.mock("./blend", () => ({
-  blendAssetForVault: vi.fn((vaultId: string) => (vaultId.includes("-eurc") ? "eurc" : "usdc")),
-  buildBlendDepositTx: vi.fn(async () => ({ xdr: "BLEND_DEPOSIT_XDR", fee: "200" })),
-  buildBlendWithdrawTx: vi.fn(async () => ({ xdr: "BLEND_WITHDRAW_XDR", fee: "200" })),
+  blendAssetForVault: vi.fn((vaultId: string) =>
+    vaultId.includes("-eurc") ? "eurc" : "usdc"
+  ),
+  buildBlendDepositTx: vi.fn(async () => ({
+    xdr: "BLEND_DEPOSIT_XDR",
+    fee: "200",
+  })),
+  buildBlendWithdrawTx: vi.fn(async () => ({
+    xdr: "BLEND_WITHDRAW_XDR",
+    fee: "200",
+  })),
   fetchBlendPositions: vi.fn(async () => [BLEND_USDC]),
 }));
 
 vi.mock("./defindex", () => ({
-  buildDefindexDepositTx: vi.fn(async () => ({ xdr: "DFX_DEPOSIT_XDR", fee: "300" })),
-  buildDefindexWithdrawTx: vi.fn(async () => ({ xdr: "DFX_WITHDRAW_XDR", fee: "300" })),
+  buildDefindexDepositTx: vi.fn(async () => ({
+    xdr: "DFX_DEPOSIT_XDR",
+    fee: "300",
+  })),
+  buildDefindexWithdrawTx: vi.fn(async () => ({
+    xdr: "DFX_WITHDRAW_XDR",
+    fee: "300",
+  })),
   fetchDefindexPosition: vi.fn(async () => [DFX_USDC]),
 }));
 
@@ -50,7 +81,13 @@ beforeEach(() => vi.clearAllMocks());
 
 describe("buildDepositTx", () => {
   it("routes a blend-usdc vault to buildBlendDepositTx with the USDC asset", async () => {
-    const result = await buildDepositTx("blend-usdc-fixed", WALLET, "10", addresses, network);
+    const result = await buildDepositTx(
+      "blend-usdc-fixed",
+      WALLET,
+      "10",
+      addresses,
+      network
+    );
     expect(result).toEqual({ xdr: "BLEND_DEPOSIT_XDR", fee: "200" });
     expect(buildBlendDepositTx).toHaveBeenCalledWith(
       { poolId: "CPOOL", assetId: "CUSDC", network },
@@ -70,7 +107,13 @@ describe("buildDepositTx", () => {
   });
 
   it("routes a defindex vault to buildDefindexDepositTx", async () => {
-    const result = await buildDepositTx("defindex-usdc", WALLET, "10", addresses, network);
+    const result = await buildDepositTx(
+      "defindex-usdc",
+      WALLET,
+      "10",
+      addresses,
+      network
+    );
     expect(result).toEqual({ xdr: "DFX_DEPOSIT_XDR", fee: "300" });
     expect(buildDefindexDepositTx).toHaveBeenCalledWith(
       { vaultId: "CDFX", network },
@@ -82,21 +125,27 @@ describe("buildDepositTx", () => {
 
   it("throws when defindexVault address is empty and vault is defindex", async () => {
     const noVault = { ...addresses, defindexVault: "" };
-    await expect(buildDepositTx("defindex-usdc", WALLET, "10", noVault, network)).rejects.toThrow(
-      /DeFindex vault not configured/
-    );
+    await expect(
+      buildDepositTx("defindex-usdc", WALLET, "10", noVault, network)
+    ).rejects.toThrow(/DeFindex vault not configured/);
   });
 
   it("throws for an unrecognised vault protocol", async () => {
-    await expect(buildDepositTx("ondo-usdy", WALLET, "10", addresses, network)).rejects.toThrow(
-      /No protocol mapping/
-    );
+    await expect(
+      buildDepositTx("ondo-usdy", WALLET, "10", addresses, network)
+    ).rejects.toThrow(/No protocol mapping/);
   });
 });
 
 describe("buildWithdrawTx", () => {
   it("routes a blend vault to buildBlendWithdrawTx", async () => {
-    const result = await buildWithdrawTx("blend-usdc-fixed", WALLET, "5", addresses, network);
+    const result = await buildWithdrawTx(
+      "blend-usdc-fixed",
+      WALLET,
+      "5",
+      addresses,
+      network
+    );
     expect(result).toEqual({ xdr: "BLEND_WITHDRAW_XDR", fee: "200" });
     expect(buildBlendWithdrawTx).toHaveBeenCalledWith(
       { poolId: "CPOOL", assetId: "CUSDC", network },
@@ -106,7 +155,13 @@ describe("buildWithdrawTx", () => {
   });
 
   it("routes a defindex vault to buildDefindexWithdrawTx", async () => {
-    const result = await buildWithdrawTx("defindex-usdc", WALLET, "5", addresses, network);
+    const result = await buildWithdrawTx(
+      "defindex-usdc",
+      WALLET,
+      "5",
+      addresses,
+      network
+    );
     expect(result).toEqual({ xdr: "DFX_WITHDRAW_XDR", fee: "300" });
     expect(buildDefindexWithdrawTx).toHaveBeenCalledWith(
       { vaultId: "CDFX", network },
@@ -117,15 +172,15 @@ describe("buildWithdrawTx", () => {
 
   it("throws when defindexVault address is empty and vault is defindex", async () => {
     const noVault = { ...addresses, defindexVault: "" };
-    await expect(buildWithdrawTx("defindex-usdc", WALLET, "5", noVault, network)).rejects.toThrow(
-      /DeFindex vault not configured/
-    );
+    await expect(
+      buildWithdrawTx("defindex-usdc", WALLET, "5", noVault, network)
+    ).rejects.toThrow(/DeFindex vault not configured/);
   });
 
   it("throws for an unrecognised vault protocol", async () => {
-    await expect(buildWithdrawTx("ondo-usdy", WALLET, "5", addresses, network)).rejects.toThrow(
-      /No protocol mapping/
-    );
+    await expect(
+      buildWithdrawTx("ondo-usdy", WALLET, "5", addresses, network)
+    ).rejects.toThrow(/No protocol mapping/);
   });
 });
 
@@ -140,7 +195,12 @@ describe("resolvePositions", () => {
 
   it("appends DeFindex positions when defindexVault is set", async () => {
     const positions = await resolvePositions(WALLET, network, addresses);
-    expect(fetchDefindexPosition).toHaveBeenCalledWith(network, "CDFX", "defindex-usdc", WALLET);
+    expect(fetchDefindexPosition).toHaveBeenCalledWith(
+      network,
+      "CDFX",
+      "defindex-usdc",
+      WALLET
+    );
     expect(positions).toContainEqual(DFX_USDC);
   });
 
@@ -152,20 +212,28 @@ describe("resolvePositions", () => {
   });
 
   it("returns Blend positions when DeFindex fetch fails", async () => {
-    vi.mocked(fetchDefindexPosition).mockRejectedValueOnce(new Error("RPC down"));
+    vi.mocked(fetchDefindexPosition).mockRejectedValueOnce(
+      new Error("RPC down")
+    );
     const positions = await resolvePositions(WALLET, network, addresses);
     expect(positions).toEqual([BLEND_USDC]);
   });
 
   it("returns DeFindex positions when Blend fetch fails", async () => {
-    vi.mocked(fetchBlendPositions).mockRejectedValueOnce(new Error("Blend RPC timeout"));
+    vi.mocked(fetchBlendPositions).mockRejectedValueOnce(
+      new Error("Blend RPC timeout")
+    );
     const positions = await resolvePositions(WALLET, network, addresses);
     expect(positions).toEqual([DFX_USDC]);
   });
 
   it("returns empty array when both fetches fail", async () => {
-    vi.mocked(fetchBlendPositions).mockRejectedValueOnce(new Error("Blend down"));
-    vi.mocked(fetchDefindexPosition).mockRejectedValueOnce(new Error("DeFindex down"));
+    vi.mocked(fetchBlendPositions).mockRejectedValueOnce(
+      new Error("Blend down")
+    );
+    vi.mocked(fetchDefindexPosition).mockRejectedValueOnce(
+      new Error("DeFindex down")
+    );
     const positions = await resolvePositions(WALLET, network, addresses);
     expect(positions).toEqual([]);
   });

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -1,5 +1,14 @@
-import { buildBlendDepositTx, buildBlendWithdrawTx, blendAssetForVault, fetchBlendPositions } from "./blend";
-import { buildDefindexDepositTx, buildDefindexWithdrawTx, fetchDefindexPosition } from "./defindex";
+import {
+  buildBlendDepositTx,
+  buildBlendWithdrawTx,
+  blendAssetForVault,
+  fetchBlendPositions,
+} from "./blend";
+import {
+  buildDefindexDepositTx,
+  buildDefindexWithdrawTx,
+  fetchDefindexPosition,
+} from "./defindex";
 import { toStroops, resolveProtocol } from "./tx";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
@@ -7,11 +16,12 @@ import { KNOWN_POOLS } from "./known-pools";
 
 function blendPositionEntries(
   network: StellarNetwork,
-  addresses: ProtocolAddresses,
+  addresses: ProtocolAddresses
 ): Array<{ assetId: string; vaultId: string }> {
-  const pools = network.network === "testnet"
-    ? Object.values(KNOWN_POOLS.testnet)
-    : Object.values(KNOWN_POOLS.mainnet);
+  const pools =
+    network.network === "testnet"
+      ? Object.values(KNOWN_POOLS.testnet)
+      : Object.values(KNOWN_POOLS.mainnet);
   const seen = new Set<string>();
   const entries: Array<{ assetId: string; vaultId: string }> = [];
   for (const pool of pools) {
@@ -72,12 +82,22 @@ export async function buildDepositTx(
 export async function resolvePositions(
   publicKey: string,
   network: StellarNetwork,
-  addresses: ProtocolAddresses,
+  addresses: ProtocolAddresses
 ): Promise<PositionInfo[]> {
   const [blendResult, dfxResult] = await Promise.allSettled([
-    fetchBlendPositions(network, addresses.blendPool, publicKey, blendPositionEntries(network, addresses)),
+    fetchBlendPositions(
+      network,
+      addresses.blendPool,
+      publicKey,
+      blendPositionEntries(network, addresses)
+    ),
     addresses.defindexVault
-      ? fetchDefindexPosition(network, addresses.defindexVault, addresses.defindexVaultId, publicKey)
+      ? fetchDefindexPosition(
+          network,
+          addresses.defindexVault,
+          addresses.defindexVaultId,
+          publicKey
+        )
       : Promise.resolve([]),
   ]);
 
@@ -88,7 +108,8 @@ export async function resolvePositions(
     console.error("[positions] DeFindex fetch failed:", dfxResult.reason);
   }
 
-  const blendPositions = blendResult.status === "fulfilled" ? blendResult.value : [];
+  const blendPositions =
+    blendResult.status === "fulfilled" ? blendResult.value : [];
   const dfxPositions = dfxResult.status === "fulfilled" ? dfxResult.value : [];
 
   return [...blendPositions, ...dfxPositions];

--- a/packages/stellar-sdk-helpers/src/positions.ts
+++ b/packages/stellar-sdk-helpers/src/positions.ts
@@ -28,14 +28,21 @@ export interface RawPosition {
  *
  * Returns an empty array when the address holds no shares.
  */
-export function computePosition(vaultId: string, raw: RawPosition): PositionInfo[] {
+export function computePosition(
+  vaultId: string,
+  raw: RawPosition
+): PositionInfo[] {
   if (raw.shares <= 0n) return [];
 
   const currentValue =
-    raw.totalShares > 0n ? (raw.shares * raw.totalAssets) / raw.totalShares : 0n;
+    raw.totalShares > 0n
+      ? (raw.shares * raw.totalAssets) / raw.totalShares
+      : 0n;
 
   const earned =
-    raw.principal !== null && currentValue > raw.principal ? currentValue - raw.principal : 0n;
+    raw.principal !== null && currentValue > raw.principal
+      ? currentValue - raw.principal
+      : 0n;
 
   return [
     {
@@ -47,4 +54,3 @@ export function computePosition(vaultId: string, raw: RawPosition): PositionInfo
     },
   ];
 }
-

--- a/packages/stellar-sdk-helpers/src/routing.test.ts
+++ b/packages/stellar-sdk-helpers/src/routing.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect } from "vitest";
 import { selectBestVault } from "./routing";
 import type { ApiVault } from "./vaults";
 
-function vault(p: Partial<Omit<ApiVault, "protocol">> & { protocol?: string }): ApiVault {
+function vault(
+  p: Partial<Omit<ApiVault, "protocol">> & { protocol?: string }
+): ApiVault {
   return {
     id: p.id ?? "v",
     protocol: (p.protocol ?? "blend") as ApiVault["protocol"],

--- a/packages/stellar-sdk-helpers/src/routing.ts
+++ b/packages/stellar-sdk-helpers/src/routing.ts
@@ -19,7 +19,10 @@ function isRoutable(vault: ApiVault, opts: RouteOptions): boolean {
  * to the best routable pool when every option is risky, and returns null when
  * nothing is routable. Pure — no I/O.
  */
-export function selectBestVault(vaults: ApiVault[], opts: RouteOptions): ApiVault | null {
+export function selectBestVault(
+  vaults: ApiVault[],
+  opts: RouteOptions
+): ApiVault | null {
   const routable = vaults.filter((v) => isRoutable(v, opts));
   if (routable.length === 0) return null;
 

--- a/packages/stellar-sdk-helpers/src/tx.test.ts
+++ b/packages/stellar-sdk-helpers/src/tx.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { rpc, Horizon } from "@stellar/stellar-sdk";
-import { toStroops, resolveProtocol, waitForTransaction, simErrorMessage, buildAddTrustlineTx, simulateView } from "./tx";
+import {
+  toStroops,
+  resolveProtocol,
+  waitForTransaction,
+  simErrorMessage,
+  buildAddTrustlineTx,
+  simulateView,
+} from "./tx";
 import type { StellarNetwork } from "./types";
 
 const { SUCCESS, FAILED, NOT_FOUND } = rpc.Api.GetTransactionStatus;
@@ -35,7 +42,9 @@ describe("simErrorMessage", () => {
   });
 
   it("trims surrounding whitespace", () => {
-    expect(simErrorMessage("  Error(WasmVm, InvalidAction)  ")).toBe("Error(WasmVm, InvalidAction)");
+    expect(simErrorMessage("  Error(WasmVm, InvalidAction)  ")).toBe(
+      "Error(WasmVm, InvalidAction)"
+    );
   });
 
   it("returns a fallback for empty or whitespace-only errors", () => {
@@ -53,15 +62,20 @@ describe("simulateView RPC timeout", () => {
     // The server mock resolves immediately so we don't need to wait for the
     // timeout — we only need to verify the deadline was registered.
     const server = {
-      simulateTransaction: vi.fn(async () => ({
-        id: "1",
-        events: [],
-        minResourceFee: "100",
-        results: [],
-        transactionData: new (await import("@stellar/stellar-sdk")).rpc.Server(
-          "https://soroban-testnet.stellar.org"
-        ),
-      } as unknown as Awaited<ReturnType<rpc.Server["simulateTransaction"]>>)),
+      simulateTransaction: vi.fn(
+        async () =>
+          ({
+            id: "1",
+            events: [],
+            minResourceFee: "100",
+            results: [],
+            transactionData: new (
+              await import("@stellar/stellar-sdk")
+            ).rpc.Server("https://soroban-testnet.stellar.org"),
+          }) as unknown as Awaited<
+            ReturnType<rpc.Server["simulateTransaction"]>
+          >
+      ),
     } as unknown as rpc.Server;
 
     try {
@@ -128,10 +142,15 @@ const TESTNET: StellarNetwork = {
   passphrase: "Test SDF Network ; September 2015",
 };
 
-const USDC_ISSUER_TESTNET = "GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56";
-const MUSDC_ISSUER_TESTNET = "GAZOB5KAE27U7QMGCJLA74TKGECONNND73GL2GIMYBXYNBVG4U5IHBX7";
+const USDC_ISSUER_TESTNET =
+  "GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56";
+const MUSDC_ISSUER_TESTNET =
+  "GAZOB5KAE27U7QMGCJLA74TKGECONNND73GL2GIMYBXYNBVG4U5IHBX7";
 
-function makeBalance(code: string, issuer: string): Horizon.HorizonApi.BalanceLine {
+function makeBalance(
+  code: string,
+  issuer: string
+): Horizon.HorizonApi.BalanceLine {
   return {
     asset_type: code.length <= 4 ? "credit_alphanum4" : "credit_alphanum12",
     asset_code: code,
@@ -159,7 +178,10 @@ describe("buildAddTrustlineTx", () => {
     } as unknown as Awaited<ReturnType<Horizon.Server["loadAccount"]>>);
 
     await expect(
-      buildAddTrustlineTx("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", TESTNET)
+      buildAddTrustlineTx(
+        "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+        TESTNET
+      )
     ).rejects.toThrow("All required trustlines already exist");
   });
 });
@@ -167,7 +189,9 @@ describe("buildAddTrustlineTx", () => {
 describe("waitForTransaction", () => {
   it("resolves once the transaction reaches SUCCESS", async () => {
     const reader = fakeReader([NOT_FOUND, NOT_FOUND, SUCCESS]);
-    const res = await waitForTransaction(reader, "TXHASH", { sleep: noopSleep });
+    const res = await waitForTransaction(reader, "TXHASH", {
+      sleep: noopSleep,
+    });
     expect(res.status).toBe(SUCCESS);
     expect(res.ledger).toBe(42);
     expect(reader.calls).toBe(3);

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -27,9 +27,13 @@ export class SorobanTimeoutError extends Error {
   }
 }
 
-const withSorobanTimeout = <T>(fn: () => Promise<T>, ms = SOROBAN_RPC_TIMEOUT_MS): Promise<T> =>
+const withSorobanTimeout = <T>(
+  fn: () => Promise<T>,
+  ms = SOROBAN_RPC_TIMEOUT_MS
+): Promise<T> =>
   withRaceTimeout(fn, ms, "Soroban RPC").catch((err: unknown): never => {
-    if (err instanceof Error && err.message.includes("timed out")) throw new SorobanTimeoutError(ms);
+    if (err instanceof Error && err.message.includes("timed out"))
+      throw new SorobanTimeoutError(ms);
     throw err;
   });
 
@@ -41,13 +45,15 @@ const MUSDC_ISSUER: Record<string, string> = {
 
 function usdcAsset(network: StellarNetwork): Asset {
   const issuer = USDC_ISSUER[network.network];
-  if (!issuer) throw new Error(`No USDC issuer for network: ${network.network}`);
+  if (!issuer)
+    throw new Error(`No USDC issuer for network: ${network.network}`);
   return new Asset("USDC", issuer);
 }
 
 function musdcAsset(network: StellarNetwork): Asset {
   const issuer = MUSDC_ISSUER[network.network];
-  if (!issuer) throw new Error(`No mUSDC issuer for network: ${network.network}`);
+  if (!issuer)
+    throw new Error(`No mUSDC issuer for network: ${network.network}`);
   return new Asset("MUSDC", issuer);
 }
 
@@ -62,9 +68,12 @@ function hasAssetTrustline(
 ): boolean {
   return balances.some(
     (b) =>
-      (b.asset_type === "credit_alphanum4" || b.asset_type === "credit_alphanum12") &&
-      (b as Horizon.HorizonApi.BalanceLine<"credit_alphanum4">).asset_code === code &&
-      (b as Horizon.HorizonApi.BalanceLine<"credit_alphanum4">).asset_issuer === issuer
+      (b.asset_type === "credit_alphanum4" ||
+        b.asset_type === "credit_alphanum12") &&
+      (b as Horizon.HorizonApi.BalanceLine<"credit_alphanum4">).asset_code ===
+        code &&
+      (b as Horizon.HorizonApi.BalanceLine<"credit_alphanum4">).asset_issuer ===
+        issuer
   );
 }
 
@@ -94,14 +103,21 @@ export async function simulateView(
   method: string,
   ...args: xdr.ScVal[]
 ): Promise<unknown> {
-  const dummyAccount = new Account("GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5", "0");
+  const dummyAccount = new Account(
+    "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+    "0"
+  );
   const contract = new Contract(contractId);
-  const tx = new TransactionBuilder(dummyAccount, { fee: BASE_FEE, networkPassphrase })
+  const tx = new TransactionBuilder(dummyAccount, {
+    fee: BASE_FEE,
+    networkPassphrase,
+  })
     .addOperation(contract.call(method, ...args))
     .setTimeout(0)
     .build();
   const sim = await withSorobanTimeout(() => server.simulateTransaction(tx));
-  if (rpc.Api.isSimulationError(sim)) throw new Error(simErrorMessage(sim.error));
+  if (rpc.Api.isSimulationError(sim))
+    throw new Error(simErrorMessage(sim.error));
   if (!rpc.Api.isSimulationSuccess(sim) || !sim.result) return null;
   return scValToNative(sim.result.retval);
 }
@@ -124,14 +140,21 @@ export async function prepareSorobanTx(
     200,
     (err) => !(err instanceof SorobanTimeoutError)
   );
-  const tx = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase })
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: passphrase,
+  })
     .addOperation(op)
     .setTimeout(300)
     .build();
   const sim = await withSorobanTimeout(() => server.simulateTransaction(tx));
-  if (rpc.Api.isSimulationError(sim)) throw new Error(`Simulation failed: ${simErrorMessage(sim.error)}`);
+  if (rpc.Api.isSimulationError(sim))
+    throw new Error(`Simulation failed: ${simErrorMessage(sim.error)}`);
   const prepared = rpc.assembleTransaction(tx, sim).build();
-  return { xdr: prepared.toEnvelope().toXDR("base64"), fee: sim.minResourceFee };
+  return {
+    xdr: prepared.toEnvelope().toXDR("base64"),
+    fee: sim.minResourceFee,
+  };
 }
 
 /**
@@ -150,7 +173,9 @@ export async function buildAddTrustlineTx(
 
   const ops: ReturnType<typeof Operation.changeTrust>[] = [];
 
-  if (!hasAssetTrustline(balances, "USDC", USDC_ISSUER[network.network] ?? "")) {
+  if (
+    !hasAssetTrustline(balances, "USDC", USDC_ISSUER[network.network] ?? "")
+  ) {
     ops.push(Operation.changeTrust({ asset: usdcAsset(network) }));
   }
   const musdcIssuer = MUSDC_ISSUER[network.network];
@@ -158,9 +183,13 @@ export async function buildAddTrustlineTx(
     ops.push(Operation.changeTrust({ asset: musdcAsset(network) }));
   }
 
-  if (ops.length === 0) throw new Error("All required trustlines already exist");
+  if (ops.length === 0)
+    throw new Error("All required trustlines already exist");
 
-  const builder = new TransactionBuilder(account, { fee: BASE_FEE, networkPassphrase: passphrase });
+  const builder = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: passphrase,
+  });
   for (const op of ops) builder.addOperation(op);
   const tx = builder.setTimeout(300).build();
 
@@ -193,7 +222,8 @@ interface TransactionReader {
   getTransaction(hash: string): Promise<rpc.Api.GetTransactionResponse>;
 }
 
-const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 /**
  * Poll `getTransaction` until the network reports a final status. Resolves on
@@ -263,7 +293,9 @@ export async function submitTx(
 
   const sent = await withSorobanTimeout(() => server.sendTransaction(tx));
   if (sent.status === "ERROR") {
-    throw new Error(`Transaction rejected at submission: ${describeSendError(sent)}`);
+    throw new Error(
+      `Transaction rejected at submission: ${describeSendError(sent)}`
+    );
   }
   if (sent.status === "TRY_AGAIN_LATER") {
     throw new Error("Transaction could not be submitted yet (try again later)");

--- a/packages/stellar-sdk-helpers/src/vaults.test.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.test.ts
@@ -59,8 +59,9 @@ describe("fetchAllVaults", () => {
   });
 
   it("returns cached result and skips DeFiLlama on repeated calls within TTL", async () => {
-    const mockFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ data: [llamaPool()] }), { status: 200 })
+    const mockFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [llamaPool()] }), { status: 200 })
     );
     vi.stubGlobal("fetch", mockFetch);
 
@@ -89,8 +90,9 @@ describe("fetchAllVaults", () => {
 
   it("re-fetches from DeFiLlama after the 60 s TTL expires", async () => {
     vi.useFakeTimers();
-    const mockFetch = vi.fn(async () =>
-      new Response(JSON.stringify({ data: [llamaPool()] }), { status: 200 })
+    const mockFetch = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ data: [llamaPool()] }), { status: 200 })
     );
     vi.stubGlobal("fetch", mockFetch);
 
@@ -104,7 +106,8 @@ describe("fetchAllVaults", () => {
 
 describe("fetchAllVaults (testnet)", () => {
   // USDC SAC for Blend TestnetV2 (from KNOWN_POOLS.testnet["blend-testnet-usdc"].assetId).
-  const TESTNET_USDC_SAC = "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU";
+  const TESTNET_USDC_SAC =
+    "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU";
 
   beforeEach(() => clearVaultCache());
   afterEach(() => {
@@ -115,7 +118,12 @@ describe("fetchAllVaults (testnet)", () => {
   it("returns testnet vault with TVL and APY derived from on-chain reserve", async () => {
     // 1 000 USDC = 10_000_000_000 stroops (7 decimal places). 5% APY = 0.05.
     vi.spyOn(PoolV2, "load").mockResolvedValue({
-      reserves: new Map([[TESTNET_USDC_SAC, { totalSupply: () => 10_000_000_000n, estSupplyApy: 0.05 }]]),
+      reserves: new Map([
+        [
+          TESTNET_USDC_SAC,
+          { totalSupply: () => 10_000_000_000n, estSupplyApy: 0.05 },
+        ],
+      ]),
     } as unknown as Awaited<ReturnType<typeof PoolV2.load>>);
 
     const vaults = await fetchAllVaults("testnet");
@@ -138,7 +146,9 @@ describe("fetchAllVaults (testnet)", () => {
 
   it("does not cache testnet results between calls", async () => {
     const loadSpy = vi.spyOn(PoolV2, "load").mockResolvedValue({
-      reserves: new Map([[TESTNET_USDC_SAC, { totalSupply: () => 0n, estSupplyApy: 0 }]]),
+      reserves: new Map([
+        [TESTNET_USDC_SAC, { totalSupply: () => 0n, estSupplyApy: 0 }],
+      ]),
     } as unknown as Awaited<ReturnType<typeof PoolV2.load>>);
 
     await fetchAllVaults("testnet");

--- a/packages/stellar-sdk-helpers/src/vaults.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.ts
@@ -1,5 +1,9 @@
 import { PoolV2 } from "@blend-capital/blend-sdk";
-import { getStellarStablecoinPools, assessPoolRisk, type RiskLevel } from "./defilamma";
+import {
+  getStellarStablecoinPools,
+  assessPoolRisk,
+  type RiskLevel,
+} from "./defilamma";
 import { KNOWN_POOLS } from "./known-pools";
 import { APP_NETWORK, withRaceTimeout } from "@meridian/shared";
 
@@ -38,7 +42,10 @@ export function isVaultCacheWarm(): boolean {
  * entry in KNOWN_POOLS.testnet.
  */
 async function fetchTestnetVaults(): Promise<ApiVault[]> {
-  const blendNetwork = { rpc: APP_NETWORK.rpcUrl, passphrase: APP_NETWORK.passphrase };
+  const blendNetwork = {
+    rpc: APP_NETWORK.rpcUrl,
+    passphrase: APP_NETWORK.passphrase,
+  };
   const vaults: ApiVault[] = [];
   for (const meta of Object.values(KNOWN_POOLS.testnet)) {
     const pool = await withRaceTimeout(
@@ -62,7 +69,9 @@ async function fetchTestnetVaults(): Promise<ApiVault[]> {
  * Blend TestnetV2 pool on-chain directly (DeFiLlama does not index testnet).
  * Mainnet results are cached for 60 s; testnet results are always fresh.
  */
-export async function fetchAllVaults(network: "mainnet" | "testnet" = APP_NETWORK.network): Promise<ApiVault[]> {
+export async function fetchAllVaults(
+  network: "mainnet" | "testnet" = APP_NETWORK.network
+): Promise<ApiVault[]> {
   if (network === "testnet") return fetchTestnetVaults();
 
   const now = Date.now();
@@ -74,7 +83,12 @@ export async function fetchAllVaults(network: "mainnet" | "testnet" = APP_NETWOR
   for (const pool of pools) {
     const meta = KNOWN_POOLS.mainnet[pool.pool];
     if (!meta) {
-      console.warn("[vaults] unknown DeFiLlama pool, skipping:", pool.pool, pool.project, pool.symbol);
+      console.warn(
+        "[vaults] unknown DeFiLlama pool, skipping:",
+        pool.pool,
+        pool.project,
+        pool.symbol
+      );
       continue;
     }
     vaults.push({


### PR DESCRIPTION
## Summary

- Adds `.prettierrc.json` (printWidth 80, es5 trailing commas, double quotes) and `.prettierignore` (excludes `dist/`, `target/`, `pnpm-lock.yaml`, contracts)
- Adds `format` and `format:check` scripts to root `package.json`; runs `pnpm format:check` in the `lint-typecheck` CI job
- Applies the initial format pass across all 77 source files so the check starts green
- Adds `commitlint.config.js` with the type enum and rules that match what CONTRIBUTING.md documents; wired to `wagoid/commitlint-github-action@v6` in a new `commitlint` job
- Adds a `pr-lint` job using `amannn/action-semantic-pull-request@v5` to validate PR titles against the same type list
- Adds a `dependency-review` job using `actions/dependency-review-action@v4` to flag CVEs and disallowed licences in new dependencies

All three new jobs are scoped to `pull_request` events only.

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [ ] `pnpm format:check` exits 0

Closes #254