### PR TITLE
chore: remove dead _addresses parameter from orchestration functions

### DIFF
--- a/api/v1/positions/[publicKey].ts
+++ b/api/v1/positions/[publicKey].ts
@@ -1,10 +1,6 @@
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 import { resolvePositions } from "@meridian/stellar-sdk-helpers";
-import {
-  APP_NETWORK,
-  buildTxAddresses,
-  isValidStellarAddress,
-} from "@meridian/shared";
+import { APP_NETWORK, isValidStellarAddress } from "@meridian/shared";
 import { applyCors, checkRateLimit } from "../../_lib/middleware.js";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -17,11 +13,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   }
 
   try {
-    const positions = await resolvePositions(
-      publicKey,
-      APP_NETWORK,
-      buildTxAddresses()
-    );
+    const positions = await resolvePositions(publicKey, APP_NETWORK);
     res.json({ positions });
   } catch (err) {
     console.error("[positions] error:", err);

--- a/api/v1/tx/deposit.ts
+++ b/api/v1/tx/deposit.ts
@@ -2,7 +2,6 @@
 import { buildDepositTx } from "@meridian/stellar-sdk-helpers";
 import {
   APP_NETWORK,
-  buildTxAddresses,
   DepositRequestSchema,
   formatZodError,
   sanitizeTxError,
@@ -25,7 +24,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       vaultId,
       walletAddress,
       amount,
-      buildTxAddresses(),
       APP_NETWORK
     );
     return res.json(result);

--- a/api/v1/tx/withdraw.ts
+++ b/api/v1/tx/withdraw.ts
@@ -2,7 +2,6 @@
 import { buildWithdrawTx } from "@meridian/stellar-sdk-helpers";
 import {
   APP_NETWORK,
-  buildTxAddresses,
   WithdrawRequestSchema,
   formatZodError,
   sanitizeTxError,
@@ -25,7 +24,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       vaultId,
       walletAddress,
       shares,
-      buildTxAddresses(),
       APP_NETWORK
     );
     return res.json(result);

--- a/apps/api/src/routes/positions.ts
+++ b/apps/api/src/routes/positions.ts
@@ -1,9 +1,5 @@
 import type { FastifyPluginAsync } from "fastify";
-import {
-  APP_NETWORK,
-  buildTxAddresses,
-  isValidStellarAddress,
-} from "@meridian/shared";
+import { APP_NETWORK, isValidStellarAddress } from "@meridian/shared";
 import { resolvePositions } from "@meridian/stellar-sdk-helpers";
 
 export const positionsRoute: FastifyPluginAsync = async (app) => {
@@ -15,11 +11,7 @@ export const positionsRoute: FastifyPluginAsync = async (app) => {
     }
 
     try {
-      const positions = await resolvePositions(
-        publicKey,
-        APP_NETWORK,
-        buildTxAddresses()
-      );
+      const positions = await resolvePositions(publicKey, APP_NETWORK);
       reply.send({ positions });
     } catch (err) {
       app.log.error(err, "[positions] read failed");

--- a/apps/api/src/routes/tx.ts
+++ b/apps/api/src/routes/tx.ts
@@ -1,7 +1,6 @@
 import type { FastifyPluginAsync } from "fastify";
 import {
   APP_NETWORK,
-  buildTxAddresses,
   DepositRequestSchema,
   WithdrawRequestSchema,
   TrustlineRequestSchema,
@@ -31,7 +30,6 @@ export const txRoute: FastifyPluginAsync = async (app) => {
           vaultId,
           walletAddress,
           amount,
-          buildTxAddresses(),
           APP_NETWORK
         );
         reply.send(result);
@@ -58,7 +56,6 @@ export const txRoute: FastifyPluginAsync = async (app) => {
           vaultId,
           walletAddress,
           shares,
-          buildTxAddresses(),
           APP_NETWORK
         );
         reply.send(result);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -79,12 +79,3 @@ export const APP_ADDRESSES = CONTRACT_ADDRESSES[_networkKey];
 export function isDefindexConfigured(): boolean {
   return Boolean(process.env.DEFINDEX_VAULT_ID ?? APP_ADDRESSES.defindex.vault);
 }
-
-/** Build the asset SAC addresses consumed by stellar-sdk-helpers. Protocol
- *  contract addresses are resolved from KNOWN_POOLS inside the SDK by vault ID. */
-export function buildTxAddresses() {
-  return {
-    usdc: APP_ADDRESSES.usdc,
-    eurc: APP_ADDRESSES.eurc,
-  };
-}

--- a/packages/stellar-sdk-helpers/src/orchestration.test.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.test.ts
@@ -3,7 +3,6 @@ import {
   buildDepositTx,
   buildWithdrawTx,
   resolvePositions,
-  type ProtocolAddresses,
 } from "./orchestration";
 import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
@@ -77,24 +76,13 @@ const network: StellarNetwork = {
   passphrase: "Test SDF Network ; September 2015",
 };
 
-const addresses: ProtocolAddresses = {
-  usdc: "CAQCFVLOBK5GIULPNZRGATJJMIZL5BSP7X5YJVMGCPTUEPFM4AVSRCJU",
-  eurc: "CCUUDM434BMZMYWYDITHFXHDMIVTGGD6T2I5UKNX5BSLXLW7HVR4MCGZ",
-};
-
 const WALLET = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
 
 beforeEach(() => vi.clearAllMocks());
 
 describe("buildDepositTx", () => {
   it("routes a meridian vault deposit through buildCoordinatorDepositTx", async () => {
-    const result = await buildDepositTx(
-      "meridian-usdc",
-      WALLET,
-      "10",
-      addresses,
-      network
-    );
+    const result = await buildDepositTx("meridian-usdc", WALLET, "10", network);
     expect(result).toEqual({ xdr: "COORDINATOR_DEPOSIT_XDR", fee: "200" });
     expect(buildCoordinatorDepositTx).toHaveBeenCalledWith(
       { contractId: VAULT_CONTRACT, network },
@@ -105,20 +93,14 @@ describe("buildDepositTx", () => {
 
   it("throws for a vault not in KNOWN_POOLS", async () => {
     await expect(
-      buildDepositTx("unknown-vault", WALLET, "10", addresses, network)
+      buildDepositTx("unknown-vault", WALLET, "10", network)
     ).rejects.toThrow(/Vault not configured/);
   });
 });
 
 describe("buildWithdrawTx", () => {
   it("routes a meridian vault withdrawal through buildCoordinatorWithdrawTx", async () => {
-    const result = await buildWithdrawTx(
-      "meridian-usdc",
-      WALLET,
-      "5",
-      addresses,
-      network
-    );
+    const result = await buildWithdrawTx("meridian-usdc", WALLET, "5", network);
     expect(result).toEqual({ xdr: "COORDINATOR_WITHDRAW_XDR", fee: "200" });
     expect(buildCoordinatorWithdrawTx).toHaveBeenCalledWith(
       { contractId: VAULT_CONTRACT, network },
@@ -129,14 +111,14 @@ describe("buildWithdrawTx", () => {
 
   it("throws for a vault not in KNOWN_POOLS", async () => {
     await expect(
-      buildWithdrawTx("unknown-vault", WALLET, "5", addresses, network)
+      buildWithdrawTx("unknown-vault", WALLET, "5", network)
     ).rejects.toThrow(/Vault not configured/);
   });
 });
 
 describe("resolvePositions", () => {
   it("calls fetchCoordinatorPosition for every meridian vault in KNOWN_POOLS", async () => {
-    const positions = await resolvePositions(WALLET, network, addresses);
+    const positions = await resolvePositions(WALLET, network);
     expect(fetchCoordinatorPosition).toHaveBeenCalledWith(
       { contractId: VAULT_CONTRACT, network },
       "meridian-usdc",
@@ -155,7 +137,7 @@ describe("resolvePositions", () => {
     vi.mocked(fetchCoordinatorPosition).mockImplementationOnce(async () => {
       throw new Error("RPC down");
     });
-    const positions = await resolvePositions(WALLET, network, addresses);
+    const positions = await resolvePositions(WALLET, network);
     expect(positions).toHaveLength(1);
   });
 
@@ -163,7 +145,7 @@ describe("resolvePositions", () => {
     vi.mocked(fetchCoordinatorPosition).mockRejectedValue(
       new Error("RPC down")
     );
-    const positions = await resolvePositions(WALLET, network, addresses);
+    const positions = await resolvePositions(WALLET, network);
     expect(positions).toEqual([]);
   });
 });

--- a/packages/stellar-sdk-helpers/src/orchestration.ts
+++ b/packages/stellar-sdk-helpers/src/orchestration.ts
@@ -8,11 +8,6 @@ import type { StellarNetwork } from "./types";
 import type { PositionInfo } from "./positions";
 import { KNOWN_POOLS } from "./known-pools";
 
-export interface ProtocolAddresses {
-  usdc: string;
-  eurc: string;
-}
-
 /**
  * Look up the registry entry for `vaultId` on the given network. Throws if the
  * vault is unknown or its contract address is not yet configured.
@@ -38,7 +33,6 @@ export async function buildDepositTx(
   vaultId: string,
   walletAddress: string,
   amount: string,
-  _addresses: ProtocolAddresses,
   network: StellarNetwork
 ): Promise<{ xdr: string; fee: string }> {
   const entry = resolveVaultEntry(vaultId, network);
@@ -57,7 +51,6 @@ export async function buildWithdrawTx(
   vaultId: string,
   walletAddress: string,
   shares: string,
-  _addresses: ProtocolAddresses,
   network: StellarNetwork
 ): Promise<{ xdr: string; fee: string }> {
   const entry = resolveVaultEntry(vaultId, network);
@@ -75,8 +68,7 @@ export async function buildWithdrawTx(
  */
 export async function resolvePositions(
   publicKey: string,
-  network: StellarNetwork,
-  _addresses: ProtocolAddresses
+  network: StellarNetwork
 ): Promise<PositionInfo[]> {
   const pools = Object.values(
     network.network === "testnet" ? KNOWN_POOLS.testnet : KNOWN_POOLS.mainnet


### PR DESCRIPTION
## Summary

- Removed the `_addresses: ProtocolAddresses` parameter from `buildDepositTx`, `buildWithdrawTx`, and `resolvePositions` in `packages/stellar-sdk-helpers/src/orchestration.ts`. The parameter was used by the old per-protocol routing logic before the coordinator/adapter rewrite (#329); the coordinator vault now resolves all asset addresses on-chain, so it was never read.
- Removed the corresponding `buildTxAddresses()` call from every call site: `api/v1/tx/deposit.ts`, `api/v1/tx/withdraw.ts`, `api/v1/positions/[publicKey].ts`, `apps/api/src/routes/tx.ts`, `apps/api/src/routes/positions.ts`.
- Removed the now-unused `buildTxAddresses` function and `ProtocolAddresses` interface entirely, since nothing references them anymore.
- Updated `orchestration.test.ts` to drop the dead argument from every call.

## Test plan

- [x] `pnpm lint && pnpm typecheck && pnpm test` pass locally
- [x] `pnpm typecheck:api` (Vercel functions outside the workspace) passes
- [x] `pnpm coverage` passes with no regressions
- [x] Confirmed no remaining references to `_addresses`, `ProtocolAddresses`, or `buildTxAddresses` anywhere in source

Closes #336