### PR TITLE
fix(build): bundle api-core for the Vercel serverless runtime

### DIFF
--- a/scripts/build-vercel.sh
+++ b/scripts/build-vercel.sh
@@ -5,13 +5,16 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 OUT="$ROOT/dist"
 
 echo "▶ Bundling workspace packages for Vercel runtime..."
-mkdir -p "$ROOT/packages/shared/dist" "$ROOT/packages/stellar-sdk-helpers/dist"
+mkdir -p "$ROOT/packages/shared/dist" "$ROOT/packages/stellar-sdk-helpers/dist" "$ROOT/packages/api-core/dist"
 esbuild "$ROOT/packages/shared/src/index.ts" \
   --bundle --platform=node --format=esm --packages=external \
   --outfile="$ROOT/packages/shared/dist/index.js"
 esbuild "$ROOT/packages/stellar-sdk-helpers/src/index.ts" \
   --bundle --platform=node --format=esm --packages=external \
   --outfile="$ROOT/packages/stellar-sdk-helpers/dist/index.js"
+esbuild "$ROOT/packages/api-core/src/index.ts" \
+  --bundle --platform=node --format=esm --packages=external \
+  --outfile="$ROOT/packages/api-core/dist/index.js"
 
 echo "▶ Cleaning output directory…"
 rm -rf "$OUT"


### PR DESCRIPTION
## Summary

- Production is currently broken: `/api/v1/positions/:publicKey` throws `ERR_MODULE_NOT_FOUND: Cannot find package '@meridian/api-core'` on Vercel, surfaced in the app as "Couldn't load your position."
- Root cause: `packages/api-core` (added in #388) is a workspace-linked TypeScript source package resolved via `"types": "./src/index.ts"` locally, but its `"main": "./dist/index.js"` is only ever produced by an explicit esbuild step. `scripts/build-vercel.sh` runs that step for `@meridian/shared` and `@meridian/stellar-sdk-helpers`, but was never updated to include `@meridian/api-core` when it was introduced, so it never gets built for the Vercel deployment and the runtime import fails.
- Added the same esbuild bundling step for `packages/api-core/src/index.ts` that already exists for the other two workspace packages.

## Test plan

- [x] Ran `PATH="$PWD/node_modules/.bin:$PATH" bash scripts/build-vercel.sh` end-to-end locally, completes successfully and produces `packages/api-core/dist/index.js`
- [x] Confirmed `import("@meridian/api-core")` resolves correctly from within `api/` after the fix (previously failed with the same `ERR_MODULE_NOT_FOUND` seen in production)
- [x] `pnpm lint && pnpm typecheck && pnpm typecheck:api` pass

Fixes the production incident affecting `/api/v1/positions/:publicKey`, `/api/v1/tx/*`, and `/api/v1/vaults*` (every Vercel handler that imports `@meridian/api-core`).
