### PR TITLE
fix(web): validate faucet XDR and env-configure the faucet URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ PORT=3001
 ALLOWED_ORIGIN=http://localhost:3000
 STELLAR_NETWORK=testnet
 
-# DeFindex vault contract address (C-address). Leave empty to disable DeFindex — only Blend positions are returned.
+# DeFindex vault contract address (C-address). Leave empty to disable DeFindex; only Blend positions are returned.
 DEFINDEX_VAULT_ID=
 
 # Upstash Redis (required in production for distributed rate limiting).
@@ -16,3 +16,5 @@ REDIS_URL=
 
 # Web
 VITE_API_URL=http://localhost:3001
+# Optional override for Blend's testnet faucet endpoint. Leave empty to use the default.
+VITE_BLEND_FAUCET_URL=

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,13 +122,14 @@ npm install -g pnpm@9
 
    Edit `.env` and set the values you need:
 
-   | Variable            | Required for | Description                                                                                                      |
-   | ------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
-   | `PORT`              | API          | Port for the Fastify API server. Default `3001`.                                                                 |
-   | `ALLOWED_ORIGIN`    | API          | CORS allowed origin. Default `http://localhost:3000`.                                                            |
-   | `STELLAR_NETWORK`   | API, SDK     | Target network: `testnet` or `mainnet`. Default `testnet`.                                                       |
-   | `DEFINDEX_VAULT_ID` | API          | DeFindex vault contract address (C-address). Leave empty to disable DeFindex; only Blend positions are returned. |
-   | `VITE_API_URL`      | Web          | URL the web app uses to reach the API. Default `http://localhost:3001`.                                          |
+   | Variable                | Required for | Description                                                                                                      |
+   | ----------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------- |
+   | `PORT`                  | API          | Port for the Fastify API server. Default `3001`.                                                                 |
+   | `ALLOWED_ORIGIN`        | API          | CORS allowed origin. Default `http://localhost:3000`.                                                            |
+   | `STELLAR_NETWORK`       | API, SDK     | Target network: `testnet` or `mainnet`. Default `testnet`.                                                       |
+   | `DEFINDEX_VAULT_ID`     | API          | DeFindex vault contract address (C-address). Leave empty to disable DeFindex; only Blend positions are returned. |
+   | `VITE_API_URL`          | Web          | URL the web app uses to reach the API. Default `http://localhost:3001`.                                          |
+   | `VITE_BLEND_FAUCET_URL` | Web          | Overrides Blend's testnet faucet endpoint. Leave empty to use the default.                                       |
 
 6. Start the development servers:
 

--- a/apps/web/src/__tests__/hooks/useVaultActions.test.ts
+++ b/apps/web/src/__tests__/hooks/useVaultActions.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import {
+  Account,
+  Asset,
+  Operation,
+  TransactionBuilder,
+} from "@stellar/stellar-sdk";
 import { useVaultActions } from "../../hooks/useVaultActions";
 import { useWalletStore } from "../../store/wallet";
 import { useToastStore } from "../../store/toast";
@@ -51,6 +57,24 @@ const KEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 // Matches USDC_ISSUER.testnet in @meridian/shared (Blend TestnetV2 issuer).
 const BLEND_TESTNET_USDC_ISSUER =
   "GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56";
+const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+
+function zeroBalanceHorizonResponse() {
+  return new Response(JSON.stringify({ balances: [] }), { status: 200 });
+}
+
+function faucetTextResponse(op: ReturnType<typeof Operation.payment>) {
+  const account = new Account(KEY, "0");
+  const xdr = new TransactionBuilder(account, {
+    fee: "100",
+    networkPassphrase: TESTNET_PASSPHRASE,
+  })
+    .addOperation(op)
+    .setTimeout(30)
+    .build()
+    .toXDR();
+  return new Response(xdr, { status: 200 });
+}
 
 beforeEach(() => {
   useWalletStore.setState({
@@ -145,6 +169,65 @@ describe("useVaultActions — deposit", () => {
 
     expect(ok).toBe(false);
     expect(api.buildDeposit).not.toHaveBeenCalled();
+  });
+
+  it("signs a faucet transaction that credits the caller's own address", async () => {
+    const legitimate = faucetTextResponse(
+      Operation.payment({
+        destination: KEY,
+        asset: new Asset("USDC", BLEND_TESTNET_USDC_ISSUER),
+        amount: "1000",
+      })
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(zeroBalanceHorizonResponse())
+        .mockResolvedValueOnce(legitimate)
+    );
+    const { result } = renderHook(() => useVaultActions());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deposit("10", "blend-usdc-fixed", "USDC");
+    });
+
+    expect(ok).toBe(true);
+    // Once to sign the faucet grant, once to sign the deposit itself.
+    expect(signTransaction).toHaveBeenCalledTimes(2);
+    expect(api.buildDeposit).toHaveBeenCalled();
+  });
+
+  it("rejects a faucet transaction that pays out to someone else", async () => {
+    const attacker = "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3";
+    const malicious = faucetTextResponse(
+      Operation.payment({
+        destination: attacker,
+        asset: new Asset("USDC", BLEND_TESTNET_USDC_ISSUER),
+        amount: "1000",
+      })
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(zeroBalanceHorizonResponse())
+        .mockResolvedValueOnce(malicious)
+    );
+    const { result } = renderHook(() => useVaultActions());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deposit("10", "blend-usdc-fixed", "USDC");
+    });
+
+    expect(ok).toBe(false);
+    expect(signTransaction).not.toHaveBeenCalled();
+    expect(api.buildDeposit).not.toHaveBeenCalled();
+    expect(useToastStore.getState().toasts).toContainEqual(
+      expect.objectContaining({ kind: "error" })
+    );
   });
 });
 

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -1,13 +1,17 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { STELLAR_NETWORKS, APP_NETWORK, USDC_ISSUER } from "@meridian/shared";
+import { assertFaucetPayment } from "@meridian/stellar-sdk-helpers";
 import { useWalletStore } from "../store/wallet";
 import { signTransaction } from "../lib/wallet";
 import { api, type ApiPosition } from "../lib/api";
 import { useToastStore } from "../store/toast";
 import { useTranslation } from "react-i18next";
 
+// Configurable so the faucet can be rotated or disabled without a code
+// deploy; falls back to Blend's public testnet faucet.
 const BLEND_FAUCET_URL =
+  import.meta.env.VITE_BLEND_FAUCET_URL ??
   "https://ewqw4hx7oa.execute-api.us-east-1.amazonaws.com/getAssets";
 
 function isMissingTrustline(msg: string) {
@@ -86,6 +90,10 @@ export function useVaultActions() {
 
   // Calls Blend's testnet faucet to fund the wallet with test USDC before the
   // first deposit. Only triggered on testnet when the user has no USDC balance.
+  // The faucet is a third-party endpoint outside Meridian's control, so the
+  // returned transaction is validated before it is ever shown to Freighter:
+  // every operation must credit the caller's own address in a known asset,
+  // never debit it or touch anything else.
   async function fundFromBlendFaucet(): Promise<boolean> {
     if (!publicKey || !passphrase) return false;
     try {
@@ -93,6 +101,7 @@ export function useVaultActions() {
       const res = await fetch(`${BLEND_FAUCET_URL}?userId=${publicKey}`);
       if (!res.ok) throw new Error(`Blend faucet returned ${res.status}`);
       const xdr = await res.text();
+      assertFaucetPayment(xdr, passphrase, network, publicKey);
       await signAndSubmit(xdr);
       push("success", "Testnet wallet funded");
       return true;

--- a/packages/stellar-sdk-helpers/src/tx.test.ts
+++ b/packages/stellar-sdk-helpers/src/tx.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { rpc, Horizon } from "@stellar/stellar-sdk";
+import {
+  rpc,
+  Horizon,
+  Account,
+  Asset,
+  Operation,
+  TransactionBuilder,
+  xdr,
+} from "@stellar/stellar-sdk";
 import {
   toStroops,
   resolveProtocol,
@@ -7,6 +15,7 @@ import {
   simErrorMessage,
   buildAddTrustlineTx,
   simulateView,
+  assertFaucetPayment,
 } from "./tx";
 import type { StellarNetwork } from "./types";
 
@@ -219,5 +228,103 @@ describe("waitForTransaction", () => {
         timeoutMs: 10_000,
       })
     ).rejects.toThrow(/Timed out/);
+  });
+});
+
+describe("assertFaucetPayment", () => {
+  const USER = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+  // Circle's mainnet USDC issuer: a validly-formed address that is not the
+  // testnet USDC/mUSDC issuer.
+  const UNKNOWN_ISSUER =
+    "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+
+  function buildTx(op: xdr.Operation, source = USER) {
+    const account = new Account(source, "0");
+    return new TransactionBuilder(account, {
+      fee: "100",
+      networkPassphrase: TESTNET.passphrase,
+    })
+      .addOperation(op)
+      .setTimeout(30)
+      .build()
+      .toXDR();
+  }
+
+  it("allows a payment crediting the caller in the known USDC asset", () => {
+    const xdr = buildTx(
+      Operation.payment({
+        destination: USER,
+        asset: new Asset("USDC", USDC_ISSUER_TESTNET),
+        amount: "100",
+      })
+    );
+    expect(() =>
+      assertFaucetPayment(xdr, TESTNET.passphrase, "testnet", USER)
+    ).not.toThrow();
+  });
+
+  it("allows a changeTrust to the known USDC or mUSDC issuer", () => {
+    const xdr = buildTx(
+      Operation.changeTrust({ asset: new Asset("USDC", USDC_ISSUER_TESTNET) })
+    );
+    expect(() =>
+      assertFaucetPayment(xdr, TESTNET.passphrase, "testnet", USER)
+    ).not.toThrow();
+  });
+
+  it("rejects a payment to an address other than the caller", () => {
+    const attacker = "GDQNY3PBOJOKYZSRMK2S7LHHGWZIUISD4QORETLMXEWXBI7KFZZMKTL3";
+    const xdr = buildTx(
+      Operation.payment({
+        destination: attacker,
+        asset: new Asset("USDC", USDC_ISSUER_TESTNET),
+        amount: "100",
+      })
+    );
+    expect(() =>
+      assertFaucetPayment(xdr, TESTNET.passphrase, "testnet", USER)
+    ).toThrow(/unexpected address/);
+  });
+
+  it("rejects a payment in an unrecognised asset", () => {
+    const xdr = buildTx(
+      Operation.payment({
+        destination: USER,
+        asset: new Asset("USDC", UNKNOWN_ISSUER),
+        amount: "100",
+      })
+    );
+    expect(() =>
+      assertFaucetPayment(xdr, TESTNET.passphrase, "testnet", USER)
+    ).toThrow(/unrecognised asset/);
+  });
+
+  it("rejects a payment above the amount ceiling", () => {
+    const xdr = buildTx(
+      Operation.payment({
+        destination: USER,
+        asset: new Asset("USDC", USDC_ISSUER_TESTNET),
+        amount: "1000000",
+      })
+    );
+    expect(() =>
+      assertFaucetPayment(xdr, TESTNET.passphrase, "testnet", USER)
+    ).toThrow(/unexpectedly large amount/);
+  });
+
+  it("rejects a changeTrust to an unrecognised issuer", () => {
+    const xdr = buildTx(
+      Operation.changeTrust({ asset: new Asset("USDC", UNKNOWN_ISSUER) })
+    );
+    expect(() =>
+      assertFaucetPayment(xdr, TESTNET.passphrase, "testnet", USER)
+    ).toThrow(/unrecognised issuer/);
+  });
+
+  it("rejects a disallowed operation type", () => {
+    const xdr = buildTx(Operation.setOptions({ homeDomain: "evil.example" }));
+    expect(() =>
+      assertFaucetPayment(xdr, TESTNET.passphrase, "testnet", USER)
+    ).toThrow(/disallowed operation type/);
   });
 });

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -2,6 +2,7 @@ import {
   Account,
   Contract,
   TransactionBuilder,
+  Transaction,
   Asset,
   Horizon,
   Operation,
@@ -305,4 +306,70 @@ export async function submitTx(
   // mempool under this hash, so wait for the ledger to record its outcome.
   const confirmed = await waitForTransaction(server, sent.hash, opts);
   return { hash: sent.hash, status: "SUCCESS", ledger: confirmed.ledger };
+}
+
+// A faucet grant well above anything a real testnet request would need.
+// Bounds the payment amount as a defence-in-depth check; the operation-type
+// and destination checks below are what actually stop an unrelated transaction.
+const FAUCET_MAX_AMOUNT = 100_000;
+
+/**
+ * Validates a transaction returned by a third-party testnet faucet before it
+ * is handed to the wallet for signing. The faucet is an HTTP endpoint outside
+ * Meridian's control; without this check, a compromised or rotated URL could
+ * return an arbitrary transaction and the caller would sign it blind. Every
+ * operation must either be a `payment` crediting `expectedPublicKey` in the
+ * known USDC asset within a sane amount, or a `changeTrust` to the known
+ * USDC/mUSDC issuer. Anything else throws before the caller ever sees it.
+ */
+export function assertFaucetPayment(
+  faucetXdr: string,
+  passphrase: string,
+  networkKey: string,
+  expectedPublicKey: string
+): Transaction {
+  const tx = TransactionBuilder.fromXDR(faucetXdr, passphrase);
+  if (!(tx instanceof Transaction)) {
+    throw new Error("Faucet response is not a supported transaction type");
+  }
+  if (tx.operations.length === 0) {
+    throw new Error("Faucet response has no operations");
+  }
+
+  const usdcIssuer = USDC_ISSUER[networkKey];
+  const musdcIssuer = MUSDC_ISSUER[networkKey];
+
+  for (const op of tx.operations) {
+    if (op.type === "payment") {
+      if (op.destination !== expectedPublicKey) {
+        throw new Error("Faucet response sends funds to an unexpected address");
+      }
+      if (op.asset.isNative() || op.asset.getIssuer() !== usdcIssuer) {
+        throw new Error("Faucet response funds an unrecognised asset");
+      }
+      if (Number(op.amount) > FAUCET_MAX_AMOUNT) {
+        throw new Error(
+          "Faucet response requests an unexpectedly large amount"
+        );
+      }
+    } else if (op.type === "changeTrust") {
+      if (!(op.line instanceof Asset)) {
+        throw new Error(
+          "Faucet response establishes an unrecognised trustline"
+        );
+      }
+      const issuer = op.line.getIssuer();
+      if (issuer !== usdcIssuer && issuer !== musdcIssuer) {
+        throw new Error(
+          "Faucet response establishes a trustline to an unrecognised issuer"
+        );
+      }
+    } else {
+      throw new Error(
+        `Faucet response contains a disallowed operation type: ${op.type}`
+      );
+    }
+  }
+
+  return tx;
 }

--- a/packages/stellar-sdk-helpers/tsconfig.json
+++ b/packages/stellar-sdk-helpers/tsconfig.json
@@ -3,10 +3,8 @@
   "compilerOptions": {
     "lib": ["ES2020", "DOM"],
     "outDir": "dist",
-    "declaration": true,
-    "paths": {
-      "@meridian/shared": ["../shared/src"]
-    }
+    "rootDir": "src",
+    "declaration": true
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts"]


### PR DESCRIPTION
## Summary

- `BLEND_FAUCET_URL` is now overridable via `VITE_BLEND_FAUCET_URL`, falling back to the current hardcoded endpoint. Documented in `.env.example` and `CONTRIBUTING.md`.
- Added `assertFaucetPayment` to `packages/stellar-sdk-helpers/src/tx.ts`, called from `fundFromBlendFaucet` in `useVaultActions.ts` right after the faucet response is fetched and before it is ever handed to Freighter. Every operation in the returned transaction must be either a `payment` crediting the caller's own address in the known testnet USDC asset within a bounded amount, or a `changeTrust` to the known USDC/mUSDC issuer. Anything else (wrong destination, wrong asset, oversized amount, a disallowed operation type, an empty transaction, a fee-bump transaction) throws before the wallet is ever shown a signing prompt.
- Added 6 unit tests for `assertFaucetPayment` in `tx.test.ts` and 2 integration-level tests in `useVaultActions.test.ts` that drive the whole `deposit()` flow through the faucet path with a hand-built XDR: one where the faucet legitimately credits the caller (deposit proceeds, `signTransaction` called twice), one where it pays a different address (deposit aborts before any signature is requested, error toast shown).
- Fixed `packages/stellar-sdk-helpers/tsconfig.json`: it had a stray `paths` override pointing `@meridian/shared` at that package's raw `src`, which pulled shared's source files into this package's own `tsc` compilation and produced a nested, broken `dist/stellar-sdk-helpers/src/...` output missing several exports (including the new `assertFaucetPayment`) instead of a flat `dist/*.js`. This had gone unnoticed because `apps/web` previously only ever imported types from this package, and type-only imports don't touch the compiled output; `assertFaucetPayment` is the first *runtime* import from `apps/web`, which is what surfaced it. Removed the redundant `paths` override and added `rootDir: "src"` so `tsc` now emits a correct, flat `dist/` (workspace resolution already reaches `@meridian/shared`'s own `dist` without the override).

Note: `apps/api/tsconfig.json` has the identical `paths` override and, unlike `apps/web`, `apps/api` does emit and run its own `dist/index.js` in production. I have not verified whether it hits the same bug live; opening a separate follow-up issue for that rather than folding an unrelated app's build config into this PR.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `pnpm coverage` passes with all configured thresholds; both touched packages' coverage improved
- [x] New tests confirm a faucet response that credits the caller proceeds through signing and deposit, and a faucet response that pays a different address is rejected before any signature prompt
- [x] Confirmed the `stellar-sdk-helpers` package now builds a flat, correct `dist/` with `assertFaucetPayment` present (previously produced a nested, incomplete output)

Closes #334