### PR TITLE
docs: rewrite architecture and deployment docs for adapter pattern

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,9 +73,9 @@ Before cloning, confirm you have the required tools installed:
 | Node.js        | `>=20`           | `node --version`    |
 | pnpm           | `9.x`            | `pnpm --version`    |
 | Rust toolchain | stable (latest)  | `rustc --version`   |
-| Soroban CLI    | latest           | `soroban --version` |
+| Stellar CLI    | latest           | `stellar --version` |
 
-Rust and Soroban CLI are only required if you are working on the smart contracts in `packages/contracts`. TypeScript-only contributors can skip them.
+Rust and the Stellar CLI (`cargo install stellar-cli`; the binary is `stellar`, the older `soroban-cli` is deprecated) are only required if you are working on the smart contracts in `packages/contracts`. TypeScript-only contributors can skip them.
 
 To install pnpm at the correct version:
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ Meridian is a **testnet technical preview**, not a finished product. Be clear-ey
 
 **Working today (testnet)**
 
-- Live APY / TVL feed across Stellar stablecoin pools (via DeFiLlama) with a risk heuristic
+- Live APY / TVL feed across Stellar stablecoin pools (via DeFiLlama on mainnet; direct on-chain queries on testnet, since DeFiLlama doesn't index it) with a risk heuristic
 - Non-custodial signing flow: the API builds an unsigned Soroban XDR, your wallet (Freighter) signs and submits it — keys never leave the browser
-- **Direct deposit / withdraw against a real Blend pool**: funds supply straight into Blend from your wallet and the resulting bToken position is yours — no Meridian-controlled custody
-- Live position reads from the Blend pool and (when a DeFindex vault is configured) DeFindex vault — current supplied value
+- **Deposit / withdraw through the live `MeridianVault` coordinator contract**: the vault forwards your USDC to its active adapter contract (`BlendAdapter` today), which supplies it straight into a real Blend pool — you receive mUSDC shares representing the position, no Meridian-controlled custody of the underlying funds
+- Live TVL and per-address position reads directly from the vault (`get_total_assets`, `get_position`)
 - Best-rate routing: the API recommends the highest-APY vault it can actually deposit into, skipping display-only protocols and pools flagged risky
-- `MeridianVault` Soroban contract (ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails) with unit tests — reserved for the v2 single-transaction rebalancing router
+- Protocol-agnostic adapter architecture: `MeridianVault` (ERC-4626-style share accounting hardened against the first-depositor inflation attack, pause + admin-rotation rails), `BlendAdapter` (live), and a `DefindexAdapter` contract (built, not yet wired to a live vault) — swapping which protocol a vault routes to is an admin-only `set_adapter` call, no vault redeploy required. A `router` contract exists reserved for a future v2 single-transaction rebalancing feature. All four have unit test coverage.
 
 **In progress — the core promise is not finished**
 
-- Direct deposit/withdraw against real DeFindex vaults — _transaction builders are implemented; gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired_
-- Per-position yield earned (cost-basis tracking for direct Blend/DeFindex positions)
+- Deposit/withdraw against a real DeFindex vault through `DefindexAdapter` — the adapter contract and transaction builders are implemented; gated behind `DEFINDEX_VAULT_ID` until a real testnet vault is wired
+- Per-position yield earned (cost-basis tracking is implemented on-chain via `get_principal`; UI display is still in progress)
 - Mainnet configuration and a security audit before any real-funds use
 
 Until a DeFindex vault is configured, the DeFindex deposit path throws a configuration error rather than silently routing elsewhere. Track progress in the [Roadmap](#roadmap) and [open issues](../../issues).
@@ -49,8 +49,8 @@ meridian/
 ├── packages/
 │   ├── stellar-sdk-helpers/  # Blend & DeFindex client wrappers
 │   ├── shared/               # Zod schemas, constants, pure utils
-│   └── contracts/            # Soroban smart contracts (Rust)
-└── scripts/          # Deploy helpers for testnet / mainnet
+│   └── contracts/            # Soroban smart contracts (Rust): vault, router, blend-adapter, defindex-adapter
+└── scripts/          # deploy-testnet.sh (fresh stack), redeploy-blend-adapter.sh (swap adapter on a live vault)
 ```
 
 This is a **pnpm + Turborepo** monorepo. All packages are TypeScript-first with strict mode enabled.
@@ -61,10 +61,10 @@ This is a **pnpm + Turborepo** monorepo. All packages are TypeScript-first with 
 User browser
   └─► Vite + React frontend
         └─► Vercel Serverless Functions (builds unsigned XDR)
-              ├─► Blend Protocol (pool data + deposit tx)
-              └─► DeFindex Protocol (vault data + deposit tx)
-                        │
-                   Stellar RPC (Soroban)
+              └─► MeridianVault coordinator contract
+                    └─► active adapter (BlendAdapter today) ─► underlying protocol pool
+                              │
+                         Stellar RPC (Soroban)
 ```
 
 In production, API routes are Vercel serverless functions (`api/v1/...`). The Fastify server in `apps/api` is used for local development only.
@@ -94,7 +94,7 @@ The API never holds private keys. It builds an unsigned Soroban transaction, ret
 
 - Node.js ≥ 20
 - pnpm ≥ 9 (`npm i -g pnpm`)
-- Rust + `wasm32-unknown-unknown` target (for contracts)
+- Rust + `wasm32v1-none` target (for contracts)
 - Stellar CLI (`cargo install stellar-cli`)
 
 ### Install
@@ -164,9 +164,9 @@ Issues are tagged `good first issue`, `medium`, and `hard`. Pick your level.
 
 ## Roadmap
 
-### Q2 2026: Deposit, withdraw and earn (testnet)
+### Q2 2026: Deposit, withdraw and earn (testnet) — shipped for Blend
 
-Non-custodial USDC deposits into Blend and DeFindex vaults on Stellar testnet. Freighter wallet connects in one click, the best-rate vault is selected automatically, and the signed transaction never leaves the browser. Live APY and TVL across protocols with risk-tier labelling. Withdraw at any time, no lock-up.
+Non-custodial USDC deposits into the `MeridianVault` coordinator contract on Stellar testnet, live and working end-to-end for Blend via `BlendAdapter`. Freighter wallet connects in one click, the best-rate vault is selected automatically, and the signed transaction never leaves the browser. Live APY and TVL across protocols with risk-tier labelling. Withdraw at any time, no lock-up. DeFindex support is built (`DefindexAdapter`) but not yet wired to a live testnet vault.
 
 ### Q3 2026: Yield tracking and position history
 

--- a/apps/docs/architecture/monorepo.md
+++ b/apps/docs/architecture/monorepo.md
@@ -67,10 +67,13 @@ meridian/
 │   │       └── utils.ts          # Pure utility functions
 │   │
 │   └── contracts/                # Rust/Soroban smart contracts
-│       └── vault/src/lib.rs      # MeridianVault contract
+│       ├── vault/src/lib.rs           # MeridianVault: protocol-agnostic coordinator
+│       ├── router/src/lib.rs          # Reserved for v2 atomic rebalancing
+│       ├── blend-adapter/src/lib.rs   # Supplies USDC into a Blend lending pool
+│       └── defindex-adapter/src/lib.rs # Deposits USDC into a DeFindex vault
 │
 ├── apps/landing/                 # Static landing page
-├── scripts/                      # Build and deploy helpers
+├── scripts/                      # deploy-testnet.sh (fresh stack), redeploy-blend-adapter.sh (swap adapter on a live vault)
 ├── vercel.json                   # Vercel routing config
 └── turbo.json                    # Turborepo task graph
 ```

--- a/apps/docs/architecture/vault-contract.md
+++ b/apps/docs/architecture/vault-contract.md
@@ -1,6 +1,6 @@
 # Vault Contract
 
-The `MeridianVault` contract is a Soroban smart contract written in Rust, located at `packages/contracts/vault/src/lib.rs`.
+The `MeridianVault` contract is a Soroban smart contract written in Rust, located at `packages/contracts/vault/src/lib.rs`. It is a protocol-agnostic coordinator: it holds no direct opinion about where funds actually earn yield. Instead it delegates all protocol-specific work to a swappable **adapter** contract (see [Adapter Contracts](#adapter-contracts) below).
 
 ## Tokens
 
@@ -9,37 +9,38 @@ The `MeridianVault` contract is a Soroban smart contract written in Rust, locate
 | USDC  | Deposit and withdrawal currency. Pulled from the user on deposit, returned on withdraw.                            |
 | mUSDC | Share token. Minted to the user on deposit, burned on withdraw. Represents proportional ownership of vault assets. |
 
-Both are standard Stellar assets managed via the `TokenClient` interface. The vault must be set as the admin of the mUSDC asset to mint and burn autonomously.
+Both are standard Stellar assets managed via the `TokenClient`/`StellarAssetClient` interfaces. The vault must be set as the admin of the mUSDC asset to mint and burn autonomously (the deploy scripts do this automatically — see [Testnet Deployment](../operations/testnet-deployment.md)).
 
 ## Interface
 
-### `initialize(admin, usdc, musdc)`
+### `initialize(admin, usdc, musdc, adapter) -> Result<(), ContractError>`
 
-Called once at deployment. Sets the admin, USDC contract address, and mUSDC contract address. Panics if called again.
+Called once at deployment. Sets the admin, USDC contract address, mUSDC contract address, and the initial yield adapter address. Requires `admin.require_auth()`. Fails with `AlreadyInitialized` if called again.
 
-### `deposit(caller, amount, route_to) -> i128`
+### `deposit(caller, amount) -> Result<i128, ContractError>`
 
-Transfers `amount` USDC from the caller into the vault, mints proportional mUSDC shares, and records the routing protocol. Panics if deposits are paused.
+Transfers `amount` USDC from the caller into the vault, forwards it to the active adapter, and mints proportional mUSDC shares. Fails with `DepositsPaused` if `set_paused(true)` is in effect, `ZeroAmount` if `amount <= 0`, or `DepositTooSmall` if the amount rounds down to zero shares at the current price.
 
 ```
-shares_minted = amount * (total_shares + OFFSET) / (vault_balance + OFFSET)
+shares_minted = amount * (total_shares + OFFSET) / (adapter_total_assets + OFFSET)
 ```
 
-At genesis (no outstanding shares), `shares = amount` (1:1). The virtual `OFFSET` (1,000 stroops) neutralises the first-depositor inflation attack: an attacker who donates USDC to inflate the share price before a victim deposits recovers only a negligible fraction of the donation, making the skim strictly unprofitable. Returns the number of shares minted.
+`OFFSET` is a virtual liquidity constant (1,000 stroops) that makes the first-deposit price 1 share = 1 stroop while neutralising the first-depositor inflation attack: an attacker who donates USDC directly to the adapter to inflate the share price before a victim deposits recovers only a negligible fraction of the donation, making the skim strictly unprofitable (see the `inflation_attack_is_unprofitable` test). Returns the number of shares minted.
 
-`route_to` is a `Protocol` enum value (`Blend` or `DeFindex`), passed by the API based on the current best rate. It is stored in contract instance storage so any observer can read where funds currently sit.
+There is no `route_to` or protocol-selection parameter on `deposit`. Which protocol the funds actually reach is determined entirely by whichever adapter the vault currently has set (see `get_adapter`/`set_adapter`), not by anything the caller passes in.
 
 Stamps `Entry(caller)` with the current ledger timestamp on the caller's first deposit. Top-ups do not reset the original entry time. Accumulates `Principal(caller)` with `amount` on every deposit.
 
-### `withdraw(caller, shares) -> i128`
+### `withdraw(caller, shares) -> Result<i128, ContractError>`
 
-Burns `shares` mUSDC from the caller and returns proportional USDC.
+Burns `shares` mUSDC from the caller, redeems the proportional adapter position, and returns the resulting USDC. Fails with `ZeroAmount` if `shares <= 0`, `NoSharesOutstanding` if the vault has no shares outstanding at all, `InsufficientShares` if the caller doesn't hold enough mUSDC, or `WithdrawalTooSmall` if the redemption rounds down to zero USDC.
 
 ```
-usdc_out = shares * (vault_balance + OFFSET) / (total_shares + OFFSET)
+adapter_shares_to_burn = shares * total_adapter_shares / total_shares
+usdc_out = <whatever the adapter's withdraw() returns for that many adapter shares>
 ```
 
-The caller must hold at least `shares` mUSDC or the transaction panics with "insufficient shares". Reduces `Principal(caller)` proportionally. A full exit clears both `Entry(caller)` and `Principal(caller)`.
+Reduces `Principal(caller)` proportionally. A full exit clears both `Entry(caller)` and `Principal(caller)`. Withdrawals are never blocked by `set_paused` — see [Authorization and safety rails](#authorization-and-safety-rails).
 
 ### `get_position(address) -> i128`
 
@@ -53,17 +54,21 @@ Returns the ledger timestamp of the address's current deposit, or `0` if it hold
 
 Returns the address's cost basis: the net USDC it has deposited and not yet withdrawn. Yield earned off-chain is computed as `current_share_value - principal`.
 
-### `get_active_protocol() -> Protocol`
-
-Returns the protocol recorded during the last deposit.
-
 ### `get_total_assets() -> i128`
 
-Returns the vault's current USDC balance in stroops.
+Returns the live USDC value of the vault's position, read directly from the active adapter's `total_assets()`. Includes yield accrued by the underlying protocol (for Blend, only as of the adapter's last `accrue()` call — see below).
 
 ### `get_total_shares() -> i128`
 
 Returns total outstanding mUSDC shares.
+
+### `get_adapter() -> Address`
+
+Returns the currently active adapter contract address.
+
+### `set_adapter(new_adapter)` (admin only)
+
+Points the vault at a new adapter contract and resets the adapter-share counter (`ADPT_SH`) to zero. **This is the only way to change which protocol a vault routes to, or to push new adapter code live** — adapter contracts have no in-place upgrade path (no `update_current_contract_wasm`). The caller is responsible for migrating funds out of the old adapter _before_ calling this: any value still sitting in the old adapter becomes unreachable through the vault's normal `withdraw()` flow once the adapter-share counter resets. See `scripts/redeploy-blend-adapter.sh` for the supported procedure.
 
 ### `set_paused(paused: bool)` (admin only)
 
@@ -81,31 +86,80 @@ Rotates the admin key. Lets a compromised or retired admin key be replaced witho
 
 Returns the current admin address.
 
+## Adapter contracts
+
+Every adapter implements the shared `YieldAdapterInterface` trait defined in `vault/src/lib.rs`:
+
+```rust
+pub trait YieldAdapterInterface {
+    fn deposit(env: Env, amount: i128) -> i128;
+    fn withdraw(env: Env, shares: i128, recipient: Address) -> i128;
+    fn total_assets(env: Env) -> i128;
+    fn get_pool(env: Env) -> Address;
+    fn get_protocol(env: Env) -> Symbol;
+}
+```
+
+`get_pool()` returns the address of the underlying protocol contract the adapter wraps (a lending pool for Blend, a vault for DeFindex). `get_protocol()` returns a stable lowercase identifier (`"blend"`, `"defindex"`) for that protocol. Both exist purely for off-chain callers: they let the frontend discover live rate data (e.g. Blend's supply APY) without maintaining a config mapping that could drift out of sync if the adapter is later swapped via `set_adapter`. The vault itself never calls either.
+
+Two adapters exist today, at `packages/contracts/blend-adapter/src/lib.rs` and `packages/contracts/defindex-adapter/src/lib.rs`.
+
+### BlendAdapter
+
+Supplies USDC into a Blend lending pool as collateral. `deposit()` calls the pool's `submit()` with a `REQUEST_SUPPLY` request; `withdraw()` calls `submit()` with a `REQUEST_WITHDRAW` request and has Blend deliver USDC straight to the recipient.
+
+`total_assets()` returns a **cached** value (`TOTAL_KEY` in instance storage), not a live query — it's updated directly on every `deposit()`/`withdraw()` call, but yield accrued independently by Blend (interest on the supplied collateral) is not reflected until `accrue()` is called. `accrue()` is permissionless (anyone can call it) and refreshes the cache by reading the adapter's current bToken balance and exchange rate straight from Blend's own ledger (`get_reserve`/`get_positions`), so there's no risk of drift between the cached total and Blend's actual accounting. It should be called before any `total_assets()` read that will inform a deposit or withdrawal price.
+
+**Auth note:** `deposit()` calls `env.authorize_as_current_contract(...)` before invoking the pool's `submit()`. This is required because Blend's pool pulls the USDC from the adapter via its own internal `token.transfer()` call — a nested invocation the pool triggers, not one the adapter makes directly. Soroban's "direct invoker" self-authorization only covers calls a contract makes itself; it does not extend to a call a _callee_ later makes on the contract's behalf several frames down the stack. Without this explicit pre-authorization, deposits fail during simulation with `HostError: Error(Auth, InvalidAction)`.
+
+### DefindexAdapter
+
+Deposits USDC into a DeFindex vault. `deposit()`/`withdraw()` wrap DeFindex's own `deposit`/`withdraw` vault interface. `total_assets()` is computed live on every call from DeFindex's `get_asset_amounts_per_shares`, unlike BlendAdapter's cached model — DeFindex vaults report value directly without a separate accrue step.
+
 ## Share price example
 
-1. User A deposits 100 USDC. Vault has 0 shares, so `shares = 100`. Vault: 100 USDC, 100 shares.
-2. Yield accrues. Vault now holds 110 USDC (10 USDC yield from Blend).
-3. User B deposits 100 USDC. `shares = 100 * 100 / 110 ≈ 90.9`. Vault: 210 USDC, 190.9 shares.
+1. User A deposits 100 USDC. Vault has 0 shares, so `shares ≈ 100` (adjusted by `OFFSET`). Adapter: 100 USDC, vault: 100 shares.
+2. Yield accrues (for Blend, after an `accrue()` call). Adapter's `total_assets()` now reports 110 USDC (10 USDC yield).
+3. User B deposits 100 USDC. `shares = 100 * 100 / 110 ≈ 90.9`. Adapter: 210 USDC, vault: 190.9 shares.
 4. User A withdraws all 100 shares. `usdc_out = 100 * 210 / 190.9 ≈ 110`. User A receives 110 USDC, profiting 10 USDC from yield.
 
 ## USDC decimal places
 
 USDC on Stellar uses 7 decimal places. 1 USDC = `10_000_000` stroops. All contract amounts are in stroops (i128). The API converts user-facing decimal strings (e.g. `"10.50"`) to stroops before building the transaction.
 
-## Authorization
+## Authorization and safety rails
 
-`caller.require_auth()` is called at the start of both `deposit` and `withdraw`. Soroban's auth framework enforces that the caller's signature covers the exact function call, preventing replay and impersonation attacks. Admin functions call an internal `require_admin` helper that reads the stored admin address and calls `require_auth()` on it.
+`caller.require_auth()` is called at the start of both `deposit` and `withdraw`. Admin functions (`set_admin`, `set_paused`, `set_adapter`) call an internal `require_admin` helper that reads the stored admin address and calls `require_auth()` on it. See [BlendAdapter's auth note](#blendadapter) above for a subtler auth requirement specific to that adapter.
+
+Deposits, but never withdrawals, can be paused via `set_paused(true)` — this is deliberate, so a pause can never trap user funds.
+
+## Error codes
+
+`ContractError` (defined in `vault/src/lib.rs`) gives fallible entry points typed, stable error codes instead of panic strings:
+
+| Variant               | Code | Meaning                                                        |
+| --------------------- | ---- | -------------------------------------------------------------- |
+| `AlreadyInitialized`  | 1    | `initialize` called on a contract that already has an admin.   |
+| `NotInitialized`      | 2    | A state-mutating call was made before `initialize`.            |
+| `DepositsPaused`      | 3    | `deposit` called while `set_paused(true)` is in effect.        |
+| `ZeroAmount`          | 4    | `deposit`/`withdraw` called with a non-positive amount/shares. |
+| `DepositTooSmall`     | 5    | The deposited amount rounds down to zero shares.               |
+| `NoSharesOutstanding` | 6    | `withdraw` called while the vault has no shares outstanding.   |
+| `InsufficientShares`  | 7    | The caller doesn't hold enough mUSDC to burn.                  |
+| `WithdrawalTooSmall`  | 8    | The shares burned round down to zero USDC.                     |
+| `Overflow`            | 9    | An intermediate arithmetic operation would overflow `i128`.    |
 
 ## Contract storage
 
-| Key                  | Storage type | Value                                                      |
-| -------------------- | ------------ | ---------------------------------------------------------- |
-| `ADMIN`              | Instance     | Admin `Address`                                            |
-| `USDC`               | Instance     | USDC contract `Address`                                    |
-| `MUSDC`              | Instance     | mUSDC contract `Address`                                   |
-| `PROTOCOL`           | Instance     | Last-used `Protocol` enum                                  |
-| `TOTAL_SH`           | Instance     | Total mUSDC shares outstanding (`i128`)                    |
-| `PAUSED`             | Instance     | Deposit pause flag (`bool`)                                |
-| `Balance(address)`   | Persistent   | Per-address mUSDC share balance (`i128`)                   |
-| `Entry(address)`     | Persistent   | Per-address deposit entry timestamp (`u64`)                |
-| `Principal(address)` | Persistent   | Per-address net USDC deposited, not yet withdrawn (`i128`) |
+| Key                  | Storage type | Value                                                             |
+| -------------------- | ------------ | ----------------------------------------------------------------- |
+| `ADMIN`              | Instance     | Admin `Address`                                                   |
+| `USDC`               | Instance     | USDC contract `Address`                                           |
+| `MUSDC`              | Instance     | mUSDC contract `Address`                                          |
+| `ADAPTER`            | Instance     | Active adapter contract `Address`                                 |
+| `TOTAL_SH`           | Instance     | Total mUSDC shares outstanding (`i128`)                           |
+| `ADPT_SH`            | Instance     | Total adapter shares outstanding, reset on `set_adapter` (`i128`) |
+| `PAUSED`             | Instance     | Deposit pause flag (`bool`)                                       |
+| `Balance(address)`   | Persistent   | Per-address mUSDC share balance (`i128`)                          |
+| `Entry(address)`     | Persistent   | Per-address deposit entry timestamp (`u64`)                       |
+| `Principal(address)` | Persistent   | Per-address net USDC deposited, not yet withdrawn (`i128`)        |

--- a/apps/docs/operations/environment-variables.md
+++ b/apps/docs/operations/environment-variables.md
@@ -10,9 +10,24 @@
 
 | Variable            | Required | Default                            | Description                                                                                                                                                                                                                                             |
 | ------------------- | -------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `STELLAR_NETWORK`   | No       | `"testnet"`                        | Selects the network the API talks to. Any value other than `"mainnet"` resolves to testnet. Controls which `CONTRACT_ADDRESSES`/`STELLAR_NETWORKS` entry (`packages/shared/src/constants.ts`) is used for every contract call the API makes.            |
 | `DEFINDEX_VAULT_ID` | No       | `""`                               | Overrides the DeFindex vault contract address at runtime. When empty, the address from `CONTRACT_ADDRESSES.testnet.defindex.vault` in `packages/shared/src/constants.ts` is used. Blend and vault contract addresses are always sourced from constants. |
 | `PORT`              | No       | `3001`                             | Fastify server port (local dev only).                                                                                                                                                                                                                   |
 | `ALLOWED_ORIGIN`    | No       | `"https://usemeridian.vercel.app"` | CORS allowed origin for the Fastify server. Set to your frontend domain in production if running Fastify as a standalone server.                                                                                                                        |
+
+## Deploy scripts (`scripts/`)
+
+These are shell environment variables read by `scripts/deploy-testnet.sh` and `scripts/redeploy-blend-adapter.sh` at deploy time, not application runtime variables, and not read from `.env` files.
+
+| Variable        | Required                               | Description                                                                                                                                                                                                                                     |
+| --------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEPLOYER`      | Yes (both scripts)                     | A funded Stellar secret key. Pays transaction fees and signs setup calls only — disposable, does not need to be kept after the script finishes.                                                                                                 |
+| `ADMIN`         | No (`deploy-testnet.sh` only)          | A public key that becomes the deployed vault's permanent admin. Defaults to `DEPLOYER`'s own address if unset (with a warning) — set explicitly to a separate, durable key for anything beyond a throwaway test, and required ahead of mainnet. |
+| `USDC_ID`       | No                                     | Overrides the testnet USDC contract address the deployed adapter/vault is wired to.                                                                                                                                                             |
+| `BLEND_POOL_ID` | No                                     | Overrides the testnet Blend pool address the deployed `BlendAdapter` is wired to.                                                                                                                                                               |
+| `VAULT_ID`      | Yes (`redeploy-blend-adapter.sh` only) | The already-live vault contract ID to eventually point at the newly deployed adapter via `set_adapter`.                                                                                                                                         |
+
+`deploy-testnet.sh` prints four contract IDs on success (`VAULT_CONTRACT_ID`, `ROUTER_CONTRACT_ID`, `BLEND_ADAPTER_CONTRACT_ID`, `MUSDC_CONTRACT_ID`) — these aren't environment variables the app reads either; `VAULT_CONTRACT_ID` and `MUSDC_CONTRACT_ID` need to be copied into `CONTRACT_ADDRESSES`/`KNOWN_POOLS` in `packages/shared/src/constants.ts` and `packages/stellar-sdk-helpers/src/known-pools.ts` respectively. See [Testnet Deployment](./testnet-deployment.md).
 
 ## Vercel
 
@@ -38,7 +53,6 @@ The Fastify server loads `.env` via the `dotenv` package on startup.
 
 ## Future variables
 
-| Variable          | Purpose                                                                 |
-| ----------------- | ----------------------------------------------------------------------- |
-| `STELLAR_NETWORK` | Switch between `testnet` and `mainnet`. Currently hardcoded to testnet. |
-| `REDIS_URL`       | If Redis caching is added back to the API layer. Currently not used.    |
+| Variable    | Purpose                                                              |
+| ----------- | -------------------------------------------------------------------- |
+| `REDIS_URL` | If Redis caching is added back to the API layer. Currently not used. |

--- a/apps/docs/operations/local-development.md
+++ b/apps/docs/operations/local-development.md
@@ -89,19 +89,26 @@ Or build a single package:
 pnpm --filter @meridian/shared build
 ```
 
-## Working with the vault contract
+## Working with the contracts
+
+`packages/contracts/` has four crates: `vault` (the coordinator), `router` (reserved for v2), and two yield adapters, `blend-adapter` and `defindex-adapter`. Build and test them all together from the `contracts` package root, or individually:
 
 ```bash
-cd packages/contracts/vault
+cd packages/contracts
 
-# Build the WASM
+# Build every crate's WASM (outputs to target/wasm32v1-none/release/)
 stellar contract build
 
-# Run Rust tests
+# Run every crate's Rust tests
 cargo test
+
+# Or a single crate
+cargo test --manifest-path blend-adapter/Cargo.toml
 ```
 
-See [Testnet Deployment](./testnet-deployment.md) for deploying the contract to testnet.
+`stellar contract build` targets `wasm32v1-none`, not `wasm32-unknown-unknown` — install it with `rustup target add wasm32v1-none` if you haven't already.
+
+See [Testnet Deployment](./testnet-deployment.md) for deploying the contracts to testnet, and [Vault Contract](../architecture/vault-contract.md) for how the vault and adapters fit together.
 
 ## Freighter wallet
 

--- a/apps/docs/operations/testnet-deployment.md
+++ b/apps/docs/operations/testnet-deployment.md
@@ -1,135 +1,128 @@
 # Testnet Deployment
 
+Meridian ships two deploy scripts, both in `scripts/`. Which one you need depends on what you're doing:
+
+| Script                              | Use when                                                                                                                                                  |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `scripts/deploy-testnet.sh`         | Standing up a brand new environment: vault, router, a `BlendAdapter`, and an mUSDC share token, all initialized and wired together.                       |
+| `scripts/redeploy-blend-adapter.sh` | Pushing new adapter code (e.g. a fix to `accrue()`, `get_pool()`, `get_protocol()`) onto an **already-live** vault, without redeploying the vault itself. |
+
+Neither script requires manual `stellar contract invoke` steps — read them before running if you want to understand exactly what they do; they're short and heavily commented.
+
 ## Prerequisites
 
-- Stellar CLI: `cargo install stellar-cli`
-- A funded testnet keypair (see below)
-- Rust with the `wasm32-unknown-unknown` target: `rustup target add wasm32-unknown-unknown`
+- Stellar CLI: `cargo install stellar-cli` (the CLI binary is `stellar`, not `soroban` — the older `soroban-cli` is deprecated)
+- Rust with the `wasm32v1-none` target: `rustup target add wasm32v1-none`. Note `stellar contract build` targets `wasm32v1-none`, not `wasm32-unknown-unknown` — if you've followed older Soroban tutorials, this is the one place that trips people up.
 
-## Generate and fund a testnet keypair
+## The `DEPLOYER` / `ADMIN` split
 
-```bash
-# Generate a new keypair and store it in the Stellar CLI keystore
-stellar keys generate --network testnet deployer
+Both scripts require a `DEPLOYER` secret key, funded via [Friendbot](https://friendbot.stellar.org/). `DEPLOYER` only pays transaction fees and signs the setup calls — it does **not** need to be kept around afterward, and can be thrown away once the script finishes.
 
-# Print the public key
-stellar keys address deployer
+`deploy-testnet.sh` additionally accepts an optional `ADMIN` **public key**. This becomes the deployed vault's permanent admin — the only address that can ever call `set_admin`, `set_paused`, or `set_adapter` on it. `ADMIN` is deliberately independent of `DEPLOYER`: whoever calls `initialize()` can pass in any address as the admin, since it's just a parameter, not tied to who signed the deploy transaction. If you don't set `ADMIN`, the script defaults it to `DEPLOYER`'s own address and prints a warning — fine for a quick throwaway test, but you should always set `ADMIN` explicitly to a separate, durable key for anything you intend to keep testing against, and it **must** be set explicitly ahead of any mainnet deployment.
 
-# Fund via Friendbot (replace with your public key)
-curl "https://friendbot.stellar.org/?addr=$(stellar keys address deployer)"
-```
+Save the `ADMIN` secret key somewhere durable (a password manager, not a plaintext file) the moment you deploy with it — there is no recovery path if it's lost. `set_admin`/`set_paused`/`set_adapter` become permanently inaccessible, and since adapters have no in-place upgrade path, that also means the vault can never be pointed at fixed adapter code again.
 
-## Build the vault contract
+## Standing up a fresh environment
 
 ```bash
-cd packages/contracts/vault
-stellar contract build
+# Generate and fund a throwaway deployer key
+stellar keys generate my-deployer --fund --network testnet
+DEPLOYER_ADDR=$(stellar keys address my-deployer)
+
+# Generate and fund a separate, durable admin key (keep this one)
+stellar keys generate my-admin --fund --network testnet
+ADMIN_ADDR=$(stellar keys address my-admin)
+
+DEPLOYER=my-deployer ADMIN=$ADMIN_ADDR bash scripts/deploy-testnet.sh
 ```
 
-This produces `target/wasm32-unknown-unknown/release/meridian_vault.wasm`.
+This builds all four contract crates (`vault`, `router`, `blend-adapter`, `defindex-adapter`), uploads and deploys the vault, router, and a `BlendAdapter`, deploys a fresh mUSDC Stellar Asset Contract, and wires everything together:
 
-## Deploy USDC and mUSDC (testnet only)
+1. Initializes the `BlendAdapter` with the vault address, Blend's testnet pool, and USDC.
+2. Initializes the vault with `admin`, `usdc`, `musdc`, and `adapter` (the just-deployed `BlendAdapter`).
+3. Sets the vault as mUSDC's admin, so it can mint/burn shares autonomously.
 
-On testnet, deploy mock Stellar Asset Contracts (SAC) for USDC and mUSDC. On mainnet, use the real USDC contract address already present in `CONTRACT_ADDRESSES.testnet.usdc`.
+It prints the four contract IDs you need at the end:
 
-To deploy a SAC you first need a funded keypair to act as the asset issuer, then wrap that classic asset as a Soroban contract:
-
-```bash
-# Generate an issuer keypair
-stellar keys generate --network testnet issuer
-curl "https://friendbot.stellar.org/?addr=$(stellar keys address issuer)"
-
-# Deploy a SAC for mock USDC
-stellar contract asset deploy \
-  --asset USDC:$(stellar keys address issuer) \
-  --network testnet \
-  --source deployer
+```text
+VAULT_CONTRACT_ID=...
+ROUTER_CONTRACT_ID=...
+BLEND_ADAPTER_CONTRACT_ID=...
+MUSDC_CONTRACT_ID=...
 ```
 
-Record the returned contract ID as `USDC_CONTRACT_ID`.
+USDC and the Blend pool address default to the existing testnet contracts (`USDC_ID`, `BLEND_POOL_ID` env vars override them if you need to point somewhere else).
 
-Repeat with a different asset code (e.g. `MUSDC`) for the share token and record as `MUSDC_CONTRACT_ID`.
+## Updating the app to use the new deployment
 
-## Deploy the vault contract
-
-```bash
-stellar contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/meridian_vault.wasm \
-  --network testnet \
-  --source deployer
-```
-
-Record the returned contract ID as `VAULT_CONTRACT_ID`.
-
-## Initialize the vault
-
-```bash
-stellar contract invoke \
-  --id $VAULT_CONTRACT_ID \
-  --network testnet \
-  --source deployer \
-  -- initialize \
-  --admin $(stellar keys address deployer) \
-  --usdc $USDC_CONTRACT_ID \
-  --musdc $MUSDC_CONTRACT_ID
-```
-
-## Transfer mUSDC admin to the vault
-
-The vault must be the admin of the mUSDC asset in order to mint and burn share tokens autonomously.
-
-```bash
-stellar contract invoke \
-  --id $MUSDC_CONTRACT_ID \
-  --network testnet \
-  --source issuer \
-  -- set_admin \
-  --new_admin $VAULT_CONTRACT_ID
-```
-
-## Update contract addresses
-
-Add the deployed contract IDs to `packages/shared/src/constants.ts`:
+The frontend and API discover the vault and mUSDC contract addresses from two places — both need updating:
 
 ```typescript
-export const CONTRACT_ADDRESSES = {
-  testnet: {
-    blend: {
-      pool: "C...",
-    },
-    defindex: {
-      factory: "C...",
-      vault: "",
-    },
-    usdc: "C...", // USDC_CONTRACT_ID
-    eurc: "C...",
-    musdc: "C...", // MUSDC_CONTRACT_ID
-    vault: "C...", // VAULT_CONTRACT_ID
-  },
-} as const;
+// packages/stellar-sdk-helpers/src/known-pools.ts
+KNOWN_POOLS.testnet["meridian-usdc"].contractId = "..."; // VAULT_CONTRACT_ID
+
+// packages/shared/src/constants.ts
+CONTRACT_ADDRESSES.testnet.vault = "..."; // VAULT_CONTRACT_ID
+CONTRACT_ADDRESSES.testnet.musdc = "..."; // MUSDC_CONTRACT_ID
 ```
 
-The vault contract address is read from constants at build time. There is no runtime environment variable for it.
+The router and adapter contract addresses are **not** hardcoded anywhere in the app — the frontend discovers the active adapter live via `vault.get_adapter()`, and that adapter's `get_pool()`/`get_protocol()`, rather than tracking it in config. This is deliberate: it means the app self-updates if the adapter is ever swapped via `set_adapter`, with nothing that could drift out of sync.
 
-## Verify the deployment
+## Verifying the deployment
 
 ```bash
-# Check total assets (should be 0 after initialization)
-stellar contract invoke \
-  --id $VAULT_CONTRACT_ID \
-  --network testnet \
-  --source deployer \
-  -- get_total_assets
+stellar contract invoke --network testnet --source my-deployer \
+  --id $VAULT_CONTRACT_ID -- get_total_assets
 ```
 
-A return value of `0` confirms the contract is initialized and responding.
+`0` confirms the contract is initialized and responding (a fresh vault has no deposits yet). You can also confirm the full adapter chain resolves correctly:
+
+```bash
+stellar contract invoke --network testnet --source my-deployer \
+  --id $VAULT_CONTRACT_ID -- get_adapter
+# -> BLEND_ADAPTER_CONTRACT_ID
+
+stellar contract invoke --network testnet --source my-deployer \
+  --id $BLEND_ADAPTER_CONTRACT_ID -- get_pool
+# -> the Blend pool address
+
+stellar contract invoke --network testnet --source my-deployer \
+  --id $BLEND_ADAPTER_CONTRACT_ID -- get_protocol
+# -> "blend"
+```
+
+This is exactly the call chain the frontend uses to discover live APY (`vault.get_adapter()` → `adapter.get_pool()`/`get_protocol()`). If any of these calls fail with `HostError: Error(WasmVm, MissingValue)`, the deployed contract predates the functions you're calling — you're pointed at a stale vault, not this one.
+
+## Pushing new adapter code to a live vault
+
+Adapter contracts have no in-place upgrade path. To get new adapter code (a bug fix, a new feature) onto an already-live vault, deploy a fresh adapter and swap the vault onto it:
+
+```bash
+VAULT_ID=$VAULT_CONTRACT_ID DEPLOYER=my-deployer bash scripts/redeploy-blend-adapter.sh
+```
+
+This builds and deploys a new `BlendAdapter`, initializes it against the same vault/pool/USDC, and then **prints, but does not run**, the final `set_adapter` command:
+
+```bash
+stellar contract invoke --network testnet --source $ADMIN \
+  --id $VAULT_ID -- set_adapter --new-adapter $NEW_ADAPTER_ID
+```
+
+This last step is deliberately manual. `set_adapter` resets the vault's adapter-share accounting to zero — if any funds are currently deposited through the vault's _current_ adapter, they become unreachable through the vault's normal withdraw flow the moment you swap. Before running the printed command:
+
+1. Confirm no funds are at risk: `vault.get_adapter()` → that adapter's `total_assets()`. If it's non-zero, withdraw first.
+2. Run the printed command using the vault's actual `ADMIN` key, not `DEPLOYER` — this call requires `admin.require_auth()`.
+
+## Getting testnet USDC
+
+Blend's testnet pool uses USDC issued by Blend's own controlled test key, not Circle's testnet USDC — the two are different Stellar assets that happen to share an asset code. Fund a testnet wallet from [Blend's public faucet](https://testnet.blend.capital) or via its API endpoint (`fundFromBlendFaucet()` in `apps/web/src/hooks/useVaultActions.ts` calls this automatically when a depositing wallet has no USDC balance). In practice the default faucet call reliably grants BLND/wETH/wBTC but has not reliably granted USDC in testing — if a deposit fails with a missing-trustline or insufficient-balance error, you may need to fund the wallet directly through Blend's own faucet UI.
 
 ## Run the signing flow end-to-end
 
-With the contract deployed and constants updated:
+With the contracts deployed and `known-pools.ts`/`constants.ts` updated:
 
 1. Open the app, connect Freighter (testnet mode).
 2. Enter a USDC amount and click **Deposit**.
-3. Freighter should display the transaction details; verify the contract address matches `VAULT_CONTRACT_ID`.
+3. Freighter displays the transaction details; verify the contract address matches `VAULT_CONTRACT_ID`.
 4. Approve the transaction.
-5. After ~5 seconds, the position summary should update with your deposited amount.
+5. After ~5 seconds, the position summary updates with your deposited amount.

--- a/apps/docs/overview/how-it-works.md
+++ b/apps/docs/overview/how-it-works.md
@@ -2,7 +2,7 @@
 
 ## Deposit flow
 
-```
+```text
 User enters amount
        │
        ▼
@@ -11,13 +11,13 @@ to POST /api/v1/tx/deposit
        │
        ▼
 API fetches account sequence from Soroban RPC
-builds invokeHostFunction calling vault.deposit(caller, amount, route_to)
+builds invokeHostFunction calling vault.deposit(caller, amount)
 simulates transaction to get resource footprint and fee
 returns { xdr, fee }
        │
        ▼
 Frontend passes XDR to Freighter
-User reviews and approves (sees: contract, function, amount, protocol)
+User reviews and approves (sees: contract, function, amount)
 Freighter returns signed XDR
        │
        ▼
@@ -26,34 +26,38 @@ API forwards to Stellar RPC
        │
        ▼
 Transaction settles (~5 seconds)
-Vault mints mUSDC shares to user's wallet
+Vault forwards USDC to its active adapter, which deploys it to the
+underlying protocol (Blend or DeFindex), and mints mUSDC shares to
+the user's wallet
 ```
+
+`vault.deposit(caller, amount)` has no protocol-selection parameter. Which protocol the deposit actually reaches is entirely determined by whichever adapter contract the vault currently has set — see [Vault Contract](../architecture/vault-contract.md#adapter-contracts).
 
 ## Withdraw flow
 
-Symmetric to deposit. The user specifies a share amount (mUSDC), the API builds a `vault.withdraw(caller, shares)` invocation, Freighter signs, and the vault burns shares and returns USDC.
+Symmetric to deposit. The user specifies a share amount (mUSDC), the API builds a `vault.withdraw(caller, shares)` invocation, Freighter signs, and the vault redeems the proportional adapter position and returns USDC.
 
 ## Rate selection
 
-The API reads live APY data from two sources:
+The API reads live APY data differently depending on network:
 
-- **Blend Capital pools** via DeFiLlama's `/pools` endpoint, filtered to Stellar stablecoins and matched against a curated pool registry.
-- **DeFindex vaults** via direct Soroban contract queries on testnet (currently returns estimated figures pending full integration).
+- **Mainnet**: Blend Capital pools via DeFiLlama's `/pools` endpoint, filtered to Stellar stablecoins and matched against a curated pool registry.
+- **Testnet**: queried directly on-chain, since DeFiLlama doesn't index testnet. For the Meridian coordinator vault specifically, the API discovers its live rate by calling `vault.get_adapter()`, then that adapter's `get_pool()`/`get_protocol()`, and branches on the returned protocol string to fetch the appropriate rate (Blend's SDK for `"blend"`; other protocols currently report `0` until wired up). This makes rate discovery self-updating: if the vault's adapter is ever swapped via `set_adapter`, the frontend picks up the new pool and protocol automatically on the next fetch, with no config entry anywhere that could drift out of sync.
 
-The vault with the highest APY becomes `bestVault`. Its ID is passed to the deposit endpoint, which maps it to the `Protocol` enum (`Blend` or `DeFindex`) used by the vault contract.
+The vault with the highest APY among vaults Meridian can actually deposit into becomes `bestVault` and is offered to the user for deposit.
 
 ## Share pricing
 
-The vault uses a proportional share model. When a user deposits:
+The vault uses a proportional share model, priced against the active adapter's reported total assets (which includes yield):
 
-```
-shares_minted = deposit_amount * total_shares / vault_balance
+```text
+shares_minted = deposit_amount * (total_shares + OFFSET) / (adapter_total_assets + OFFSET)
 ```
 
-If the vault has no outstanding shares, `shares = amount` (1:1 at genesis). As yield accrues and `vault_balance` grows relative to `total_shares`, the share price rises. Withdrawers receive:
+`OFFSET` is a small virtual-liquidity constant that makes the first deposit price 1 share ≈ 1 stroop while neutralising the classic first-depositor inflation attack. If the vault has no outstanding shares, this reduces to roughly `shares = amount` (1:1 at genesis). As yield accrues and the adapter's reported total assets grow relative to outstanding shares, the share price rises. Withdrawers receive:
 
-```
-usdc_out = shares_burned * vault_balance / total_shares
+```text
+usdc_out = <the adapter's redemption of the caller's proportional share of adapter shares>
 ```
 
 This means early depositors automatically benefit from yield without any claim or harvest action.
@@ -61,5 +65,5 @@ This means early depositors automatically benefit from yield without any claim o
 ## Security properties
 
 - **No server-side keys.** The API returns unsigned XDR only. Private keys never leave Freighter.
-- **User-visible routing.** The `route_to` parameter is part of the signed transaction. The user sees exactly which protocol their funds are going to before signing.
-- **On-chain state.** USDC balances, share balances, and the active protocol are all stored in Soroban contract storage, auditable by anyone.
+- **User-visible transaction contents.** Freighter shows the exact contract, function, and amount before the user signs — there is no hidden parameter deciding where funds go; that's determined entirely by the vault's current adapter, which is itself a matter of on-chain, auditable state (`vault.get_adapter()`).
+- **On-chain state.** USDC balances, share balances, and the active adapter are all stored in Soroban contract storage, auditable by anyone.

--- a/apps/docs/overview/introduction.md
+++ b/apps/docs/overview/introduction.md
@@ -20,4 +20,4 @@ Switching which protocol a vault routes to happens via `set_adapter` (admin-only
 
 ## Status
 
-Meridian is a testnet technical preview. The coordinator vault, `BlendAdapter`, router, XDR builder, and frontend are all deployed and live on Stellar testnet, with a working end-to-end deposit/withdraw signing flow. A `DefindexAdapter` contract exists but has no live testnet DeFindex vault wired up yet. Mainnet deployment and a security audit are still ahead — see the root [README](../../../README.md#project-status) for the current, detailed status.
+Meridian is a testnet technical preview. The coordinator vault, `BlendAdapter`, router, XDR builder, and frontend are all deployed and live on Stellar testnet, with a working end-to-end deposit/withdraw signing flow. A `DefindexAdapter` contract exists but has no live testnet DeFindex vault wired up yet. Mainnet deployment and a security audit are still ahead — see the root [README](https://github.com/drydocs/meridian#project-status) for the current, detailed status.

--- a/apps/docs/overview/introduction.md
+++ b/apps/docs/overview/introduction.md
@@ -1,21 +1,23 @@
 # Introduction
 
-Meridian is a stablecoin yield aggregator on the Stellar network. Users deposit USDC into a single vault and earn yield automatically, with Meridian routing their funds to whichever underlying protocol is currently offering the best rate.
+Meridian is a stablecoin yield aggregator on the Stellar network. Users deposit USDC into a coordinator vault contract and earn yield automatically; the vault delegates to a swappable adapter contract that deploys funds to whichever underlying protocol it's currently pointed at.
 
 ## What it does
 
-1. A user connects their Freighter wallet and deposits USDC.
-2. Meridian compares live APY across supported protocols (currently Blend Capital and DeFindex).
-3. The vault routes the deposit to the highest-yielding option, recorded on-chain at signing time so the user can verify the routing decision before approving.
+1. A user connects their Freighter wallet and deposits USDC into the `MeridianVault` coordinator contract.
+2. The vault forwards the deposit to its currently active adapter contract, which deploys it to the underlying protocol (today, Blend Capital via `BlendAdapter`; DeFindex support exists as a `DefindexAdapter` contract but has no live testnet vault wired up yet).
+3. Meridian compares live APY across supported protocols to recommend which vault to deposit into, but which protocol a given vault's funds actually reach is on-chain state (the vault's active adapter, `vault.get_adapter()`), not a parameter chosen at signing time.
 4. The user receives mUSDC share tokens representing their position. Share price appreciates as yield accrues.
 5. At any time the user can withdraw by burning their mUSDC shares, receiving USDC plus accumulated yield.
+
+Switching which protocol a vault routes to happens via `set_adapter` (admin-only, deploying a new adapter contract and pointing the vault at it) — it is not something that happens per-deposit or per-user.
 
 ## What it does not do
 
 - Meridian never holds or controls private keys. The server builds an unsigned transaction and returns it to the browser; the user signs with Freighter.
-- Meridian does not custody funds. The vault contract on Stellar holds USDC and mUSDC is a standard Stellar asset.
+- Meridian does not custody funds in the traditional sense. The vault forwards deposited USDC to its active adapter, which deploys it directly to the underlying protocol (e.g. supplied as collateral in a Blend pool); mUSDC is a standard Stellar asset representing the resulting position.
 - Meridian does not guarantee yield. APY figures are live estimates from on-chain data and DeFiLlama. Past rates do not predict future rates.
 
 ## Status
 
-Meridian is in active development on Stellar testnet. The vault contract, XDR builder, and frontend are implemented. Testnet deployment and end-to-end signing are the next milestones before mainnet.
+Meridian is a testnet technical preview. The coordinator vault, `BlendAdapter`, router, XDR builder, and frontend are all deployed and live on Stellar testnet, with a working end-to-end deposit/withdraw signing flow. A `DefindexAdapter` contract exists but has no live testnet DeFindex vault wired up yet. Mainnet deployment and a security audit are still ahead — see the root [README](../../../README.md#project-status) for the current, detailed status.


### PR DESCRIPTION
## Summary

- Rewrote `vault-contract.md`, `testnet-deployment.md`, and `how-it-works.md`, which described the pre-adapter architecture: a `deposit(caller, amount, route_to)` signature that no longer exists, a `get_active_protocol()` method that's been replaced by `get_adapter()`/`set_adapter()`, and a manual single-keypair deploy flow that predates both the adapter contracts and the real `deploy-testnet.sh`/`redeploy-blend-adapter.sh` scripts.
- `vault-contract.md` now documents the vault's actual interface (verified against `packages/contracts/vault/src/lib.rs` and `stellar contract info interface`), the `YieldAdapterInterface` trait, both adapters' behavior (including BlendAdapter's `authorize_as_current_contract` requirement and its cached vs. live `total_assets()` model), the typed `ContractError` codes, and current contract storage layout.
- `testnet-deployment.md` is rewritten entirely around the two real scripts, including the deliberate `DEPLOYER`/`ADMIN` key separation and the risk of losing the admin key.
- `README.md`'s "Working today" section previously described deposits going *directly* into Blend's pool, bypassing the vault entirely ("no Meridian-controlled custody"). That's no longer accurate: deposits and withdrawals now go through the live `MeridianVault` coordinator, which delegates to its active adapter. Corrected, and updated the architecture tree, data-flow diagram, and roadmap to reflect that Blend deposit/withdraw is shipped, not upcoming.
- Targeted fixes: `environment-variables.md` now documents `STELLAR_NETWORK` (already implemented, previously listed as a future variable) and the deploy scripts' `DEPLOYER`/`ADMIN`/`VAULT_ID`/etc env vars; `monorepo.md` and `local-development.md` now list all four contract crates instead of just `vault`; `CONTRIBUTING.md` and `README.md`'s prerequisite tables now reference the `stellar` CLI and `wasm32v1-none` target instead of the deprecated `soroban` CLI and `wasm32-unknown-unknown`.

## Test plan

- [x] Every claim about contract behavior verified against `packages/contracts/*/src/lib.rs` and `stellar contract info interface` output, not just read off old docs
- [x] `grep`-swept `README.md`, `CONTRIBUTING.md`, and `apps/docs/` for `route_to`, `get_active_protocol`, `wasm32-unknown-unknown`, `soroban --version`, and the dead pre-migration contract/issuer addresses — no remaining stale references outside intentional "here's what changed" mentions
- [x] `prettier --check` clean on all changed files

Closes #358
