### PR TITLE
feat(ci): verify contract addresses against on-chain bytecode

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Contract addresses deployed from this repo's source. Any change here must be
+# independently verified against the actual on-chain bytecode before merging,
+# not trusted from the PR description alone.
+/packages/shared/src/constants.ts @collinsezedike
+/packages/stellar-sdk-helpers/src/known-pools.ts @collinsezedike

--- a/.github/workflows/verify-contract-addresses.yml
+++ b/.github/workflows/verify-contract-addresses.yml
@@ -1,0 +1,34 @@
+name: Verify Contract Addresses
+
+# Guards against a specific supply-chain risk: a PR can submit clean,
+# reviewable contract source while pointing a contract address at different,
+# unreviewed bytecode the contributor deployed themselves. Only triggers on
+# PRs touching the files where deployed vault addresses are recorded.
+on:
+  pull_request:
+    paths:
+      - "packages/shared/src/constants.ts"
+      - "packages/stellar-sdk-helpers/src/known-pools.ts"
+
+jobs:
+  verify:
+    name: Verify On-Chain Bytecode
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32v1-none
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/contracts
+      - name: Install Stellar CLI
+        run: cargo install --locked stellar-cli
+      - name: Verify contract addresses match on-chain bytecode
+        run: pnpm verify:contracts

--- a/.github/workflows/verify-contract-addresses.yml
+++ b/.github/workflows/verify-contract-addresses.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "packages/shared/src/constants.ts"
       - "packages/stellar-sdk-helpers/src/known-pools.ts"
+  workflow_dispatch: {}
 
 jobs:
   verify:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "typecheck": "turbo run typecheck",
     "typecheck:api": "tsc --noEmit -p api/tsconfig.json",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "verify:contracts": "tsx scripts/verify-contract-addresses.ts"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.0.0"
@@ -20,6 +21,7 @@
     "@types/node": "^20.0.0",
     "esbuild": "^0.28.1",
     "turbo": "^2.10.4",
+    "tsx": "^4.23.0",
     "typescript": "^6.0.3",
     "prettier": "^3.9.4",
     "@eslint/js": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
+      tsx:
+        specifier: ^4.23.0
+        version: 4.23.0
       turbo:
         specifier: ^2.10.4
         version: 2.10.4

--- a/scripts/verify-contract-addresses.ts
+++ b/scripts/verify-contract-addresses.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env tsx
+/**
+ * Verifies that every vault contract address recorded in this repo actually
+ * has on-chain bytecode matching the vault contract built from this repo's
+ * own source, and that CONTRACT_ADDRESSES and KNOWN_POOLS agree with each
+ * other on the vault address.
+ *
+ * This exists to catch a specific supply-chain risk: a PR can submit clean,
+ * reviewable source while pointing a contract address at different,
+ * unreviewed bytecode the contributor deployed themselves. Reviewing the
+ * source diff alone cannot catch that; this script rebuilds the source and
+ * compares its hash against what is actually live on-chain.
+ *
+ * Only the vault contract is checked, since it's the only contract whose
+ * address is currently tracked in these two files and whose source lives in
+ * this repo. Third-party contracts (Blend's pool, DeFindex's factory/vault,
+ * the USDC/EURC issuers) can't be verified this way, since nobody here
+ * controls their source.
+ */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CONTRACT_ADDRESSES } from "../packages/shared/src/constants";
+import { KNOWN_POOLS } from "../packages/stellar-sdk-helpers/src/known-pools";
+
+const CONTRACTS_DIR = join(__dirname, "..", "packages", "contracts");
+const BUILT_WASM_PATH = join(
+  CONTRACTS_DIR,
+  "target",
+  "wasm32v1-none",
+  "release",
+  "meridian_vault.wasm"
+);
+
+interface VerifyTarget {
+  label: string;
+  network: "testnet" | "mainnet";
+  address: string;
+}
+
+function sha256(filePath: string): string {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function retry<T>(
+  fn: () => T,
+  { attempts = 3, delayMs = 3000 } = {}
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return fn();
+    } catch (err) {
+      lastErr = err;
+      if (i < attempts - 1) {
+        console.warn(
+          `  attempt ${i + 1}/${attempts} failed, retrying in ${delayMs}ms...`
+        );
+        await sleep(delayMs);
+      }
+    }
+  }
+  throw lastErr;
+}
+
+async function fetchOnChainHash(
+  address: string,
+  network: string
+): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "meridian-verify-"));
+  const outFile = join(dir, `${address}.wasm`);
+  await retry(() => {
+    execFileSync(
+      "stellar",
+      [
+        "contract",
+        "fetch",
+        "--id",
+        address,
+        "--network",
+        network,
+        "-o",
+        outFile,
+      ],
+      { stdio: "inherit" }
+    );
+  });
+  return sha256(outFile);
+}
+
+function collectTargets(): VerifyTarget[] {
+  const targets: VerifyTarget[] = [];
+  for (const network of ["testnet", "mainnet"] as const) {
+    const address = CONTRACT_ADDRESSES[network].vault;
+    if (address) {
+      targets.push({
+        label: `CONTRACT_ADDRESSES.${network}.vault`,
+        network,
+        address,
+      });
+    }
+  }
+
+  const knownPoolAddress = KNOWN_POOLS.testnet["meridian-usdc"]?.contractId;
+  if (knownPoolAddress) {
+    targets.push({
+      label: 'KNOWN_POOLS.testnet["meridian-usdc"].contractId',
+      network: "testnet",
+      address: knownPoolAddress,
+    });
+  }
+
+  return targets;
+}
+
+function checkInternalConsistency(targets: VerifyTarget[]): boolean {
+  const testnetAddresses = new Set(
+    targets.filter((t) => t.network === "testnet").map((t) => t.address)
+  );
+  if (testnetAddresses.size > 1) {
+    console.error(
+      "MISMATCH: CONTRACT_ADDRESSES.testnet.vault and " +
+        'KNOWN_POOLS.testnet["meridian-usdc"].contractId disagree on the ' +
+        `vault address: ${[...testnetAddresses].join(", ")}`
+    );
+    return false;
+  }
+  return true;
+}
+
+async function main() {
+  const targets = collectTargets();
+
+  if (targets.length === 0) {
+    console.log("No vault addresses configured, nothing to verify.");
+    return;
+  }
+
+  if (!checkInternalConsistency(targets)) {
+    process.exit(1);
+  }
+
+  console.log("Building vault contract from source...");
+  execFileSync("stellar", ["contract", "build"], {
+    cwd: CONTRACTS_DIR,
+    stdio: "inherit",
+  });
+
+  if (!existsSync(BUILT_WASM_PATH)) {
+    console.error(`Expected built WASM not found at ${BUILT_WASM_PATH}`);
+    process.exit(1);
+  }
+  const builtHash = sha256(BUILT_WASM_PATH);
+  console.log(`Locally built vault WASM hash: ${builtHash}`);
+
+  let failed = false;
+  const seenAddresses = new Set<string>();
+  for (const target of targets) {
+    const dedupeKey = `${target.network}:${target.address}`;
+    if (seenAddresses.has(dedupeKey)) continue;
+    seenAddresses.add(dedupeKey);
+
+    console.log(
+      `Verifying ${target.label} (${target.address}) on ${target.network}...`
+    );
+    const onChainHash = await fetchOnChainHash(target.address, target.network);
+    console.log(`  on-chain hash: ${onChainHash}`);
+
+    if (onChainHash !== builtHash) {
+      console.error(
+        `MISMATCH: ${target.label} (${target.address}) on-chain bytecode ` +
+          "does not match the vault contract built from this repo's source."
+      );
+      failed = true;
+    } else {
+      console.log("  OK: matches locally built source.");
+    }
+  }
+
+  if (failed) {
+    process.exit(1);
+  }
+  console.log("All contract addresses verified against on-chain bytecode.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Added `.github/CODEOWNERS`, requesting review on any PR touching `packages/shared/src/constants.ts` or `packages/stellar-sdk-helpers/src/known-pools.ts`, where deployed contract addresses are recorded.
- Added `scripts/verify-contract-addresses.ts`, which rebuilds the vault contract from this repo's own source via `stellar contract build`, fetches the actual on-chain bytecode at every non-empty vault address in `CONTRACT_ADDRESSES`, hashes both, and fails if they don't match. Also fails if `CONTRACT_ADDRESSES` and `KNOWN_POOLS` disagree with each other on the vault address.
- Added a new CI workflow, `verify-contract-addresses.yml`, triggered only on PRs touching those two files, that runs the script as a required check.
- The on-chain fetch retries on transient failure (3 attempts, 3s backoff) rather than hard-failing on the first Soroban RPC hiccup.

This closes a real gap: code review of a contract's source diff alone cannot catch a PR that submits clean, reviewable source while pointing the recorded address at different, unreviewed bytecode the contributor deployed themselves. This becomes a concrete risk rather than a theoretical one now that external, bounty-motivated contributors are starting to submit PRs.

Only the vault contract is covered, since it's the only address currently tracked in these two files whose source lives in this repo — Blend's pool, DeFindex's factory/vault, and the USDC/EURC issuers are third-party contracts nobody here controls the source for. The router and adapter contracts aren't tracked as addresses anywhere yet; once they are, this same mechanism extends to them automatically with no additional code.

Deliberately did not change branch protection review-count requirements: GitHub blocks a PR author from approving their own PR, so a hard review-count gate would lock the repo's own maintainer out of merging solo work. The actual hard gate is this new required status check instead, which isn't tied to reviewer identity.

## Test plan

- [x] Ran `pnpm verify:contracts` locally end-to-end against the live testnet vault: builds successfully, fetches on-chain bytecode, hashes match (independently confirmed against `stellar contract build`'s own reported Wasm Hash)
- [x] `pnpm format:check && pnpm lint && pnpm typecheck && pnpm typecheck:api` pass
- [x] `tsc --noEmit --strict` on the new script passes with no type errors

Closes #389
