### PR TITLE
fix: log and surface repeated post-withdraw sync failures

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -37,7 +37,8 @@
     "assetsAdded": "Vault assets added to wallet",
     "withdrawalFailed": "Withdrawal failed",
     "withdrew": "Withdrew",
-    "deposited": "Deposited"
+    "deposited": "Deposited",
+    "syncDelayed": "Position sync is delayed. Your withdrawal succeeded, but the displayed balance may be stale."
   },
 
   "common": {

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -37,7 +37,8 @@
     "assetsAdded": "Actifs du coffre ajoutés au portefeuille",
     "withdrawalFailed": "Échec du retrait",
     "withdrew": "Retiré",
-    "deposited": "Déposé"
+    "deposited": "Déposé",
+    "syncDelayed": "La synchronisation de la position est retardée. Votre retrait a réussi, mais le solde affiché peut être obsolète."
   },
 
   "common": {

--- a/apps/web/src/__tests__/hooks/useVaultActions.test.ts
+++ b/apps/web/src/__tests__/hooks/useVaultActions.test.ts
@@ -22,6 +22,7 @@ vi.mock("../../lib/api", () => ({
     buildDeposit: vi.fn(async () => ({ xdr: "DEPOSIT_XDR" })),
     buildWithdraw: vi.fn(async () => ({ xdr: "WITHDRAW_XDR" })),
     submitTx: vi.fn(async () => ({ hash: "TX_HASH" })),
+    getPositions: vi.fn(async () => ({ positions: [] })),
   },
 }));
 
@@ -33,6 +34,8 @@ vi.mock("react-i18next", () => {
     "vaultActions.depositFailed": "Deposit failed",
     "vaultActions.withdrawalFailed": "Withdrawal failed",
     "vaultActions.failedAssets": "Failed to add vault assets",
+    "vaultActions.syncDelayed":
+      "Position sync is delayed. Your withdrawal succeeded, but the displayed balance may be stale.",
   };
 
   return {
@@ -181,5 +184,39 @@ describe("useVaultActions — withdraw", () => {
 
     expect(ok).toBe(false);
     expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "error" });
+  });
+
+  it("logs and surfaces a toast after repeated post-withdraw sync failures", async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.mocked(api.getPositions).mockRejectedValue(new Error("RPC down"));
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.withdraw("5", "blend-usdc-fixed", "USDC");
+    });
+
+    // syncWhenReady polls every 3 s; three consecutive failures triggers the toast.
+    for (let i = 0; i < 3; i++) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+      });
+    }
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[syncWhenReady] poll failed:",
+      expect.any(Error)
+    );
+    expect(useToastStore.getState().toasts).toContainEqual(
+      expect.objectContaining({
+        kind: "error",
+        message:
+          "Position sync is delayed. Your withdrawal succeeded, but the displayed balance may be stale.",
+      })
+    );
+
+    warnSpy.mockRestore();
+    vi.useRealTimers();
   });
 });

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -199,10 +199,12 @@ export function useVaultActions() {
       // the real data into the cache. Give up after 30 s.
       const key = publicKey;
       const startedAt = Date.now();
+      let consecutiveFailures = 0;
       const syncWhenReady = async (): Promise<void> => {
         if (Date.now() - startedAt > 30_000) return;
         try {
           const data = await api.getPositions(key);
+          consecutiveFailures = 0;
           const live =
             data.positions.find((p) => p.vaultId === vaultId) ??
             data.positions[0];
@@ -210,8 +212,12 @@ export function useVaultActions() {
             queryClient.setQueryData(["positions", key], data.positions);
             return;
           }
-        } catch {
-          // network error — retry next tick
+        } catch (err) {
+          consecutiveFailures += 1;
+          console.warn("[syncWhenReady] poll failed:", err);
+          if (consecutiveFailures === 3) {
+            push("error", t("vaultActions.syncDelayed"));
+          }
         }
         setTimeout(() => void syncWhenReady(), 3_000);
       };


### PR DESCRIPTION
## Summary

- `syncWhenReady` in `useVaultActions.ts` silently swallowed every polling error with an empty `catch {}`, giving no signal when the post-withdraw position sync failed repeatedly.
- Failures are now logged with `console.warn`, and after 3 consecutive failures an error toast informs the user the displayed balance may be stale.
- Added `vaultActions.syncDelayed` translation keys (en, fr) and a unit test covering the repeated-failure path.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] New test verifies `console.warn` is called and the toast appears after 3 consecutive `getPositions` failures

Closes #340