### PR TITLE
chore: derive APP_NETWORK from STELLAR_NETWORK environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # API
 PORT=3001
 ALLOWED_ORIGIN=http://localhost:3000
+STELLAR_NETWORK=testnet
 
 # DeFindex vault contract address (C-address). Leave empty to disable DeFindex — only Blend positions are returned.
 DEFINDEX_VAULT_ID=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,7 @@ npm install -g pnpm@9
    | ------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
    | `PORT`              | API          | Port for the Fastify API server. Default `3001`.                                                                 |
    | `ALLOWED_ORIGIN`    | API          | CORS allowed origin. Default `http://localhost:3000`.                                                            |
+   | `STELLAR_NETWORK`   | API, SDK     | Target network: `testnet` or `mainnet`. Default `testnet`.                                                       |
    | `DEFINDEX_VAULT_ID` | API          | DeFindex vault contract address (C-address). Leave empty to disable DeFindex; only Blend positions are returned. |
    | `VITE_API_URL`      | Web          | URL the web app uses to reach the API. Default `http://localhost:3001`.                                          |
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -69,9 +69,12 @@ export const STELLAR_NETWORKS = {
   },
 };
 
-// Convenience aliases. Both API layers (Vercel + Fastify) target testnet today.
-export const APP_NETWORK = STELLAR_NETWORKS.testnet;
-export const APP_ADDRESSES = CONTRACT_ADDRESSES.testnet;
+const _networkKey = (
+  process.env.STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet"
+) satisfies keyof typeof STELLAR_NETWORKS;
+
+export const APP_NETWORK = STELLAR_NETWORKS[_networkKey];
+export const APP_ADDRESSES = CONTRACT_ADDRESSES[_networkKey];
 
 export function isDefindexConfigured(): boolean {
   return Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault);


### PR DESCRIPTION
## Summary

- `APP_NETWORK` and `APP_ADDRESSES` in `packages/shared/src/constants.ts` were hardcoded to `testnet`. Promoting to mainnet required a source change and a redeploy. They now read from `process.env.STELLAR_NETWORK`, defaulting to `testnet` when the variable is absent or set to any value other than `mainnet`.
- Added `STELLAR_NETWORK=testnet` to `.env.example`.
- Added `STELLAR_NETWORK` to the environment variable table in `CONTRIBUTING.md`.

## Test plan

- [ ] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [ ] Setting `STELLAR_NETWORK=mainnet` causes `APP_NETWORK` to resolve to the mainnet RPC and passphrase

Closes #339