### PR TITLE
ci(contracts): enforce cargo fmt --check on Soroban contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,10 +91,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-          components: clippy
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: packages/contracts
+      - name: Check formatting
+        working-directory: packages/contracts
+        run: cargo fmt --all -- --check
       - name: Run clippy
         working-directory: packages/contracts
         run: cargo clippy --all-targets -- -D warnings


### PR DESCRIPTION
## Summary

- Added a `cargo fmt --all -- --check` step to the Soroban Contract Tests CI job, matching the formatting gate TS code already has via `pnpm format:check`.
- Added the `rustfmt` component to the job's Rust toolchain setup, needed for the new step.

`cargo fmt --all` was already recommended in CONTRIBUTING.md's local-checks section, but nothing in CI actually verified it, so a PR could slip through with unformatted Rust code. The repo currently passes `cargo fmt --all -- --check` cleanly with no changes needed, so this doesn't require any cleanup elsewhere in the codebase first.

## Test plan

- [x] `cargo fmt --all -- --check` passes cleanly on `main` as of this branch
- [x] `cargo clippy --all-targets -- -D warnings && cargo test` still pass, unaffected by the new step
