### PR TITLE
fix(contracts): regroup digits to fix clippy inconsistent grouping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,9 +87,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: packages/contracts
+      - name: Run clippy
+        working-directory: packages/contracts
+        run: cargo clippy --all-targets -- -D warnings
       - name: Run contract tests
         working-directory: packages/contracts
         run: cargo test

--- a/packages/contracts/router/src/lib.rs
+++ b/packages/contracts/router/src/lib.rs
@@ -78,7 +78,7 @@ mod tests {
         let user = Address::generate(&env);
 
         let usdc_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
-        StellarAssetClient::new(&env, &usdc_id).mint(&user, &1_000_0000000_i128);
+        StellarAssetClient::new(&env, &usdc_id).mint(&user, &10_000_000_000_i128);
 
         let musdc_a_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let vault_a_id = env.register(MeridianVault, ());
@@ -123,7 +123,7 @@ mod tests {
         let user = Address::generate(&env);
 
         let usdc_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
-        StellarAssetClient::new(&env, &usdc_id).mint(&user, &1_000_0000000_i128);
+        StellarAssetClient::new(&env, &usdc_id).mint(&user, &10_000_000_000_i128);
 
         let musdc_a_id = env.register_stellar_asset_contract_v2(admin.clone()).address();
         let vault_a_id = env.register(MeridianVault, ());

--- a/packages/contracts/vault/src/lib.rs
+++ b/packages/contracts/vault/src/lib.rs
@@ -329,7 +329,7 @@ mod tests {
         StellarAssetClient::new(&env, &musdc_id).set_admin(&vault_id);
 
         // Fund the user with 1000 USDC (7 decimal places: 1000 * 10^7).
-        StellarAssetClient::new(&env, &usdc_id).mint(&user, &1_000_0000000_i128);
+        StellarAssetClient::new(&env, &usdc_id).mint(&user, &10_000_000_000_i128);
 
         (env, admin, user, usdc_id, musdc_id, vault)
     }
@@ -364,7 +364,7 @@ mod tests {
 
         // User should have their USDC back.
         let user_balance = TokenClient::new(&env, &usdc_id).balance(&user);
-        assert_eq!(user_balance, 1_000_0000000_i128);
+        assert_eq!(user_balance, 10_000_000_000_i128);
     }
 
     #[test]
@@ -443,7 +443,7 @@ mod tests {
         // A second user deposits 100 USDC — should receive fewer shares
         // because the share price has risen.
         let user2 = Address::generate(&env);
-        StellarAssetClient::new(&env, &usdc_id).mint(&user2, &1_000_0000000_i128);
+        StellarAssetClient::new(&env, &usdc_id).mint(&user2, &10_000_000_000_i128);
         let shares2 = vault.deposit(&user2, &amount, &Protocol::Blend);
 
         // 100 shares outstanding, vault has 110 USDC.


### PR DESCRIPTION
## Summary

- Fixed `clippy::inconsistent_digit_grouping` in `vault/src/lib.rs` (3 sites) and `router/src/lib.rs` (2 sites): `1_000_0000000_i128` mixed a thousands-grouping style with a decimal-place-grouping style in the same literal, which clippy flags. Regrouped to `10_000_000_000_i128` (consistent thousands grouping) with no change in value (both represent 1000 USDC at 7 decimal places).
- Added a `cargo clippy --all-targets -- -D warnings` step to the `contracts` CI job so this class of regression is caught automatically going forward, since the lint isn't run anywhere in CI today.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` in `packages/contracts` passes cleanly, both per-crate and for the whole workspace
- [x] `cargo test` in `packages/contracts` passes: 18 vault tests + 2 router tests, all green, no value changes

Closes #346