### PR TITLE
feat(web): add error boundary and position-load error state

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -27,7 +27,8 @@
     "balance": "Balance",
     "position": "You have no active position to withdraw from.",
     "shares": "Shares",
-    "waiting": "Waiting for signature..."
+    "waiting": "Waiting for signature...",
+    "positionsError": "Couldn't load your position. Deposits and withdrawals still work."
   },
 
   "vaultActions": {
@@ -43,6 +44,7 @@
   "common": {
     "connectWallet": "Connect Wallet",
     "connecting": "Connecting...",
-    "installFreighter": "Install Freighter"
+    "installFreighter": "Install Freighter",
+    "retry": "Retry"
   }
 }

--- a/apps/web/messages/fr.json
+++ b/apps/web/messages/fr.json
@@ -27,7 +27,8 @@
     "balance": "Solde",
     "position": "Vous n'avez aucune position active à retirer.",
     "shares": "Parts",
-    "waiting": "En attente de signature..."
+    "waiting": "En attente de signature...",
+    "positionsError": "Impossible de charger votre position. Les dépôts et retraits fonctionnent toujours."
   },
 
   "vaultActions": {
@@ -43,6 +44,7 @@
   "common": {
     "connectWallet": "Connecter le portefeuille",
     "connecting": "Connexion...",
-    "installFreighter": "Installer Freighter"
+    "installFreighter": "Installer Freighter",
+    "retry": "Réessayer"
   }
 }

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { VaultPanel } from "./components/dashboard/VaultPanel";
 import { WalletConnect } from "./components/onboarding/WalletConnect";
 import { Toasts } from "./components/ui/Toasts";
+import { ErrorBoundary } from "./components/ui/ErrorBoundary";
 import { useWalletStore } from "./store/wallet";
 import { useTranslation } from "react-i18next";
 
@@ -36,7 +37,9 @@ function Dashboard() {
       </header>
 
       <main className="max-w-xl mx-auto px-6 py-10">
-        <VaultPanel />
+        <ErrorBoundary>
+          <VaultPanel />
+        </ErrorBoundary>
       </main>
     </div>
   );

--- a/apps/web/src/__tests__/components/ErrorBoundary.test.tsx
+++ b/apps/web/src/__tests__/components/ErrorBoundary.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ErrorBoundary } from "../../components/ui/ErrorBoundary";
+
+function Bomb(): never {
+  throw new Error("render panic");
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children normally when nothing throws", () => {
+    render(
+      <ErrorBoundary>
+        <p>fine</p>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("fine")).toBeDefined();
+  });
+
+  it("catches a render error and shows a fallback instead of crashing", () => {
+    // React logs the caught error to the console by default; keep the test
+    // output clean since we're deliberately triggering it.
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>
+    );
+
+    expect(
+      screen.getByText("Something went wrong. Please reload the page.")
+    ).toBeDefined();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/apps/web/src/__tests__/components/VaultPanel.test.tsx
+++ b/apps/web/src/__tests__/components/VaultPanel.test.tsx
@@ -1,55 +1,41 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { VaultPanel } from "../../components/dashboard/VaultPanel";
 import { useWalletStore } from "../../store/wallet";
+import { useVaults } from "../../hooks/useVaults";
+import { usePositions } from "../../hooks/usePositions";
+import { useVaultActions } from "../../hooks/useVaultActions";
+import { useWalletConnect } from "../../hooks/useWalletConnect";
 
 const refetchPositions = vi.fn();
+const deposit = vi.fn(async () => true);
+const withdraw = vi.fn(async () => true);
+const handleConnect = vi.fn();
 
-vi.mock("../../hooks/useVaults", () => ({
-  useVaults: () => ({
-    data: {
-      vaults: [
-        {
-          id: "meridian-usdc",
-          protocol: "meridian",
-          asset: "USDC",
-          name: "Meridian",
-          label: "USDC Vault",
-          apy: 8,
-          tvl: 10_000,
-          userBalance: 0,
-          riskLevel: "safe",
-        },
-      ],
-      recommendedVaultId: "meridian-usdc",
-    },
-    isLoading: false,
-  }),
-}));
+const VAULT = {
+  id: "meridian-usdc",
+  protocol: "meridian",
+  asset: "USDC",
+  name: "Meridian",
+  label: "USDC Vault",
+  apy: 8,
+  tvl: 10_000,
+  userBalance: 0,
+  riskLevel: "safe" as const,
+};
 
-vi.mock("../../hooks/usePositions", () => ({
-  usePositions: () => ({
-    data: [],
-    isError: true,
-    refetch: refetchPositions,
-  }),
-}));
+const POSITION = {
+  vaultId: "meridian-usdc",
+  shares: 50,
+  deposited: 100,
+  earned: 5,
+  entryTime: 1_700_000_000,
+};
 
-vi.mock("../../hooks/useVaultActions", () => ({
-  useVaultActions: () => ({
-    deposit: vi.fn(async () => true),
-    withdraw: vi.fn(async () => true),
-    isDepositing: false,
-    isWithdrawing: false,
-  }),
-}));
-
-vi.mock("../../hooks/useWalletConnect", () => ({
-  useWalletConnect: () => ({
-    handleConnect: vi.fn(),
-    status: "idle",
-  }),
-}));
+vi.mock("../../hooks/useVaults", () => ({ useVaults: vi.fn() }));
+vi.mock("../../hooks/usePositions", () => ({ usePositions: vi.fn() }));
+vi.mock("../../hooks/useVaultActions", () => ({ useVaultActions: vi.fn() }));
+vi.mock("../../hooks/useWalletConnect", () => ({ useWalletConnect: vi.fn() }));
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -58,17 +44,46 @@ vi.mock("react-i18next", () => ({
   }),
 }));
 
+function mockVaultsLoaded() {
+  vi.mocked(useVaults).mockReturnValue({
+    data: { vaults: [VAULT], recommendedVaultId: "meridian-usdc" },
+    isLoading: false,
+  } as ReturnType<typeof useVaults>);
+}
+
+function mockPositions(overrides: Partial<ReturnType<typeof usePositions>>) {
+  vi.mocked(usePositions).mockReturnValue({
+    data: [],
+    isError: false,
+    refetch: refetchPositions,
+    ...overrides,
+  } as ReturnType<typeof usePositions>);
+}
+
 beforeEach(() => {
-  refetchPositions.mockClear();
+  vi.clearAllMocks();
   useWalletStore.setState({
     publicKey: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
     connected: true,
     network: "testnet",
   });
+  mockVaultsLoaded();
+  mockPositions({ isError: false });
+  vi.mocked(useVaultActions).mockReturnValue({
+    deposit,
+    withdraw,
+    isDepositing: false,
+    isWithdrawing: false,
+  } as unknown as ReturnType<typeof useVaultActions>);
+  vi.mocked(useWalletConnect).mockReturnValue({
+    handleConnect,
+    status: "idle",
+  } as ReturnType<typeof useWalletConnect>);
 });
 
 describe("VaultPanel — position load error", () => {
   it("shows an error message with a retry button when positions fail to load", () => {
+    mockPositions({ isError: true });
     render(<VaultPanel />);
 
     expect(screen.getByText("vaultPanel.positionsError")).toBeDefined();
@@ -78,10 +93,9 @@ describe("VaultPanel — position load error", () => {
   });
 
   it("keeps the deposit tab usable while positions fail to load", () => {
+    mockPositions({ isError: true });
     render(<VaultPanel />);
 
-    // The deposit amount input and button are still present and become
-    // enabled once an amount is entered, unaffected by the positions error.
     const amountInput = screen.getByPlaceholderText("0.00");
     fireEvent.change(amountInput, { target: { value: "10" } });
 
@@ -89,5 +103,76 @@ describe("VaultPanel — position load error", () => {
       .getByText("vaultPanel.deposit")
       .closest("button");
     expect(depositButton?.disabled).toBe(false);
+  });
+
+  it("does not show the error message once positions load successfully", () => {
+    mockPositions({ isError: false, data: [POSITION] });
+    render(<VaultPanel />);
+
+    expect(screen.queryByText("vaultPanel.positionsError")).toBeNull();
+  });
+});
+
+describe("VaultPanel — disconnected", () => {
+  it("prompts to connect instead of showing deposit/withdraw tabs", () => {
+    useWalletStore.setState({ publicKey: null, connected: false });
+    render(<VaultPanel />);
+
+    expect(screen.getByText("vaultPanel.connectUSDC")).toBeDefined();
+    expect(screen.queryByText("vaultPanel.deposit")).toBeNull();
+  });
+
+  it("calls handleConnect when the connect button is clicked", () => {
+    useWalletStore.setState({ publicKey: null, connected: false });
+    render(<VaultPanel />);
+
+    fireEvent.click(screen.getByText("common.connectWallet"));
+    expect(handleConnect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("VaultPanel — deposit", () => {
+  it("calls deposit with the entered amount and clears the field on success", async () => {
+    render(<VaultPanel />);
+
+    fireEvent.change(screen.getByPlaceholderText("0.00"), {
+      target: { value: "25" },
+    });
+    fireEvent.click(screen.getByText("vaultPanel.deposit"));
+
+    await waitFor(() => {
+      expect(deposit).toHaveBeenCalledWith("25", "meridian-usdc", "USDC");
+    });
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("0.00")).toHaveProperty("value", "");
+    });
+  });
+});
+
+describe("VaultPanel — withdraw", () => {
+  it("shows the position and calls withdraw with the entered shares", async () => {
+    mockPositions({ isError: false, data: [POSITION] });
+    render(<VaultPanel />);
+
+    // The tab switcher renders a raw capitalized label ("Withdraw"), distinct
+    // from the action button below it, which renders the translated
+    // "vaultPanel.withdraw" key.
+    fireEvent.click(screen.getByText("Withdraw"));
+    fireEvent.change(screen.getByPlaceholderText("0.00"), {
+      target: { value: "10" },
+    });
+    fireEvent.click(screen.getByText("vaultPanel.withdraw"));
+
+    await waitFor(() => {
+      expect(withdraw).toHaveBeenCalledWith("10", "meridian-usdc", "USDC");
+    });
+  });
+
+  it("shows the no-position message when withdrawing with nothing deposited", () => {
+    mockPositions({ isError: false, data: [] });
+    render(<VaultPanel />);
+
+    fireEvent.click(screen.getByText("Withdraw"));
+    expect(screen.getByText("vaultPanel.position")).toBeDefined();
   });
 });

--- a/apps/web/src/__tests__/components/VaultPanel.test.tsx
+++ b/apps/web/src/__tests__/components/VaultPanel.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { VaultPanel } from "../../components/dashboard/VaultPanel";
+import { useWalletStore } from "../../store/wallet";
+
+const refetchPositions = vi.fn();
+
+vi.mock("../../hooks/useVaults", () => ({
+  useVaults: () => ({
+    data: {
+      vaults: [
+        {
+          id: "meridian-usdc",
+          protocol: "meridian",
+          asset: "USDC",
+          name: "Meridian",
+          label: "USDC Vault",
+          apy: 8,
+          tvl: 10_000,
+          userBalance: 0,
+          riskLevel: "safe",
+        },
+      ],
+      recommendedVaultId: "meridian-usdc",
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("../../hooks/usePositions", () => ({
+  usePositions: () => ({
+    data: [],
+    isError: true,
+    refetch: refetchPositions,
+  }),
+}));
+
+vi.mock("../../hooks/useVaultActions", () => ({
+  useVaultActions: () => ({
+    deposit: vi.fn(async () => true),
+    withdraw: vi.fn(async () => true),
+    isDepositing: false,
+    isWithdrawing: false,
+  }),
+}));
+
+vi.mock("../../hooks/useWalletConnect", () => ({
+  useWalletConnect: () => ({
+    handleConnect: vi.fn(),
+    status: "idle",
+  }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: "en" },
+  }),
+}));
+
+beforeEach(() => {
+  refetchPositions.mockClear();
+  useWalletStore.setState({
+    publicKey: "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5",
+    connected: true,
+    network: "testnet",
+  });
+});
+
+describe("VaultPanel — position load error", () => {
+  it("shows an error message with a retry button when positions fail to load", () => {
+    render(<VaultPanel />);
+
+    expect(screen.getByText("vaultPanel.positionsError")).toBeDefined();
+    const retryButton = screen.getByText("common.retry");
+    fireEvent.click(retryButton);
+    expect(refetchPositions).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the deposit tab usable while positions fail to load", () => {
+    render(<VaultPanel />);
+
+    // The deposit amount input and button are still present and become
+    // enabled once an amount is entered, unaffected by the positions error.
+    const amountInput = screen.getByPlaceholderText("0.00");
+    fireEvent.change(amountInput, { target: { value: "10" } });
+
+    const depositButton = screen
+      .getByText("vaultPanel.deposit")
+      .closest("button");
+    expect(depositButton?.disabled).toBe(false);
+  });
+});

--- a/apps/web/src/components/dashboard/VaultPanel.tsx
+++ b/apps/web/src/components/dashboard/VaultPanel.tsx
@@ -36,7 +36,11 @@ export function VaultPanel() {
   const { t, i18n } = useTranslation();
   const { connected, publicKey } = useWalletStore();
   const { handleConnect, status: connectStatus } = useWalletConnect();
-  const { data: positions = [] } = usePositions(publicKey);
+  const {
+    data: positions = [],
+    isError: positionsError,
+    refetch: refetchPositions,
+  } = usePositions(publicKey);
   const { deposit, withdraw, isDepositing, isWithdrawing } = useVaultActions();
 
   const [tab, setTab] = useState<Tab>("deposit");
@@ -193,6 +197,22 @@ export function VaultPanel() {
               +{formatUsd(position.earned, i18n.language)}
             </p>
           </div>
+        </div>
+      )}
+
+      {/* Position load error — deposit/withdraw stay usable, only the
+          position summary is affected. */}
+      {connected && positionsError && (
+        <div className="mx-7 my-5 rounded-xl border border-amber-800/70 bg-amber-950/20 px-4 py-3.5 flex items-center justify-between gap-3">
+          <p className="text-sm text-amber-400">
+            {t("vaultPanel.positionsError")}
+          </p>
+          <button
+            onClick={() => void refetchPositions()}
+            className="shrink-0 rounded-lg border border-amber-800/70 px-3 py-1.5 text-xs font-medium text-amber-300 hover:border-amber-700 hover:text-amber-200 transition-colors duration-150"
+          >
+            {t("common.retry")}
+          </button>
         </div>
       )}
 

--- a/apps/web/src/components/ui/ErrorBoundary.tsx
+++ b/apps/web/src/components/ui/ErrorBoundary.tsx
@@ -1,0 +1,51 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+// Catches unexpected render panics, separate from the predictable async data
+// failures TanStack Query already surfaces via isError/error (handled inline
+// in VaultPanel). A boundary can't recover from a render error other than
+// remounting its subtree, so this deliberately only offers a reload.
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(
+      "[ErrorBoundary] caught render error:",
+      error,
+      info.componentStack
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="rounded-2xl border border-red-900/50 bg-red-950/20 p-6 text-center">
+          <p className="text-sm text-red-400">
+            Something went wrong. Please reload the page.
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            className="mt-3 rounded-lg border border-red-800/70 px-4 py-1.5 text-xs font-medium text-red-300 hover:border-red-700 hover:text-red-200 transition-colors duration-150"
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}


### PR DESCRIPTION
## Summary

- Wired `usePositions`'s existing `isError` and `refetch` fields into `VaultPanel`: when position data fails to load (e.g. the API's 503 on Soroban RPC failure), a dismissible-by-nature amber message appears with a "Retry" button that calls `refetch()`. The deposit and withdraw tabs stay fully usable in this state — `positions` already defaults to `[]` on error, so `bestVault`/`hasPosition` degrade gracefully rather than crashing.
- Added a reusable class-based `ErrorBoundary` in `apps/web/src/components/ui/ErrorBoundary.tsx`, wrapping `VaultPanel` in `App.tsx`. This is deliberately separate from the `isError` handling above: TanStack Query already surfaces predictable async data failures, so the boundary exists only to catch unexpected render panics, with a reload action as the recovery path (a boundary can't recover a broken subtree any other way).
- Added `vaultPanel.positionsError` and `common.retry` to both `en.json` and `fr.json`; the existing i18n key-parity test (`__tests__/i18n.test.ts`) still passes.

## Test plan

- [x] New `VaultPanel.test.tsx`: asserts the error message and retry button render when `usePositions` reports `isError: true`, that clicking retry calls `refetch()`, and that the deposit tab (amount input + button) stays interactive throughout
- [x] New `ErrorBoundary.test.tsx`: asserts children render normally when nothing throws, and that a thrown render error is caught and replaced with the fallback UI instead of crashing the tree
- [x] `pnpm --filter web test`: 29 tests pass
- [x] `pnpm --filter web typecheck` clean
- [x] `pnpm lint` clean (root, covers `apps/web`)
- [x] Dev server smoke-tested: app loads (200) with the boundary wired in, no console errors

Closes #230
