### PR TITLE
feat(web): proactively establish trustlines before deposit

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -25,7 +25,6 @@
     "connectUSDC": "Connect your Freighter wallet to deposit USDC and start earning yield automatically.",
     "amount": "Amount",
     "balance": "Balance",
-    "addAssets": "Add vault assets to wallet",
     "position": "You have no active position to withdraw from.",
     "shares": "Shares",
     "waiting": "Waiting for signature..."

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -25,7 +25,6 @@
     "connectUSDC": "Connectez votre portefeuille Freighter pour déposer des USDC et commencer à générer du rendement automatiquement.",
     "amount": "Montant",
     "balance": "Solde",
-    "addAssets": "Ajouter les actifs du coffre au portefeuille",
     "position": "Vous n'avez aucune position active à retirer.",
     "shares": "Parts",
     "waiting": "En attente de signature..."

--- a/apps/web/src/__tests__/hooks/useVaultActions.test.ts
+++ b/apps/web/src/__tests__/hooks/useVaultActions.test.ts
@@ -54,10 +54,34 @@ import { api } from "../../lib/api";
 import { signTransaction } from "../../lib/wallet";
 
 const KEY = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
-// Matches USDC_ISSUER.testnet in @meridian/shared (Blend TestnetV2 issuer).
+// Matches USDC_ISSUER.testnet / MUSDC_ISSUER.testnet in @meridian/shared.
 const BLEND_TESTNET_USDC_ISSUER =
   "GATALTGTWIOT6BUDBCZM3Q4OQ4BO2COLOAZ7IYSKPLC2PMSOPPGF5V56";
+const MUSDC_TESTNET_ISSUER =
+  "GDZX7DOZMVEZJSWPDIZCTSCAKW4LBB3UGNWYAG5YTCBL4JPMUPAWWEUD";
 const TESTNET_PASSPHRASE = "Test SDF Network ; September 2015";
+
+function bothTrustlinesHorizonResponse() {
+  return new Response(
+    JSON.stringify({
+      balances: [
+        {
+          asset_type: "credit_alphanum4",
+          asset_code: "USDC",
+          asset_issuer: BLEND_TESTNET_USDC_ISSUER,
+          balance: "100.0000000",
+        },
+        {
+          asset_type: "credit_alphanum4",
+          asset_code: "MUSDC",
+          asset_issuer: MUSDC_TESTNET_ISSUER,
+          balance: "0.0000000",
+        },
+      ],
+    }),
+    { status: 200 }
+  );
+}
 
 function zeroBalanceHorizonResponse() {
   return new Response(JSON.stringify({ balances: [] }), { status: 200 });
@@ -87,26 +111,13 @@ beforeEach(() => {
   setQueryData.mockClear();
   getQueryData.mockClear();
   vi.clearAllMocks();
-  // Stub fetch so hasBlendUsdcBalance returns true (balance > 0), skipping the
-  // testnet faucet path. Tests that need the faucet path override this per-test.
+  // Stub fetch so both the proactive trustline check and hasBlendUsdcBalance
+  // see USDC + mUSDC trustlines and a positive USDC balance, skipping the
+  // add-trustline and testnet-faucet paths. Tests that need either path
+  // override this per-test.
   vi.stubGlobal(
     "fetch",
-    vi.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            balances: [
-              {
-                asset_type: "credit_alphanum4",
-                asset_code: "USDC",
-                asset_issuer: BLEND_TESTNET_USDC_ISSUER,
-                balance: "100.0000000",
-              },
-            ],
-          }),
-          { status: 200 }
-        )
-    )
+    vi.fn(async () => bothTrustlinesHorizonResponse())
   );
 });
 
@@ -141,18 +152,58 @@ describe("useVaultActions — deposit", () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ["vaults"] });
   });
 
-  it("sets needsTrustline when the API signals a missing trustline", async () => {
-    vi.mocked(api.buildDeposit).mockRejectedValueOnce(
-      new Error("USDC trustline missing")
+  it("silently establishes a missing mUSDC trustline before depositing", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        // Trustline check: mUSDC trustline missing.
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              balances: [
+                {
+                  asset_type: "credit_alphanum4",
+                  asset_code: "USDC",
+                  asset_issuer: BLEND_TESTNET_USDC_ISSUER,
+                  balance: "100.0000000",
+                },
+              ],
+            }),
+            { status: 200 }
+          )
+        )
+        // hasBlendUsdcBalance check, called after the trustline is established.
+        .mockResolvedValueOnce(bothTrustlinesHorizonResponse())
     );
+    const { result } = renderHook(() => useVaultActions());
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.deposit("10", "blend-usdc-fixed", "USDC");
+    });
+
+    expect(ok).toBe(true);
+    expect(api.addTrustline).toHaveBeenCalledWith(KEY);
+    expect(api.buildDeposit).toHaveBeenCalled();
+    // Once to sign the trustline transaction, once for the deposit itself.
+    expect(signTransaction).toHaveBeenCalledTimes(2);
+    expect(useToastStore.getState().toasts).toContainEqual(
+      expect.objectContaining({
+        kind: "success",
+        message: "Vault assets added to wallet",
+      })
+    );
+  });
+
+  it("does not attempt a trustline transaction when both already exist", async () => {
     const { result } = renderHook(() => useVaultActions());
 
     await act(async () => {
       await result.current.deposit("10", "blend-usdc-fixed", "USDC");
     });
 
-    expect(result.current.needsTrustline).toBe(true);
-    expect(useToastStore.getState().toasts[0]).toMatchObject({ kind: "error" });
+    expect(api.addTrustline).not.toHaveBeenCalled();
   });
 
   it("returns false without calling the API when no publicKey", async () => {
@@ -184,6 +235,9 @@ describe("useVaultActions — deposit", () => {
       "fetch",
       vi
         .fn()
+        // Trustline check: both already present.
+        .mockResolvedValueOnce(bothTrustlinesHorizonResponse())
+        // hasBlendUsdcBalance check: no USDC balance yet.
         .mockResolvedValueOnce(zeroBalanceHorizonResponse())
         .mockResolvedValueOnce(legitimate)
     );
@@ -213,6 +267,7 @@ describe("useVaultActions — deposit", () => {
       "fetch",
       vi
         .fn()
+        .mockResolvedValueOnce(bothTrustlinesHorizonResponse())
         .mockResolvedValueOnce(zeroBalanceHorizonResponse())
         .mockResolvedValueOnce(malicious)
     );

--- a/apps/web/src/components/dashboard/VaultPanel.tsx
+++ b/apps/web/src/components/dashboard/VaultPanel.tsx
@@ -37,15 +37,7 @@ export function VaultPanel() {
   const { connected, publicKey } = useWalletStore();
   const { handleConnect, status: connectStatus } = useWalletConnect();
   const { data: positions = [] } = usePositions(publicKey);
-  const {
-    deposit,
-    withdraw,
-    addTrustline,
-    needsTrustline,
-    isDepositing,
-    isWithdrawing,
-    clearNeedsTrustline,
-  } = useVaultActions();
+  const { deposit, withdraw, isDepositing, isWithdrawing } = useVaultActions();
 
   const [tab, setTab] = useState<Tab>("deposit");
   const [amount, setAmount] = useState("");
@@ -94,7 +86,6 @@ export function VaultPanel() {
   function handleTabChange(next: Tab) {
     setTab(next);
     setAmount("");
-    clearNeedsTrustline();
   }
 
   return (
@@ -273,14 +264,6 @@ export function VaultPanel() {
                 onKeyDown={onAmountKeyDown}
               />
             </div>
-            {needsTrustline && (
-              <button
-                onClick={addTrustline}
-                className="w-full rounded-xl border border-amber-800/70 bg-amber-950/20 hover:border-amber-700 text-amber-400 hover:text-amber-300 text-sm font-medium py-3 transition-colors duration-150"
-              >
-                {t("vaultPanel.addAssets")}
-              </button>
-            )}
             <button
               onClick={handleDeposit}
               disabled={!amount || !bestVault || isDepositing}

--- a/apps/web/src/hooks/useVaultActions.ts
+++ b/apps/web/src/hooks/useVaultActions.ts
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { STELLAR_NETWORKS, APP_NETWORK, USDC_ISSUER } from "@meridian/shared";
+import {
+  STELLAR_NETWORKS,
+  APP_NETWORK,
+  USDC_ISSUER,
+  MUSDC_ISSUER,
+} from "@meridian/shared";
 import { assertFaucetPayment } from "@meridian/stellar-sdk-helpers";
 import { useWalletStore } from "../store/wallet";
 import { signTransaction } from "../lib/wallet";
@@ -14,37 +19,67 @@ const BLEND_FAUCET_URL =
   import.meta.env.VITE_BLEND_FAUCET_URL ??
   "https://ewqw4hx7oa.execute-api.us-east-1.amazonaws.com/getAssets";
 
-function isMissingTrustline(msg: string) {
-  return msg.toLowerCase().includes("trustline");
+function horizonUrlFor(network: string) {
+  return network === "mainnet"
+    ? "https://horizon.stellar.org"
+    : "https://horizon-testnet.stellar.org";
+}
+
+async function fetchBalances(publicKey: string, network: string) {
+  const res = await fetch(`${horizonUrlFor(network)}/accounts/${publicKey}`);
+  if (!res.ok) return null;
+  return (await res.json()) as {
+    balances: {
+      asset_type: string;
+      asset_code?: string;
+      asset_issuer?: string;
+      balance: string;
+    }[];
+  };
 }
 
 async function hasBlendUsdcBalance(
   publicKey: string,
   network: string
 ): Promise<boolean> {
-  const horizonUrl =
-    network === "mainnet"
-      ? "https://horizon.stellar.org"
-      : "https://horizon-testnet.stellar.org";
   const issuer = USDC_ISSUER[network];
   if (!issuer) return true;
   try {
-    const res = await fetch(`${horizonUrl}/accounts/${publicKey}`);
-    if (!res.ok) return true;
-    const account = (await res.json()) as {
-      balances: {
-        asset_type: string;
-        asset_code?: string;
-        asset_issuer?: string;
-        balance: string;
-      }[];
-    };
+    const account = await fetchBalances(publicKey, network);
+    if (!account) return true;
     return account.balances.some(
       (b) =>
         b.asset_code === "USDC" &&
         b.asset_issuer === issuer &&
         parseFloat(b.balance) > 0
     );
+  } catch {
+    return true;
+  }
+}
+
+// A trustline just needs to exist (balance can be 0) to receive that asset,
+// unlike hasBlendUsdcBalance above which also requires a positive balance.
+// Checked proactively before depositing so a first-time depositor's missing
+// mUSDC (or USDC) trustline is established silently up front, instead of the
+// deposit failing on-chain and the user having to notice and click a
+// separate "Add Assets" step.
+async function hasRequiredTrustlines(
+  publicKey: string,
+  network: string
+): Promise<boolean> {
+  const usdcIssuer = USDC_ISSUER[network];
+  const musdcIssuer = MUSDC_ISSUER[network];
+  try {
+    const account = await fetchBalances(publicKey, network);
+    if (!account) return true;
+    const hasTrustline = (code: string, issuer: string) =>
+      account.balances.some(
+        (b) => b.asset_code === code && b.asset_issuer === issuer
+      );
+    const hasUsdc = !usdcIssuer || hasTrustline("USDC", usdcIssuer);
+    const hasMusdc = !musdcIssuer || hasTrustline("MUSDC", musdcIssuer);
+    return hasUsdc && hasMusdc;
   } catch {
     return true;
   }
@@ -57,7 +92,6 @@ export function useVaultActions() {
   const { push } = useToastStore();
   const [isDepositing, setIsDepositing] = useState(false);
   const [isWithdrawing, setIsWithdrawing] = useState(false);
-  const [needsTrustline, setNeedsTrustline] = useState(false);
 
   const passphrase =
     STELLAR_NETWORKS[network as keyof typeof STELLAR_NETWORKS]?.passphrase;
@@ -76,7 +110,6 @@ export function useVaultActions() {
     try {
       const { xdr } = await api.addTrustline(publicKey);
       await signAndSubmit(xdr);
-      setNeedsTrustline(false);
       push("success", t("vaultActions.assetsAdded"));
       return true;
     } catch (err) {
@@ -122,8 +155,17 @@ export function useVaultActions() {
     if (!publicKey || !passphrase) return false;
     setIsDepositing(true);
     try {
+      // Establish any missing trustline(s) first, silently, before the user
+      // has any reason to expect more than one signature — same one-click,
+      // two-signature shape as the faucet funding step below.
+      const hasTrustlines = await hasRequiredTrustlines(publicKey, network);
+      if (!hasTrustlines) {
+        const ok = await addTrustline();
+        if (!ok) return false;
+      }
+
       // On testnet, automatically fund the wallet from Blend's faucet when the
-      // user has no USDC balance. Covers both missing trustline and zero balance.
+      // user has no USDC balance.
       if (APP_NETWORK.network === "testnet") {
         const hasFunds = await hasBlendUsdcBalance(publicKey, network);
         if (!hasFunds) {
@@ -138,7 +180,6 @@ export function useVaultActions() {
         amount,
       });
       await signAndSubmit(xdr);
-      setNeedsTrustline(false);
       queryClient.invalidateQueries({ queryKey: ["positions", publicKey] });
       // Without this, the vault panel's TVL/APY keep serving their cached
       // value for up to staleTime (5 min) after a deposit actually lands.
@@ -148,9 +189,6 @@ export function useVaultActions() {
     } catch (err) {
       const msg =
         err instanceof Error ? err.message : t("vaultActions.depositFailed");
-      if (isMissingTrustline(msg)) {
-        setNeedsTrustline(true);
-      }
       push("error", msg);
       return false;
     } finally {
@@ -254,10 +292,7 @@ export function useVaultActions() {
   return {
     deposit,
     withdraw,
-    addTrustline,
-    needsTrustline,
     isDepositing,
     isWithdrawing,
-    clearNeedsTrustline: () => setNeedsTrustline(false),
   };
 }

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -14,6 +14,14 @@ export const USDC_ISSUER: Record<string, string> = {
   mainnet: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
 };
 
+// mUSDC is the vault's share token. Issuer = the musdc-issuer key used during
+// deployment (see scripts/deploy-testnet.sh's ADMIN, which becomes the mUSDC
+// asset's issuer before admin control is handed to the vault contract).
+export const MUSDC_ISSUER: Record<string, string> = {
+  testnet: "GDZX7DOZMVEZJSWPDIZCTSCAKW4LBB3UGNWYAG5YTCBL4JPMUPAWWEUD",
+  mainnet: "",
+};
+
 export const CONTRACT_ADDRESSES = {
   testnet: {
     blend: {

--- a/packages/stellar-sdk-helpers/src/tx.ts
+++ b/packages/stellar-sdk-helpers/src/tx.ts
@@ -18,6 +18,7 @@ import {
   withRetry,
   withRaceTimeout,
   USDC_ISSUER,
+  MUSDC_ISSUER,
   CONTRACT_ADDRESSES,
 } from "@meridian/shared";
 import { buildHorizonServer } from "./horizon";
@@ -45,12 +46,6 @@ const withSorobanTimeout = <T>(
       throw new SorobanTimeoutError(ms);
     throw err;
   });
-
-// mUSDC is the vault's share token. Issuer = the musdc-issuer key used during deployment.
-const MUSDC_ISSUER: Record<string, string> = {
-  testnet: "GDZX7DOZMVEZJSWPDIZCTSCAKW4LBB3UGNWYAG5YTCBL4JPMUPAWWEUD",
-  mainnet: "",
-};
 
 function usdcAsset(network: StellarNetwork): Asset {
   const issuer = USDC_ISSUER[network.network];


### PR DESCRIPTION
## Summary

- Removed the reactive "Add Assets" button and the deposit-fails-then-notice-a-button-then-retry flow. `deposit()` now proactively checks whether the wallet holds both the USDC and mUSDC trustlines before building the deposit transaction, mirroring the existing proactive `hasBlendUsdcBalance()`/`fundFromBlendFaucet()` check already in the same function.
- If a trustline is missing, `addTrustline()` runs silently first (same underlying `buildAddTrustlineTx()` in `packages/stellar-sdk-helpers`, unchanged) before the deposit is built. A first-time depositor now clicks "Deposit" once and signs two wallet prompts in sequence, with no separate button and no visible failed-then-retry step. A single transaction bundling `changeTrust` and `vault.deposit()` isn't possible on Stellar (a transaction with a Soroban `InvokeHostFunction` operation can only contain that one operation), so two signatures is the realistic floor here.
- Removed `needsTrustline` state, `isMissingTrustline()`, and the "Add Assets" button (and its now-orphaned `vaultPanel.addAssets` translation key in both locales).
- Moved `MUSDC_ISSUER` from a private constant in `packages/stellar-sdk-helpers/src/tx.ts` to `packages/shared/src/constants.ts`, alongside `USDC_ISSUER`. The frontend's new proactive trustline check needs the mUSDC issuer address too, and duplicating that constant in two places is exactly the kind of thing that already caused a real bug once this session (a stale `MUSDC_ISSUER` value after a vault redeploy) — better to have one source of truth.
- No contract or SDK behavior changes: `buildAddTrustlineTx()` and the vault's `deposit(caller, amount)` signature are untouched; this is purely a frontend orchestration change.

## Test plan

- [x] `pnpm --filter web test -- useVaultActions` passes: new tests cover silently establishing a missing trustline before depositing (asserting `addTrustline` runs, two signatures happen in order, a success toast confirms the trustline step), and confirm no trustline transaction is attempted when both already exist
- [x] `pnpm --filter web test` (full suite) passes
- [x] `pnpm --filter stellar-sdk-helpers test` passes after moving `MUSDC_ISSUER`
- [x] `pnpm typecheck` clean across all packages
- [x] `prettier --check` clean on all changed files

Closes #360
