### PR TITLE
fix(web): detect revoked Freighter site access and clear stale wallet state

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -43,9 +43,15 @@ function Dashboard() {
 }
 
 export default function App() {
-  // Evict a stale persisted wallet if Freighter is no longer available.
   useEffect(() => {
-    void useWalletStore.getState().revalidate();
+    const revalidate = () => void useWalletStore.getState().revalidate();
+    revalidate();
+    // Re-check authorization when the window regains focus. Freighter opens
+    // as an extension popup (separate window), so the page loses focus while
+    // the popup is open and regains it when it closes — this catches revoked
+    // site access without requiring a page reload.
+    window.addEventListener("focus", revalidate);
+    return () => window.removeEventListener("focus", revalidate);
   }, []);
 
   return (

--- a/apps/web/src/__tests__/hooks/useVaultActions.test.ts
+++ b/apps/web/src/__tests__/hooks/useVaultActions.test.ts
@@ -13,6 +13,7 @@ vi.mock("@tanstack/react-query", () => ({
 
 vi.mock("../../lib/wallet", () => ({
   signTransaction: vi.fn(async () => "SIGNED_XDR"),
+  isFreighterAuthorized: vi.fn(async () => true),
 }));
 
 vi.mock("../../lib/api", () => ({

--- a/apps/web/src/__tests__/store/wallet.test.ts
+++ b/apps/web/src/__tests__/store/wallet.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useWalletStore } from "../../store/wallet";
 
 vi.mock("../../lib/wallet", () => ({
-  isFreighterInstalled: vi.fn(),
+  isFreighterAuthorized: vi.fn(),
 }));
 
-import { isFreighterInstalled } from "../../lib/wallet";
+import { isFreighterAuthorized } from "../../lib/wallet";
 
 const KEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
@@ -43,12 +43,12 @@ describe("useWalletStore", () => {
 
   it("revalidate does nothing when no publicKey is set", async () => {
     await useWalletStore.getState().revalidate();
-    expect(isFreighterInstalled).not.toHaveBeenCalled();
+    expect(isFreighterAuthorized).not.toHaveBeenCalled();
   });
 
-  it("revalidate keeps connection when Freighter is still installed", async () => {
+  it("revalidate keeps connection when site is still authorized", async () => {
     useWalletStore.setState({ publicKey: KEY, connected: true });
-    vi.mocked(isFreighterInstalled).mockResolvedValue(true);
+    vi.mocked(isFreighterAuthorized).mockResolvedValue(true);
     await useWalletStore.getState().revalidate();
     expect(useWalletStore.getState()).toMatchObject({
       publicKey: KEY,
@@ -56,9 +56,9 @@ describe("useWalletStore", () => {
     });
   });
 
-  it("revalidate disconnects when Freighter extension is gone", async () => {
+  it("revalidate disconnects when site access was revoked", async () => {
     useWalletStore.setState({ publicKey: KEY, connected: true });
-    vi.mocked(isFreighterInstalled).mockResolvedValue(false);
+    vi.mocked(isFreighterAuthorized).mockResolvedValue(false);
     await useWalletStore.getState().revalidate();
     expect(useWalletStore.getState()).toMatchObject({
       publicKey: null,

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -48,7 +48,7 @@ async function hasBlendUsdcBalance(
 
 export function useVaultActions() {
   const { t } = useTranslation();
-  const { publicKey, network } = useWalletStore();
+  const { publicKey, network, revalidate } = useWalletStore();
   const queryClient = useQueryClient();
   const { push } = useToastStore();
   const [isDepositing, setIsDepositing] = useState(false);
@@ -59,6 +59,10 @@ export function useVaultActions() {
     STELLAR_NETWORKS[network as keyof typeof STELLAR_NETWORKS]?.passphrase;
 
   async function signAndSubmit(xdr: string) {
+    await revalidate();
+    if (!useWalletStore.getState().connected) {
+      throw new Error(t("walletConnect.walletDisconnected"));
+    }
     const signedXdr = await signTransaction(xdr, passphrase);
     await api.submitTx({ xdr: signedXdr });
   }

--- a/apps/web/src/lib/wallet.ts
+++ b/apps/web/src/lib/wallet.ts
@@ -1,5 +1,6 @@
 import {
   isConnected,
+  isAllowed,
   requestAccess,
   signTransaction as freighterSign,
 } from "@stellar/freighter-api";
@@ -7,6 +8,15 @@ import {
 export async function isFreighterInstalled(): Promise<boolean> {
   const result = await isConnected();
   return result.isConnected;
+}
+
+// Checks whether the user has granted this site access in Freighter.
+// Returns false if the extension is absent or the site permission was revoked.
+export async function isFreighterAuthorized(): Promise<boolean> {
+  const installed = await isFreighterInstalled();
+  if (!installed) return false;
+  const result = await isAllowed();
+  return result.isAllowed;
 }
 
 export async function connectFreighter(): Promise<string> {

--- a/apps/web/src/store/wallet.ts
+++ b/apps/web/src/store/wallet.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { WalletState } from "../types";
-import { isFreighterInstalled } from "../lib/wallet";
+import { isFreighterAuthorized } from "../lib/wallet";
 
 interface WalletStore extends WalletState {
   connect: (publicKey: string) => void;
@@ -21,12 +21,12 @@ export const useWalletStore = create<WalletStore>()(
       disconnect: () => set({ publicKey: null, connected: false }),
       setNetwork: (network) => set({ network }),
 
-      // Re-check the persisted key against Freighter. If the extension is gone
-      // or access was revoked between sessions, drop the stale connection.
+      // Re-check the persisted key against Freighter. Clears stale state when
+      // the extension is gone or the user revoked site access between sessions.
       revalidate: async () => {
         if (!get().publicKey) return;
-        const installed = await isFreighterInstalled();
-        if (!installed) set({ publicKey: null, connected: false });
+        const authorized = await isFreighterAuthorized();
+        if (!authorized) set({ publicKey: null, connected: false });
       },
     }),
     {


### PR DESCRIPTION
## Summary

- `revalidate()` now calls `isAllowed()` from `@stellar/freighter-api` instead of `isConnected()`. The old check only detected a missing extension; the new one detects revoked site permissions, which is the actual failure mode when a user disconnects via the Freighter popup.
- A `focus` listener on the window re-runs `revalidate()` whenever the page regains focus. Freighter opens as an extension popup (a separate browser window), so the page loses focus while it is open and regains it when it closes - this catches revoked access without requiring a page reload.
- `signAndSubmit` in `useVaultActions` calls `revalidate()` before touching Freighter. If the wallet is stale (e.g. focus listener missed the popup close), it throws `"Wallet Disconnected"` with a legible toast rather than a cryptic Freighter API error.
- Updated `wallet.test.ts` to mock `isFreighterAuthorized` instead of `isFreighterInstalled` and renamed the `revalidate` test cases to reflect what is actually being checked.

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [ ] Connect Freighter, then revoke site access from the Freighter extension popup - app resets to disconnected state on window focus without a page reload.
- [ ] With a stale connection in cache (`publicKey` in localStorage but access revoked), refresh the page - app shows disconnected immediately on mount.
- [ ] Attempting a deposit with a stale connection shows a "Wallet Disconnected" toast rather than a Freighter API error.

Closes #327
