### PR TITLE
fix(web): refresh vaults query cache after deposit and withdraw

### DIFF
--- a/apps/web/src/__tests__/hooks/useVaultActions.test.ts
+++ b/apps/web/src/__tests__/hooks/useVaultActions.test.ts
@@ -138,6 +138,7 @@ describe("useVaultActions — deposit", () => {
       kind: "success",
       message: "Deposited 10 USDC",
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["vaults"] });
   });
 
   it("sets needsTrustline when the API signals a missing trustline", async () => {
@@ -251,6 +252,7 @@ describe("useVaultActions — withdraw", () => {
       kind: "success",
       message: "Withdrew 5 USDC",
     });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["vaults"] });
   });
 
   it("pushes an error toast and returns false when withdraw fails", async () => {

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -140,6 +140,9 @@ export function useVaultActions() {
       await signAndSubmit(xdr);
       setNeedsTrustline(false);
       queryClient.invalidateQueries({ queryKey: ["positions", publicKey] });
+      // Without this, the vault panel's TVL/APY keep serving their cached
+      // value for up to staleTime (5 min) after a deposit actually lands.
+      queryClient.invalidateQueries({ queryKey: ["vaults"] });
       push("success", `${t("vaultActions.deposited")} ${amount} ${asset}`);
       return true;
     } catch (err) {
@@ -182,6 +185,10 @@ export function useVaultActions() {
       });
 
       await signAndSubmit(xdr);
+
+      // Without this, the vault panel's TVL/APY keep serving their cached
+      // value for up to staleTime (5 min) after a withdrawal actually lands.
+      queryClient.invalidateQueries({ queryKey: ["vaults"] });
 
       // Optimistic update: partial withdrawal scales the position down in-place
       // so the position card stays visible with an approximate remaining balance.


### PR DESCRIPTION
## Summary

- TVL and APY on the vault panel kept showing their pre-transaction value for up to 5 minutes after a deposit or withdrawal, even though the vaults API itself already had current data by the time the frontend would have asked for it.
- Root cause: `useVaultActions.ts`'s `deposit()` and `withdraw()` only invalidated the `["positions", publicKey]` react-query cache on success, never `["vaults"]`. `useVaults()` has a 5 minute `staleTime`, so the vault panel kept serving stale TVL/APY until that window lapsed or the tab regained focus.
- Fix: both `deposit()` and `withdraw()` now also call `queryClient.invalidateQueries({ queryKey: ["vaults"] })` right after the transaction is signed and submitted, forcing an immediate refetch regardless of `staleTime`.

## Test plan

- [x] `pnpm --filter web test -- useVaultActions` passes: new assertions confirm both `deposit()` and `withdraw()` invalidate the `["vaults"]` query on success
- [x] `pnpm --filter web typecheck` clean
- [x] `prettier --check` clean
