### PR TITLE
fix: resolve vault contracts from KNOWN_POOLS instead of ProtocolAddresses

### DIFF
--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -20,7 +20,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     const positions = await resolvePositions(
       publicKey,
       APP_NETWORK,
-      buildTxAddresses(process.env.DEFINDEX_VAULT_ID)
+      buildTxAddresses()
     );
     res.json({ positions });
   } catch (err) {

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -25,7 +25,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       vaultId,
       walletAddress,
       amount,
-      buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
+      buildTxAddresses(),
       APP_NETWORK
     );
     return res.json(result);

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -25,7 +25,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       vaultId,
       walletAddress,
       shares,
-      buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
+      buildTxAddresses(),
       APP_NETWORK
     );
     return res.json(result);

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -18,7 +18,7 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
       const positions = await resolvePositions(
         publicKey,
         APP_NETWORK,
-        buildTxAddresses(process.env.DEFINDEX_VAULT_ID)
+        buildTxAddresses()
       );
       reply.send({ positions });
     } catch (err) {

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -31,7 +31,7 @@ export const txRoute: FastifyPluginAsync = async (app) => {
           vaultId,
           walletAddress,
           amount,
-          buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
+          buildTxAddresses(),
           APP_NETWORK
         );
         reply.send(result);
@@ -58,7 +58,7 @@ export const txRoute: FastifyPluginAsync = async (app) => {
           vaultId,
           walletAddress,
           shares,
-          buildTxAddresses(process.env.DEFINDEX_VAULT_ID),
+          buildTxAddresses(),
           APP_NETWORK
         );
         reply.send(result);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -77,14 +77,11 @@ export function isDefindexConfigured(): boolean {
   return Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault);
 }
 
-/** Build the ProtocolAddresses object consumed by stellar-sdk-helpers, allowing
- *  the DeFindex vault contract address to be overridden at runtime via DEFINDEX_VAULT_ID. */
-export function buildTxAddresses(defindexOverride?: string) {
+/** Build the asset SAC addresses consumed by stellar-sdk-helpers. Protocol
+ *  contract addresses are resolved from KNOWN_POOLS inside the SDK by vault ID. */
+export function buildTxAddresses() {
   return {
-    blendPool: APP_ADDRESSES.blend.pool,
     usdc: APP_ADDRESSES.usdc,
     eurc: APP_ADDRESSES.eurc,
-    defindexVault: defindexOverride ?? APP_ADDRESSES.defindex.vault,
-    defindexVaultId: "defindex-usdc",
   };
 }

--- a/packages/stellar-sdk-helpers/src/known-pools.ts
+++ b/packages/stellar-sdk-helpers/src/known-pools.ts
@@ -3,10 +3,13 @@ export interface KnownPoolMeta {
   name: string;
   protocol: "blend" | "defindex";
   label: string;
+  // The main protocol contract for this vault: lending pool address for Blend,
+  // vault contract address for DeFindex. Optional on mainnet until deployed.
+  contractId?: string;
 }
 
 export interface TestnetPoolMeta extends KnownPoolMeta {
-  poolId: string;
+  contractId: string;
   assetId: string;
   asset: string;
 }
@@ -52,7 +55,17 @@ export const KNOWN_POOLS: {
       name: "Blend Capital",
       protocol: "blend",
       label: "TestnetV2",
-      poolId: "CCEBVDYM32YNYCVNRXQKDFFPISJJCV557CDZEIRBEE4NCV4KHPQ44HGF",
+      contractId: "CCEBVDYM32YNYCVNRXQKDFFPISJJCV557CDZEIRBEE4NCV4KHPQ44HGF",
+      assetId: "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU",
+      asset: "USDC",
+    },
+    // Paltalabs single-asset USDC vault on DeFindex testnet.
+    "defindex-usdc": {
+      id: "defindex-usdc",
+      name: "DeFindex",
+      protocol: "defindex",
+      label: "USDC Vault",
+      contractId: "CBMVK2JK6NTOT2O4HNQAIQFJY232BHKGLIMXDVQVHIIZKDACXDFZDWHN",
       assetId: "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU",
       asset: "USDC",
     },

--- a/packages/stellar-sdk-helpers/src/orchestration.test.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.test.ts
@@ -23,6 +23,35 @@ const DFX_USDC: PositionInfo = {
   entryTime: 0,
 };
 
+vi.mock("./known-pools", () => ({
+  KNOWN_POOLS: {
+    testnet: {
+      "blend-testnet-usdc": {
+        id: "blend-usdc-fixed",
+        protocol: "blend",
+        contractId: "CPOOL",
+        assetId: "CUSDC",
+        asset: "USDC",
+      },
+      "blend-testnet-eurc": {
+        id: "blend-eurc-fixed",
+        protocol: "blend",
+        contractId: "CPOOL",
+        assetId: "CEURC",
+        asset: "EURC",
+      },
+      "defindex-usdc": {
+        id: "defindex-usdc",
+        protocol: "defindex",
+        contractId: "CDFX",
+        assetId: "CUSDC",
+        asset: "USDC",
+      },
+    },
+    mainnet: {},
+  },
+}));
+
 vi.mock("./blend", () => ({
   blendAssetForVault: vi.fn((vaultId: string) =>
     vaultId.includes("-eurc") ? "eurc" : "usdc"
@@ -68,11 +97,8 @@ const network: StellarNetwork = {
 };
 
 const addresses: ProtocolAddresses = {
-  blendPool: "CPOOL",
   usdc: "CUSDC",
   eurc: "CEURC",
-  defindexVault: "CDFX",
-  defindexVaultId: "defindex-usdc",
 };
 
 const WALLET = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
@@ -123,17 +149,16 @@ describe("buildDepositTx", () => {
     expect(buildBlendDepositTx).not.toHaveBeenCalled();
   });
 
-  it("throws when defindexVault address is empty and vault is defindex", async () => {
-    const noVault = { ...addresses, defindexVault: "" };
+  it("throws for a vault not in KNOWN_POOLS", async () => {
     await expect(
-      buildDepositTx("defindex-usdc", WALLET, "10", noVault, network)
-    ).rejects.toThrow(/DeFindex vault not configured/);
+      buildDepositTx("defindex-eurc", WALLET, "10", addresses, network)
+    ).rejects.toThrow(/Vault not configured/);
   });
 
   it("throws for an unrecognised vault protocol", async () => {
     await expect(
       buildDepositTx("ondo-usdy", WALLET, "10", addresses, network)
-    ).rejects.toThrow(/No protocol mapping/);
+    ).rejects.toThrow();
   });
 });
 
@@ -170,30 +195,30 @@ describe("buildWithdrawTx", () => {
     );
   });
 
-  it("throws when defindexVault address is empty and vault is defindex", async () => {
-    const noVault = { ...addresses, defindexVault: "" };
+  it("throws for a vault not in KNOWN_POOLS", async () => {
     await expect(
-      buildWithdrawTx("defindex-usdc", WALLET, "5", noVault, network)
-    ).rejects.toThrow(/DeFindex vault not configured/);
+      buildWithdrawTx("defindex-eurc", WALLET, "5", addresses, network)
+    ).rejects.toThrow(/Vault not configured/);
   });
 
   it("throws for an unrecognised vault protocol", async () => {
     await expect(
       buildWithdrawTx("ondo-usdy", WALLET, "5", addresses, network)
-    ).rejects.toThrow(/No protocol mapping/);
+    ).rejects.toThrow();
   });
 });
 
 describe("resolvePositions", () => {
-  it("calls fetchBlendPositions with the correct reserves and returns its result", async () => {
+  it("calls fetchBlendPositions with the pool contract and reserves from KNOWN_POOLS", async () => {
     const positions = await resolvePositions(WALLET, network, addresses);
     expect(fetchBlendPositions).toHaveBeenCalledWith(network, "CPOOL", WALLET, [
       { assetId: "CUSDC", vaultId: "blend-usdc-fixed" },
+      { assetId: "CEURC", vaultId: "blend-eurc-fixed" },
     ]);
     expect(positions).toContainEqual(BLEND_USDC);
   });
 
-  it("appends DeFindex positions when defindexVault is set", async () => {
+  it("fetches DeFindex positions for every DeFindex vault in KNOWN_POOLS", async () => {
     const positions = await resolvePositions(WALLET, network, addresses);
     expect(fetchDefindexPosition).toHaveBeenCalledWith(
       network,
@@ -202,13 +227,6 @@ describe("resolvePositions", () => {
       WALLET
     );
     expect(positions).toContainEqual(DFX_USDC);
-  });
-
-  it("skips DeFindex fetch when defindexVault is empty", async () => {
-    const noVault = { ...addresses, defindexVault: "" };
-    const positions = await resolvePositions(WALLET, network, noVault);
-    expect(fetchDefindexPosition).not.toHaveBeenCalled();
-    expect(positions).toEqual([BLEND_USDC]);
   });
 
   it("returns Blend positions when DeFindex fetch fails", async () => {
@@ -227,7 +245,7 @@ describe("resolvePositions", () => {
     expect(positions).toEqual([DFX_USDC]);
   });
 
-  it("returns empty array when both fetches fail", async () => {
+  it("returns empty array when all fetches fail", async () => {
     vi.mocked(fetchBlendPositions).mockRejectedValueOnce(
       new Error("Blend down")
     );

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -14,39 +14,32 @@ import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
 import { KNOWN_POOLS } from "./known-pools";
 
-function blendPositionEntries(
-  network: StellarNetwork,
-  addresses: ProtocolAddresses
-): Array<{ assetId: string; vaultId: string }> {
-  const pools =
-    network.network === "testnet"
-      ? Object.values(KNOWN_POOLS.testnet)
-      : Object.values(KNOWN_POOLS.mainnet);
-  const seen = new Set<string>();
-  const entries: Array<{ assetId: string; vaultId: string }> = [];
-  for (const pool of pools) {
-    if (pool.protocol !== "blend") continue;
-    const assetKey = blendAssetForVault(pool.id);
-    if (seen.has(assetKey)) continue;
-    seen.add(assetKey);
-    entries.push({ assetId: addresses[assetKey], vaultId: pool.id });
-  }
-  return entries;
-}
-
 export interface ProtocolAddresses {
-  blendPool: string;
   usdc: string;
   eurc: string;
-  defindexVault: string;
-  defindexVaultId: string;
+}
+
+/**
+ * Look up the registry entry for `vaultId` on the given network. Throws if the
+ * vault is unknown or its contract address is not yet configured.
+ */
+function resolveVaultEntry(vaultId: string, network: StellarNetwork) {
+  const pools =
+    network.network === "testnet" ? KNOWN_POOLS.testnet : KNOWN_POOLS.mainnet;
+  const entry = Object.values(pools).find((p) => p.id === vaultId);
+  if (!entry?.contractId) {
+    throw new Error(
+      `Vault not configured: ${vaultId}. Add it to KNOWN_POOLS with a contractId.`
+    );
+  }
+  return { ...entry, contractId: entry.contractId };
 }
 
 /**
  * Build an unsigned deposit transaction for the vault identified by `vaultId`.
- * Routes to Blend or DeFindex based on the vault ID prefix and returns the
- * unsigned XDR and estimated fee. Throws if the vault protocol is unrecognised
- * or the required contract address is not configured.
+ * Routes to the correct protocol by looking up the vault in KNOWN_POOLS. Throws
+ * if the vault is unregistered, its contract is unconfigured, or its protocol
+ * prefix is unrecognised.
  */
 export async function buildDepositTx(
   vaultId: string,
@@ -55,64 +48,20 @@ export async function buildDepositTx(
   addresses: ProtocolAddresses,
   network: StellarNetwork
 ): Promise<{ xdr: string; fee: string }> {
+  const entry = resolveVaultEntry(vaultId, network);
   if (resolveProtocol(vaultId) === "Blend") {
-    const asset = blendAssetForVault(vaultId);
+    const assetKey = blendAssetForVault(vaultId);
     return buildBlendDepositTx(
-      { poolId: addresses.blendPool, assetId: addresses[asset], network },
+      { poolId: entry.contractId, assetId: addresses[assetKey], network },
       walletAddress,
       toStroops(amount)
     );
   }
-  if (!addresses.defindexVault) {
-    throw new Error("DeFindex vault not configured. Set DEFINDEX_VAULT_ID.");
-  }
   return buildDefindexDepositTx(
-    { vaultId: addresses.defindexVault, network },
+    { vaultId: entry.contractId, network },
     walletAddress,
     toStroops(amount)
   );
-}
-
-/**
- * Fetches all positions for `publicKey` across Blend reserves and (optionally)
- * the DeFindex vault. Each source is fetched independently: a failure in one
- * (e.g. RPC timeout, user has no Blend entry) does not suppress positions from
- * the other. Both failures are logged; partial results are returned.
- */
-export async function resolvePositions(
-  publicKey: string,
-  network: StellarNetwork,
-  addresses: ProtocolAddresses
-): Promise<PositionInfo[]> {
-  const [blendResult, dfxResult] = await Promise.allSettled([
-    fetchBlendPositions(
-      network,
-      addresses.blendPool,
-      publicKey,
-      blendPositionEntries(network, addresses)
-    ),
-    addresses.defindexVault
-      ? fetchDefindexPosition(
-          network,
-          addresses.defindexVault,
-          addresses.defindexVaultId,
-          publicKey
-        )
-      : Promise.resolve([]),
-  ]);
-
-  if (blendResult.status === "rejected") {
-    console.error("[positions] Blend fetch failed:", blendResult.reason);
-  }
-  if (dfxResult.status === "rejected") {
-    console.error("[positions] DeFindex fetch failed:", dfxResult.reason);
-  }
-
-  const blendPositions =
-    blendResult.status === "fulfilled" ? blendResult.value : [];
-  const dfxPositions = dfxResult.status === "fulfilled" ? dfxResult.value : [];
-
-  return [...blendPositions, ...dfxPositions];
 }
 
 /**
@@ -128,20 +77,72 @@ export async function buildWithdrawTx(
   addresses: ProtocolAddresses,
   network: StellarNetwork
 ): Promise<{ xdr: string; fee: string }> {
+  const entry = resolveVaultEntry(vaultId, network);
   if (resolveProtocol(vaultId) === "Blend") {
-    const asset = blendAssetForVault(vaultId);
+    const assetKey = blendAssetForVault(vaultId);
     return buildBlendWithdrawTx(
-      { poolId: addresses.blendPool, assetId: addresses[asset], network },
+      { poolId: entry.contractId, assetId: addresses[assetKey], network },
       walletAddress,
       toStroops(shares)
     );
   }
-  if (!addresses.defindexVault) {
-    throw new Error("DeFindex vault not configured. Set DEFINDEX_VAULT_ID.");
-  }
   return buildDefindexWithdrawTx(
-    { vaultId: addresses.defindexVault, network },
+    { vaultId: entry.contractId, network },
     walletAddress,
     toStroops(shares)
   );
+}
+
+/**
+ * Fetches all positions for `publicKey` across every registered vault on the
+ * given network. Blend vaults that share a pool contract are batched into one
+ * RPC call; each DeFindex vault is fetched independently. Failures from any
+ * single source are logged and suppressed so partial results are always returned.
+ */
+export async function resolvePositions(
+  publicKey: string,
+  network: StellarNetwork,
+  addresses: ProtocolAddresses
+): Promise<PositionInfo[]> {
+  const pools = Object.values(
+    network.network === "testnet" ? KNOWN_POOLS.testnet : KNOWN_POOLS.mainnet
+  );
+
+  // Group Blend reserves by pool contract so vaults sharing a pool get one fetch.
+  const blendGroups = new Map<
+    string,
+    Array<{ assetId: string; vaultId: string }>
+  >();
+  for (const pool of pools) {
+    if (pool.protocol !== "blend" || !pool.contractId) continue;
+    const assetKey = blendAssetForVault(pool.id);
+    if (!blendGroups.has(pool.contractId)) blendGroups.set(pool.contractId, []);
+    blendGroups
+      .get(pool.contractId)!
+      .push({ assetId: addresses[assetKey], vaultId: pool.id });
+  }
+
+  const dfxPools = pools.filter(
+    (p): p is typeof p & { contractId: string } =>
+      p.protocol === "defindex" && Boolean(p.contractId)
+  );
+
+  const results = await Promise.allSettled([
+    ...[...blendGroups.entries()].map(([poolId, reserves]) =>
+      fetchBlendPositions(network, poolId, publicKey, reserves)
+    ),
+    ...dfxPools.map((p) =>
+      fetchDefindexPosition(network, p.contractId, p.id, publicKey)
+    ),
+  ]);
+
+  const positions: PositionInfo[] = [];
+  for (const result of results) {
+    if (result.status === "fulfilled") {
+      positions.push(...result.value);
+    } else {
+      console.error("[positions] fetch failed:", result.reason);
+    }
+  }
+  return positions;
 }

--- a/packages/stellar-sdk-helpers/src/vaults.ts
+++ b/packages/stellar-sdk-helpers/src/vaults.ts
@@ -47,9 +47,11 @@ async function fetchTestnetVaults(): Promise<ApiVault[]> {
     passphrase: APP_NETWORK.passphrase,
   };
   const vaults: ApiVault[] = [];
-  for (const meta of Object.values(KNOWN_POOLS.testnet)) {
+  for (const meta of Object.values(KNOWN_POOLS.testnet).filter(
+    (p) => p.protocol === "blend"
+  )) {
     const pool = await withRaceTimeout(
-      () => PoolV2.load(blendNetwork, meta.poolId),
+      () => PoolV2.load(blendNetwork, meta.contractId),
       10_000,
       "Blend RPC"
     );


### PR DESCRIPTION
## Summary

- Moved vault contract address lookup into the SDK: `buildDepositTx`, `buildWithdrawTx`, and `resolvePositions` now resolve pool/vault contracts from `KNOWN_POOLS` by `vaultId` instead of accepting them through `ProtocolAddresses`
- `ProtocolAddresses` now holds only the two asset SAC addresses (`usdc`, `eurc`) that are genuinely network-global; all protocol-specific contract fields (`blendPool`, `defindexVault`, `defindexVaultId`) are removed
- Renamed `poolId` to `contractId` in `TestnetPoolMeta` for protocol-agnostic naming; added optional `contractId` to `KnownPoolMeta` for future mainnet population
- Added the DeFindex testnet vault to `KNOWN_POOLS.testnet` so it is registered alongside the Blend pool
- `resolvePositions` now groups Blend vaults by pool contract (one `fetchBlendPositions` call per unique contract) and iterates every DeFindex vault independently, making both protocol paths scale to multiple pools or vaults without further changes
- `buildTxAddresses` in `@meridian/shared` simplified to a no-argument call returning `{ usdc, eurc }`; all six call sites updated accordingly
- Adding a new protocol requires only: a new entry in `KNOWN_POOLS`, a new builder function in the SDK, and a new dispatch case in `orchestration.ts` - the API layer stays untouched

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] Verified `buildDepositTx` routes Blend and DeFindex vaults to their respective builders with contracts sourced from the registry
- [x] Verified `resolvePositions` groups Blend reserves by pool contract and fetches each DeFindex vault independently
- [x] Verified unregistered vault ID throws a clear `Vault not configured` error naming the missing entry

Closes #281